### PR TITLE
Fix CI: remove unused function (v0.8.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3] - 2026-01-02
+
+### Fixed
+
+- Remove unused `cleanup_payment_method/1` function that caused warnings-as-errors CI failure
+
 ## [0.8.2] - 2026-01-02
 
 ### Fixed

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PaperTiger.MixProject do
   @moduledoc false
   use Mix.Project
 
-  @version "0.8.2"
+  @version "0.8.3"
   @url "https://github.com/EnaiaInc/paper_tiger"
   @maintainers ["Enaia Inc"]
 

--- a/test/paper_tiger/contract_test.exs
+++ b/test/paper_tiger/contract_test.exs
@@ -511,12 +511,6 @@ defmodule PaperTiger.ContractTest do
     end
   end
 
-  defp cleanup_payment_method(_payment_method_id) do
-    # PaymentMethods don't need explicit cleanup in Stripe
-    # They're automatically cleaned up when not attached to a customer
-    :ok
-  end
-
   defp cleanup_invoice(_invoice_id) do
     # Invoices don't need explicit cleanup in Stripe
     # They're automatically managed with the customer


### PR DESCRIPTION
Removes unused `cleanup_payment_method/1` function that caused warnings-as-errors CI failure.