### PR TITLE
[ENA-7701] Auto-register webhooks from config on startup

### DIFF
--- a/lib/paper_tiger/application.ex
+++ b/lib/paper_tiger/application.ex
@@ -89,6 +89,8 @@ defmodule PaperTiger.Application do
       {:ok, pid} ->
         # Load init_data after stores are initialized
         load_init_data()
+        # Register configured webhooks
+        register_configured_webhooks()
         {:ok, pid}
 
       error ->
@@ -104,6 +106,11 @@ defmodule PaperTiger.Application do
       {:ok, _stats} -> :ok
       {:error, reason} -> Logger.error("PaperTiger init_data failed: #{inspect(reason)}")
     end
+  end
+
+  # Registers webhooks from application config
+  defp register_configured_webhooks do
+    PaperTiger.register_configured_webhooks()
   end
 
   # Returns children that only start under certain conditions

--- a/lib/paper_tiger/resources/subscription.ex
+++ b/lib/paper_tiger/resources/subscription.ex
@@ -331,11 +331,26 @@ defmodule PaperTiger.Resources.Subscription do
   defp build_minimal_price_object(price_id) do
     %{
       active: true,
+      billing_scheme: nil,
+      created: nil,
       currency: "usd",
+      currency_options: nil,
+      custom_unit_amount: nil,
       id: price_id,
       livemode: false,
+      lookup_key: nil,
+      metadata: nil,
+      nickname: nil,
       object: "price",
-      type: "recurring"
+      product: nil,
+      recurring: nil,
+      tax_behavior: nil,
+      tiers: nil,
+      tiers_mode: nil,
+      transform_quantity: nil,
+      type: "recurring",
+      unit_amount: nil,
+      unit_amount_decimal: nil
     }
   end
 

--- a/lib/paper_tiger/telemetry_handler.ex
+++ b/lib/paper_tiger/telemetry_handler.ex
@@ -136,6 +136,7 @@ defmodule PaperTiger.TelemetryHandler do
       data: %{
         object: object
       },
+      delivery_attempts: [],
       id: PaperTiger.Resource.generate_id("evt"),
       livemode: false,
       object: "event",


### PR DESCRIPTION
## Summary
- PaperTiger now auto-registers webhook endpoints from application config on startup
- Host applications no longer need to manually call `PaperTiger.register_configured_webhooks()`

## Changes
Added `register_configured_webhooks/0` call to PaperTiger's application startup sequence, after stores are initialized. This means webhooks configured via:

```elixir
config :paper_tiger,
  webhooks: [
    [url: "http://localhost:4000/webhooks/stripe", secret: "whsec_test", events: ["*"]]
  ]
```

Are automatically registered when PaperTiger starts, matching the behavior of real Stripe Dashboard-registered webhooks.