### PR TITLE
[ENA-7695] Fix Stripe API response structure mismatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Subscription `latest_invoice`**: Now populated with the actual latest Invoice object for the subscription instead of always being null
+- **PaymentIntent `charges`**: Now contains actual Charge objects from the store instead of an empty list
+- **Charge `balance_transaction`**: Successful charges now create and link a BalanceTransaction with proper fee calculation (2.9% + $0.30)
+- **Refund `balance_transaction`**: Refunds now create and link a BalanceTransaction with negative amounts
+
 ### Added
 
 - **Environment-specific port configuration**: New env vars `PAPER_TIGER_PORT_DEV` and `PAPER_TIGER_PORT_TEST` allow different ports per Mix environment. Enables running dev server and tests simultaneously without port conflicts. Precedence: `PAPER_TIGER_PORT_{ENV}` > `PAPER_TIGER_PORT` > config > 4001.
+- `PaperTiger.BalanceTransactionHelper` module for creating balance transactions with Stripe-compatible fee calculations
 
 ## [0.8.5] - 2026-01-02
 

--- a/lib/paper_tiger/balance_transaction_helper.ex
+++ b/lib/paper_tiger/balance_transaction_helper.ex
@@ -1,0 +1,122 @@
+defmodule PaperTiger.BalanceTransactionHelper do
+  @moduledoc """
+  Helper functions for creating balance transactions.
+
+  Balance transactions are created automatically when:
+  - A charge is created (type: "charge")
+  - A refund is created (type: "refund")
+  - A payout is created (type: "payout")
+
+  ## Fee Calculation
+
+  Stripe's standard fee is 2.9% + $0.30 per successful card charge.
+  For simplicity, PaperTiger uses this formula for all charges.
+  """
+
+  alias PaperTiger.Store.BalanceTransactions
+
+  @stripe_percentage 0.029
+  @stripe_fixed_fee 30
+
+  @doc """
+  Creates a balance transaction for a charge.
+
+  Returns the balance transaction ID.
+  """
+  @spec create_for_charge(map()) :: {:ok, String.t()} | {:error, term()}
+  def create_for_charge(charge) do
+    amount = get_field(charge, :amount, 0)
+    currency = get_field(charge, :currency, "usd")
+    fee = calculate_fee(amount)
+
+    balance_transaction = %{
+      amount: amount,
+      available_on: PaperTiger.now() + 172_800,
+      created: PaperTiger.now(),
+      currency: currency,
+      description: get_field(charge, :description, "Charge"),
+      fee: fee,
+      fee_details: [build_fee_detail(fee, currency)],
+      id: PaperTiger.Resource.generate_id("txn"),
+      net: amount - fee,
+      object: "balance_transaction",
+      reporting_category: "charge",
+      source: get_field(charge, :id, nil),
+      status: "pending",
+      type: "charge"
+    }
+
+    insert_and_return_id(balance_transaction)
+  end
+
+  @doc """
+  Creates a balance transaction for a refund.
+
+  Refunds have negative amounts and return fees proportionally.
+  """
+  @spec create_for_refund(map(), map()) :: {:ok, String.t()} | {:error, term()}
+  def create_for_refund(refund, original_charge) do
+    refund_amount = get_field(refund, :amount, 0)
+    original_amount = get_field(original_charge, :amount, 0)
+    currency = get_field(refund, :currency, "usd")
+    fee_refund = calculate_proportional_fee_refund(original_amount, refund_amount)
+
+    balance_transaction = %{
+      amount: -refund_amount,
+      available_on: PaperTiger.now(),
+      created: PaperTiger.now(),
+      currency: currency,
+      description: "Refund",
+      fee: -fee_refund,
+      fee_details: [build_fee_detail(-fee_refund, currency)],
+      id: PaperTiger.Resource.generate_id("txn"),
+      net: -refund_amount + fee_refund,
+      object: "balance_transaction",
+      reporting_category: "refund",
+      source: get_field(refund, :id, nil),
+      status: "available",
+      type: "refund"
+    }
+
+    insert_and_return_id(balance_transaction)
+  end
+
+  @doc """
+  Calculates Stripe's processing fee for a given amount.
+
+  Formula: 2.9% + $0.30 (in cents)
+  """
+  @spec calculate_fee(integer()) :: integer()
+  def calculate_fee(amount) when is_integer(amount) and amount > 0 do
+    round(amount * @stripe_percentage) + @stripe_fixed_fee
+  end
+
+  def calculate_fee(_), do: 0
+
+  # Helper to get field from map with atom or string key
+  defp get_field(map, key, default) do
+    Map.get(map, key) || Map.get(map, to_string(key)) || default
+  end
+
+  defp build_fee_detail(amount, currency) do
+    %{
+      amount: amount,
+      application: nil,
+      currency: currency,
+      description: "Stripe processing fees",
+      type: "stripe_fee"
+    }
+  end
+
+  defp calculate_proportional_fee_refund(original_amount, refund_amount) when original_amount > 0 do
+    original_fee = calculate_fee(original_amount)
+    div(original_fee * refund_amount, original_amount)
+  end
+
+  defp calculate_proportional_fee_refund(_, _), do: 0
+
+  defp insert_and_return_id(balance_transaction) do
+    {:ok, txn} = BalanceTransactions.insert(balance_transaction)
+    {:ok, txn.id}
+  end
+end


### PR DESCRIPTION
## Summary

- Subscription `latest_invoice` now populated with actual Invoice object
- PaymentIntent `charges` now contains actual Charge objects from store
- Charge `balance_transaction` creates and links BalanceTransaction for successful charges
- Refund `balance_transaction` creates and links BalanceTransaction for refunds

## Changes

New `BalanceTransactionHelper` module handles balance transaction creation with proper Stripe fee calculation (2.9% + $0.30). Store query helpers (`find_by_payment_intent`, `find_by_subscription`) populate nested objects on retrieval.