### PR TITLE
Add environment-specific port configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Environment-specific port configuration**: New env vars `PAPER_TIGER_PORT_DEV` and `PAPER_TIGER_PORT_TEST` allow different ports per Mix environment. Enables running dev server and tests simultaneously without port conflicts. Precedence: `PAPER_TIGER_PORT_{ENV}` > `PAPER_TIGER_PORT` > config > 4001.
+
 ## [0.8.5] - 2026-01-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -127,8 +127,20 @@ PaperTiger respects environment variables for runtime configuration:
 
 - `PAPER_TIGER_AUTO_START` - Set to "true" to enable HTTP server
 - `PAPER_TIGER_PORT` - Port to run on (default: 4001)
+- `PAPER_TIGER_PORT_DEV` - Port for dev environment (overrides `PAPER_TIGER_PORT`)
+- `PAPER_TIGER_PORT_TEST` - Port for test environment (overrides `PAPER_TIGER_PORT`)
 
-This is useful for Heroku, Render, or other PaaS deployments:
+**Port precedence:** `PAPER_TIGER_PORT_{ENV}` > `PAPER_TIGER_PORT` > config > 4001
+
+This allows running dev server and tests simultaneously on different ports:
+
+```bash
+# In .env or shell
+export PAPER_TIGER_PORT_DEV=4001
+export PAPER_TIGER_PORT_TEST=4003
+```
+
+This is also useful for Heroku, Render, or other PaaS deployments:
 
 ```bash
 # Enable PaperTiger for PR apps

--- a/lib/paper_tiger/application.ex
+++ b/lib/paper_tiger/application.ex
@@ -137,12 +137,25 @@ defmodule PaperTiger.Application do
     end
   end
 
-  # Get port from env var or config (env var takes precedence)
+  # Get port from env var or config
+  # Precedence: PAPER_TIGER_PORT_{ENV} > PAPER_TIGER_PORT > config > default
   defp get_port do
-    case System.get_env("PAPER_TIGER_PORT") do
-      nil -> Application.get_env(:paper_tiger, :port, 4001)
-      port_string -> String.to_integer(port_string)
+    env_specific_var = "PAPER_TIGER_PORT_#{mix_env_upcase()}"
+
+    case System.get_env(env_specific_var) do
+      nil ->
+        case System.get_env("PAPER_TIGER_PORT") do
+          nil -> Application.get_env(:paper_tiger, :port, 4001)
+          port_string -> String.to_integer(port_string)
+        end
+
+      port_string ->
+        String.to_integer(port_string)
     end
+  end
+
+  defp mix_env_upcase do
+    Mix.env() |> Atom.to_string() |> String.upcase()
   end
 
   defp maybe_add_workers(children) do


### PR DESCRIPTION
## Summary

- Add `PAPER_TIGER_PORT_DEV` and `PAPER_TIGER_PORT_TEST` env vars
- Enables running dev server and tests simultaneously without port conflicts
- Precedence: `PAPER_TIGER_PORT_{ENV}` > `PAPER_TIGER_PORT` > config > 4001

Closes ENA-7697