### PR TITLE
[ENA-7698] Fix pre-0.9 issues: sync blocking, subscription item IDs, httpc removal

### DIFF
--- a/lib/paper_tiger/application.ex
+++ b/lib/paper_tiger/application.ex
@@ -46,6 +46,7 @@ defmodule PaperTiger.Application do
         # Core systems (always running)
         PaperTiger.Clock,
         PaperTiger.Idempotency,
+        {Task.Supervisor, name: PaperTiger.TaskSupervisor},
         PaperTiger.WebhookDelivery,
 
         # Resource stores (always running)

--- a/test/support/test_client.ex
+++ b/test/support/test_client.ex
@@ -143,21 +143,20 @@ defmodule PaperTiger.TestClient do
   defp verify_test_mode_via_api!(api_key) do
     # Make a simple API call to verify we're actually in test mode
     # The /v1/balance endpoint is read-only and returns livemode field
-    url = ~c"https://api.stripe.com/v1/balance"
+    url = "https://api.stripe.com/v1/balance"
 
-    # :httpc requires charlist headers
     headers = [
-      {~c"authorization", String.to_charlist("Bearer #{api_key}")},
-      {~c"content-type", ~c"application/x-www-form-urlencoded"}
+      {"authorization", "Bearer #{api_key}"},
+      {"content-type", "application/x-www-form-urlencoded"}
     ]
 
-    case :httpc.request(:get, {url, headers}, [], []) do
-      {:ok, {{_, 200, _}, _headers, body}} ->
-        case Jason.decode(List.to_string(body)) do
-          {:ok, %{"livemode" => false}} ->
+    case Req.get(url, headers: headers) do
+      {:ok, %{body: body, status: 200}} ->
+        case body do
+          %{"livemode" => false} ->
             :ok
 
-          {:ok, %{"livemode" => true}} ->
+          %{"livemode" => true} ->
             raise """
             🚨 LIVE MODE CONFIRMED BY STRIPE API! 🚨
 
@@ -177,7 +176,7 @@ defmodule PaperTiger.TestClient do
             :ok
         end
 
-      {:ok, {{_, 401, _}, _, _}} ->
+      {:ok, %{status: 401}} ->
         raise """
         Invalid Stripe API key!
 


### PR DESCRIPTION
## Summary
- Fix sync webhook mode blocking the GenServer during retry backoffs
- Fix subscription item ID instability on update (now diffs instead of delete-all/recreate)
- Replace :httpc with Req in TestClient
- Use realistic Stripe User-Agent header for webhooks

## Changes
**Sync webhook blocking**: Spawns a Task for sync delivery so the GenServer remains responsive during retries. Added TaskSupervisor to isolate delivery task failures.

**Subscription item IDs**: Update now properly diffs items - existing items with matching IDs are updated in place, new items are created, removed items are deleted. This preserves IDs for apps that store subscription_item IDs locally.

**httpc → Req**: Unified HTTP stack by replacing :httpc with Req in TestClient's API verification.