### PR TITLE
Subscription items return full price object instead of ID string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4] - 2026-01-02
+
+### Fixed
+
+- **Subscription items now return full price object**: `subscription.items.data[].price` is now a full price object (with `id`, `object`, `currency`, etc.) instead of just the price ID string, matching real Stripe API behavior
+- Same fix applied to `subscription_item.price` when creating/updating subscription items directly
+- When price doesn't exist in the store, returns a minimal price object with required fields for API compatibility
+
+### Added
+
+- Contract test validating subscription item price structure against real Stripe API
+- `TestClient.create_product/1` and `TestClient.create_price/1` helpers for contract testing
+
 ## [0.8.3] - 2026-01-02
 
 ### Fixed

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PaperTiger.MixProject do
   @moduledoc false
   use Mix.Project
 
-  @version "0.8.3"
+  @version "0.8.4"
   @url "https://github.com/EnaiaInc/paper_tiger"
   @maintainers ["Enaia Inc"]
 

--- a/test/support/test_client.ex
+++ b/test/support/test_client.ex
@@ -278,6 +278,36 @@ defmodule PaperTiger.TestClient do
     end
   end
 
+  ## Product Operations
+
+  @doc """
+  Creates a product.
+  """
+  def create_product(params) do
+    case mode() do
+      :real_stripe ->
+        create_product_real(params)
+
+      :paper_tiger ->
+        create_product_mock(params)
+    end
+  end
+
+  ## Price Operations
+
+  @doc """
+  Creates a price.
+  """
+  def create_price(params) do
+    case mode() do
+      :real_stripe ->
+        create_price_real(params)
+
+      :paper_tiger ->
+        create_price_mock(params)
+    end
+  end
+
   ## Subscription Operations
 
   @doc """
@@ -511,6 +541,20 @@ defmodule PaperTiger.TestClient do
     end
   end
 
+  defp create_product_real(params) do
+    case Stripe.Product.create(normalize_params(params), stripe_opts()) do
+      {:ok, product} -> {:ok, stripe_to_map(product)}
+      {:error, error} -> {:error, stripe_error_to_map(error)}
+    end
+  end
+
+  defp create_price_real(params) do
+    case Stripe.Price.create(normalize_params(params), stripe_opts()) do
+      {:ok, price} -> {:ok, stripe_to_map(price)}
+      {:error, error} -> {:error, stripe_error_to_map(error)}
+    end
+  end
+
   ## Private - PaperTiger Mock
 
   defp create_customer_mock(params) do
@@ -580,6 +624,16 @@ defmodule PaperTiger.TestClient do
 
   defp get_invoice_mock(invoice_id) do
     conn = request(:get, "/v1/invoices/#{invoice_id}", %{})
+    handle_response(conn)
+  end
+
+  defp create_product_mock(params) do
+    conn = request(:post, "/v1/products", params)
+    handle_response(conn)
+  end
+
+  defp create_price_mock(params) do
+    conn = request(:post, "/v1/prices", params)
     handle_response(conn)
   end
 


### PR DESCRIPTION
## Summary

- Fixes `subscription.items.data[].price` to return full price object instead of just the price ID string
- Same fix for `subscription_item.price` when creating items directly
- Falls back to minimal price object when price ID doesn't exist in store

## Changes

PaperTiger wasn't matching real Stripe API behavior - it returned a string for `price` instead of the full object with `id`, `object`, `currency`, etc. This caused issues when consuming code expected the full object structure.

Added contract test that validates against real Stripe API to prevent regression.

Bumps version to 0.8.4.