### PR TITLE
Add live key safety guard for contract tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-01-02
+
+### Added
+
+- **Live key safety guard**: `TestClient` now performs two-layer validation before running contract tests against real Stripe:
+  1. Validates API key prefix (rejects `sk_live_*`, `rk_live_*`)
+  2. Makes a live API call to `/v1/balance` and verifies `livemode: false`
+
+  This prevents accidental production usage even if someone crafts a key with a fake prefix
+
 ### Fixed
 
 - BillingEngine now retries existing open invoices instead of creating duplicates on each billing cycle

--- a/README.md
+++ b/README.md
@@ -394,7 +394,14 @@ export VALIDATE_AGAINST_STRIPE=true
 mix test test/paper_tiger/contract_test.exs
 ```
 
-Tests run against stripe.com to validate that PaperTiger behavior matches production. Requires a Stripe test account. Only use test mode API keys (sk*test*\*).
+Tests run against stripe.com to validate that PaperTiger behavior matches production. Requires a Stripe test account.
+
+> **🛡️ Safety Guard:** PaperTiger performs two-layer validation before running against real Stripe:
+>
+> 1. Validates the API key prefix (rejects `sk_live_*`, `rk_live_*`)
+> 2. Makes a live API call to `/v1/balance` and verifies `livemode: false`
+>
+> If you accidentally configure a live-mode key, the tests will refuse to run with a clear error message. This prevents accidental charges to real customers.
 
 ### Writing Contract Tests
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PaperTiger.MixProject do
   @moduledoc false
   use Mix.Project
 
-  @version "0.8.0"
+  @version "0.8.1"
   @url "https://github.com/EnaiaInc/paper_tiger"
   @maintainers ["Enaia Inc"]
 


### PR DESCRIPTION
## Summary

- Adds two-layer validation before running contract tests against real Stripe
- Prevents accidental production usage

## Changes

**Layer 1 - Key prefix validation:**
- Rejects `sk_live_*` and `rk_live_*` keys immediately
- Requires `sk_test_*` or `rk_test_*` prefix

**Layer 2 - Live API verification:**
- Makes a call to `/v1/balance` endpoint
- Verifies `livemode: false` in response
- Catches edge cases where someone might craft a fake prefix

If either check fails, tests refuse to run with a clear error message.

Bumps version to 0.8.1.