### PR TITLE
Add synchronous webhook delivery mode for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.5] - 2026-01-02
+
+### Added
+
+- **Synchronous webhook delivery mode**: Configure `webhook_mode: :sync` to have API calls block until webhooks are delivered. Useful for testing where you need to assert on webhook side effects immediately after API calls.
+- `WebhookDelivery.deliver_event_sync/2` function for explicit synchronous delivery
+
 ## [0.8.4] - 2026-01-02
 
 ### Fixed

--- a/lib/paper_tiger/telemetry_handler.ex
+++ b/lib/paper_tiger/telemetry_handler.ex
@@ -151,12 +151,18 @@ defmodule PaperTiger.TelemetryHandler do
 
   defp deliver_to_webhooks(event, event_type) do
     %{data: webhooks} = Webhooks.list(%{})
+    sync_mode? = Application.get_env(:paper_tiger, :webhook_mode) == :sync
 
     webhooks
     |> Enum.filter(&event_matches_webhook?(&1, event_type))
     |> Enum.each(fn webhook ->
       Logger.debug("Delivering #{event_type} to webhook #{webhook.id}")
-      WebhookDelivery.deliver_event(event.id, webhook.id)
+
+      if sync_mode? do
+        WebhookDelivery.deliver_event_sync(event.id, webhook.id)
+      else
+        WebhookDelivery.deliver_event(event.id, webhook.id)
+      end
     end)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PaperTiger.MixProject do
   @moduledoc false
   use Mix.Project
 
-  @version "0.8.4"
+  @version "0.8.5"
   @url "https://github.com/EnaiaInc/paper_tiger"
   @maintainers ["Enaia Inc"]
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,1 @@
 ExUnit.start()
-
-# Load all test support files
-Code.require_file("support/test_client.ex", __DIR__)


### PR DESCRIPTION
## Summary

- Adds `webhook_mode: :sync` config option to block API calls until webhooks are delivered
- Adds `WebhookDelivery.deliver_event_sync/2` for explicit synchronous delivery
- TelemetryHandler checks config and uses sync mode when configured

## Changes

PaperTiger delivers webhooks asynchronously by default, which can cause race conditions in tests where assertions run before webhooks have been processed.

With sync mode enabled, API calls that trigger webhooks (like creating a subscription) will block until the webhook HTTP request completes. This ensures that by the time the API call returns, any webhook side effects (like database records created by webhook handlers) are available for assertions.

Usage:
```elixir
config :paper_tiger, webhook_mode: :sync
```

Bumps version to 0.8.5.