### PR TITLE
[ENA-7699] Add checkout session URL field and SubscriptionSchedule endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Add `paper_tiger` to your dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:paper_tiger, "~> 0.8.0"}
+    {:paper_tiger, "~> 0.9.0"}
   ]
 end
 ```
@@ -87,7 +87,7 @@ Add PaperTiger to your dependencies:
 # mix.exs
 def deps do
   [
-    {:paper_tiger, "~> 0.1.0", only: [:dev, :test]},
+    {:paper_tiger, "~> 0.9.0", only: [:dev, :test]},
     {:stripity_stripe, "~> 3.0"}
   ]
 end

--- a/examples/getting_started.livemd
+++ b/examples/getting_started.livemd
@@ -15,7 +15,7 @@ This LiveBook demonstrates how to use PaperTiger, a stateful mock Stripe server 
 IO.puts("Installing dependencies...")
 
 Mix.install([
-  {:paper_tiger, "~> 0.7"},
+  {:paper_tiger, "~> 0.9"},
   {:req, "~> 0.5"},
   {:kino, "~> 0.16.0"}
 ])

--- a/lib/paper_tiger/application.ex
+++ b/lib/paper_tiger/application.ex
@@ -27,6 +27,7 @@ defmodule PaperTiger.Application do
   alias PaperTiger.Store.Sources
   alias PaperTiger.Store.SubscriptionItems
   alias PaperTiger.Store.Subscriptions
+  alias PaperTiger.Store.SubscriptionSchedules
   alias PaperTiger.Store.TaxRates
   alias PaperTiger.Store.Tokens
   alias PaperTiger.Store.Topups
@@ -61,6 +62,7 @@ defmodule PaperTiger.Application do
         PaymentIntents,
         SetupIntents,
         SubscriptionItems,
+        SubscriptionSchedules,
         InvoiceItems,
         Plans,
         Coupons,

--- a/lib/paper_tiger/resources/subscription_schedule.ex
+++ b/lib/paper_tiger/resources/subscription_schedule.ex
@@ -1,0 +1,297 @@
+defmodule PaperTiger.Resources.SubscriptionSchedule do
+  @moduledoc """
+  Handles SubscriptionSchedule resource endpoints.
+
+  ## Endpoints
+
+  - POST   /v1/subscription_schedules             - Create subscription schedule
+  - GET    /v1/subscription_schedules/:id         - Retrieve subscription schedule
+  - POST   /v1/subscription_schedules/:id         - Update subscription schedule
+  - POST   /v1/subscription_schedules/:id/cancel  - Cancel subscription schedule
+  - POST   /v1/subscription_schedules/:id/release - Release subscription schedule
+  - GET    /v1/subscription_schedules             - List subscription schedules
+
+  ## SubscriptionSchedule Object
+
+      %{
+        id: "sub_sched_...",
+        object: "subscription_schedule",
+        created: 1234567890,
+        customer: "cus_...",
+        status: "not_started",
+        phases: [
+          %{
+            start_date: 1234567890,
+            end_date: 1237159890,
+            plans: [%{price: "price_...", quantity: 1}]
+          }
+        ],
+        # ... other fields
+      }
+
+  ## Schedule Statuses
+
+  - not_started - Schedule hasn't started yet
+  - active - Schedule is currently active
+  - completed - Schedule has completed all phases
+  - released - Schedule was released
+  - canceled - Schedule was canceled
+  """
+
+  import PaperTiger.Resource
+
+  alias PaperTiger.Store.SubscriptionSchedules
+
+  require Logger
+
+  @doc """
+  Creates a new subscription schedule.
+
+  ## Required Parameters
+
+  - customer - Customer ID
+  - phases - Array of schedule phases
+
+  ## Optional Parameters
+
+  - from_subscription - Create from existing subscription
+  - start_date - When schedule should start
+  - end_behavior - What happens when schedule ends
+  - metadata - Key-value metadata
+  """
+  @spec create(Plug.Conn.t()) :: Plug.Conn.t()
+  def create(conn) do
+    with {:ok, _params} <- validate_params(conn.params, [:customer]),
+         schedule = build_schedule(conn.params),
+         {:ok, schedule} <- SubscriptionSchedules.insert(schedule) do
+      maybe_store_idempotency(conn, schedule)
+      :telemetry.execute([:paper_tiger, :subscription_schedule, :created], %{}, %{object: schedule})
+
+      schedule
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :invalid_params, field} ->
+        error_response(
+          conn,
+          PaperTiger.Error.invalid_request("Missing required parameter", field)
+        )
+    end
+  end
+
+  @doc """
+  Retrieves a subscription schedule by ID.
+  """
+  @spec retrieve(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def retrieve(conn, id) do
+    case SubscriptionSchedules.get(id) do
+      {:ok, schedule} ->
+        schedule
+        |> maybe_expand(conn.params)
+        |> then(&json_response(conn, 200, &1))
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("subscription_schedule", id))
+    end
+  end
+
+  @doc """
+  Updates a subscription schedule.
+  """
+  @spec update(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def update(conn, id) do
+    with {:ok, existing} <- SubscriptionSchedules.get(id),
+         updated = merge_updates(existing, conn.params),
+         {:ok, updated} <- SubscriptionSchedules.update(updated) do
+      :telemetry.execute([:paper_tiger, :subscription_schedule, :updated], %{}, %{object: updated})
+
+      updated
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("subscription_schedule", id))
+    end
+  end
+
+  @doc """
+  Lists all subscription schedules with pagination.
+
+  ## Parameters
+
+  - limit - Number of items (default: 10, max: 100)
+  - starting_after - Cursor for pagination
+  - ending_before - Reverse cursor
+  - customer - Filter by customer ID
+  - scheduled - Filter to only scheduled (not_started) schedules
+  """
+  @spec list(Plug.Conn.t()) :: Plug.Conn.t()
+  def list(conn) do
+    pagination_opts = parse_pagination_params(conn.params)
+
+    # Get schedules, optionally filtered
+    schedules =
+      case {Map.get(conn.params, :customer), Map.get(conn.params, :scheduled)} do
+        {nil, nil} ->
+          :ets.tab2list(SubscriptionSchedules.table_name())
+          |> Enum.map(fn {_id, schedule} -> schedule end)
+
+        {customer_id, nil} when is_binary(customer_id) ->
+          SubscriptionSchedules.find_by_customer(customer_id)
+
+        {nil, scheduled} when scheduled in [true, "true"] ->
+          SubscriptionSchedules.find_scheduled()
+
+        {customer_id, scheduled} when is_binary(customer_id) and scheduled in [true, "true"] ->
+          SubscriptionSchedules.find_by_customer(customer_id)
+          |> Enum.filter(fn s -> s.status == "not_started" end)
+
+        {customer_id, _} when is_binary(customer_id) ->
+          SubscriptionSchedules.find_by_customer(customer_id)
+
+        _ ->
+          :ets.tab2list(SubscriptionSchedules.table_name())
+          |> Enum.map(fn {_id, schedule} -> schedule end)
+      end
+
+    result =
+      PaperTiger.List.paginate(
+        schedules,
+        Map.put(pagination_opts, :url, "/v1/subscription_schedules")
+      )
+
+    json_response(conn, 200, result)
+  end
+
+  @doc """
+  Cancels a subscription schedule.
+
+  POST /v1/subscription_schedules/:id/cancel
+
+  Cancels the schedule and any associated subscription.
+  """
+  @spec cancel(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def cancel(conn, id) do
+    with {:ok, schedule} <- SubscriptionSchedules.get(id),
+         canceled = cancel_schedule(schedule),
+         {:ok, canceled} <- SubscriptionSchedules.update(canceled) do
+      :telemetry.execute([:paper_tiger, :subscription_schedule, :canceled], %{}, %{object: canceled})
+
+      canceled
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("subscription_schedule", id))
+    end
+  end
+
+  @doc """
+  Releases a subscription schedule.
+
+  POST /v1/subscription_schedules/:id/release
+
+  Releases the schedule, keeping any active subscription but removing future phases.
+  """
+  @spec release(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def release(conn, id) do
+    with {:ok, schedule} <- SubscriptionSchedules.get(id),
+         released = release_schedule(schedule),
+         {:ok, released} <- SubscriptionSchedules.update(released) do
+      :telemetry.execute([:paper_tiger, :subscription_schedule, :released], %{}, %{object: released})
+
+      released
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("subscription_schedule", id))
+    end
+  end
+
+  ## Private Functions
+
+  defp build_schedule(params) do
+    now = PaperTiger.now()
+
+    %{
+      canceled_at: nil,
+      completed_at: nil,
+      created: now,
+      current_phase: nil,
+      customer: Map.get(params, :customer),
+      default_settings: %{
+        application_fee_percent: nil,
+        billing_cycle_anchor: "automatic",
+        billing_thresholds: nil,
+        collection_method: "charge_automatically",
+        default_payment_method: nil,
+        invoice_settings: nil,
+        transfer_data: nil
+      },
+      end_behavior: Map.get(params, :end_behavior, "release"),
+      from_subscription: Map.get(params, :from_subscription),
+      id: generate_id("sub_sched", Map.get(params, :id)),
+      livemode: false,
+      metadata: Map.get(params, :metadata, %{}),
+      object: "subscription_schedule",
+      phases: build_phases(Map.get(params, :phases, [])),
+      released_at: nil,
+      released_subscription: nil,
+      status: "not_started",
+      subscription: nil
+    }
+  end
+
+  defp build_phases(phases) when is_list(phases) do
+    Enum.map(phases, fn phase ->
+      %{
+        add_invoice_items: [],
+        application_fee_percent: nil,
+        billing_cycle_anchor: nil,
+        billing_thresholds: nil,
+        collection_method: nil,
+        coupon: nil,
+        default_payment_method: nil,
+        default_tax_rates: [],
+        end_date: Map.get(phase, :end_date) || Map.get(phase, "end_date"),
+        invoice_settings: nil,
+        items: Map.get(phase, :items) || Map.get(phase, "items") || [],
+        metadata: Map.get(phase, :metadata) || Map.get(phase, "metadata") || %{},
+        plans: Map.get(phase, :plans) || Map.get(phase, "plans") || [],
+        proration_behavior: "create_prorations",
+        start_date: Map.get(phase, :start_date) || Map.get(phase, "start_date"),
+        transfer_data: nil,
+        trial_end: nil
+      }
+    end)
+  end
+
+  defp build_phases(_), do: []
+
+  defp cancel_schedule(schedule) do
+    now = PaperTiger.now()
+
+    %{
+      schedule
+      | canceled_at: now,
+        status: "canceled"
+    }
+  end
+
+  defp release_schedule(schedule) do
+    now = PaperTiger.now()
+
+    %{
+      schedule
+      | released_at: now,
+        released_subscription: schedule.subscription,
+        status: "released"
+    }
+  end
+
+  defp maybe_expand(schedule, params) do
+    expand_params = parse_expand_params(params)
+    PaperTiger.Hydrator.hydrate(schedule, expand_params)
+  end
+end

--- a/lib/paper_tiger/router.ex
+++ b/lib/paper_tiger/router.ex
@@ -75,6 +75,7 @@ defmodule PaperTiger.Router do
   alias PaperTiger.Resources.Source
   alias PaperTiger.Resources.Subscription
   alias PaperTiger.Resources.SubscriptionItem
+  alias PaperTiger.Resources.SubscriptionSchedule
   alias PaperTiger.Resources.TaxRate
   alias PaperTiger.Resources.Token
   alias PaperTiger.Resources.Topup
@@ -196,6 +197,7 @@ defmodule PaperTiger.Router do
   stripe_resource("cards", Card, [])
   stripe_resource("bank_accounts", BankAccount, [])
   stripe_resource("subscription_items", SubscriptionItem, [])
+  stripe_resource("subscription_schedules", SubscriptionSchedule, except: [:delete])
   stripe_resource("invoiceitems", InvoiceItem, [])
   stripe_resource("topups", Topup, except: [:delete])
   stripe_resource("balance_transactions", BalanceTransaction, only: [:retrieve, :list])
@@ -217,6 +219,16 @@ defmodule PaperTiger.Router do
 
   post "/v1/subscriptions/:id/cancel" do
     Subscription.cancel(conn, id)
+  end
+
+  ## Custom Subscription Schedule Endpoints
+
+  post "/v1/subscription_schedules/:id/cancel" do
+    SubscriptionSchedule.cancel(conn, id)
+  end
+
+  post "/v1/subscription_schedules/:id/release" do
+    SubscriptionSchedule.release(conn, id)
   end
 
   ## Custom Invoice Endpoints

--- a/lib/paper_tiger/store/subscription_schedules.ex
+++ b/lib/paper_tiger/store/subscription_schedules.ex
@@ -1,0 +1,72 @@
+defmodule PaperTiger.Store.SubscriptionSchedules do
+  @moduledoc """
+  ETS-backed storage for SubscriptionSchedule resources.
+
+  Uses the shared store pattern via `use PaperTiger.Store` which provides:
+  - GenServer wraps ETS table
+  - Reads go directly to ETS (concurrent, fast)
+  - Writes go through GenServer (serialized, safe)
+
+  ## Architecture
+
+  - **ETS Table**: `:paper_tiger_subscription_schedules` (public, read_concurrency: true)
+  - **GenServer**: Serializes writes, handles initialization
+  - **Shared Implementation**: All CRUD operations via PaperTiger.Store
+
+  ## Examples
+
+      # Direct read (no GenServer bottleneck)
+      {:ok, schedule} = PaperTiger.Store.SubscriptionSchedules.get("sub_sched_123")
+
+      # Serialized write
+      schedule = %{id: "sub_sched_123", customer: "cus_123", status: "not_started", ...}
+      {:ok, schedule} = PaperTiger.Store.SubscriptionSchedules.insert(schedule)
+
+      # Query helpers (direct ETS access)
+      schedules = PaperTiger.Store.SubscriptionSchedules.find_by_customer("cus_123")
+  """
+
+  use PaperTiger.Store,
+    table: :paper_tiger_subscription_schedules,
+    resource: "subscription_schedule"
+
+  @doc """
+  Finds subscription schedules by customer ID.
+
+  **Direct ETS access** - does not go through GenServer.
+
+  Returns all subscription schedules for the given customer, regardless of status.
+  """
+  @spec find_by_customer(String.t()) :: [map()]
+  def find_by_customer(customer_id) when is_binary(customer_id) do
+    :ets.match_object(@table, {:_, %{customer: customer_id}})
+    |> Enum.map(fn {_id, schedule} -> schedule end)
+  end
+
+  @doc """
+  Finds all active (not_started or active) subscription schedules.
+
+  **Direct ETS access** - does not go through GenServer.
+  """
+  @spec find_active() :: [map()]
+  def find_active do
+    all()
+    |> Enum.filter(fn schedule -> schedule.status in ["not_started", "active"] end)
+  end
+
+  @doc """
+  Finds subscription schedules that are scheduled (not yet started).
+
+  **Direct ETS access** - does not go through GenServer.
+  """
+  @spec find_scheduled() :: [map()]
+  def find_scheduled do
+    :ets.match_object(@table, {:_, %{status: "not_started"}})
+    |> Enum.map(fn {_id, schedule} -> schedule end)
+  end
+
+  defp all do
+    :ets.tab2list(@table)
+    |> Enum.map(fn {_id, schedule} -> schedule end)
+  end
+end


### PR DESCRIPTION
## Summary
- Add `url` field to checkout sessions with Stripe-compatible format
- Add SubscriptionSchedule store and resource endpoints
- Update version numbers to 0.9.0 in README and Livebook

## Changes
Checkout sessions now include a `url` field matching real Stripe's format (`https://checkout.stripe.com/c/pay/{id}#{fragment}`).

SubscriptionSchedule endpoints support the operations Enaia uses: create, retrieve, update, list (with customer/scheduled filtering), cancel, and release.