### PR TITLE
[ENA-7702] Return proper Stripe errors for missing resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2026-01-02
+
+### Fixed
+
+- **Proper Stripe error responses for missing resources**: Instead of crashing, PaperTiger now returns the same error format as Stripe when a resource doesn't exist
+  - Returns `resource_missing` error code with proper message format: "No such <resource>: '<id>'"
+  - Includes correct `param` values matching Stripe (e.g., `id` for customers, `price` for prices)
+  - HTTP 404 status code for not found errors
+
+### Added
+
+- Contract tests verifying error responses match Stripe's format
+
+## [0.9.1] - 2026-01-02
+
+### Fixed
+
+- **Events missing `delivery_attempts` field**: Events created via telemetry now include `delivery_attempts: []` field, fixing KeyError when accessing this field
+
+### Added
+
+- **Auto-register webhooks from application config on startup**: PaperTiger now automatically registers webhooks configured via `config :paper_tiger, webhooks: [...]` when the application starts, eliminating need for manual registration in your Application module
+
 ## [0.9.0] - 2026-01-02
 
 ### Fixed

--- a/lib/paper_tiger/error.ex
+++ b/lib/paper_tiger/error.ex
@@ -80,15 +80,49 @@ defmodule PaperTiger.Error do
 
   @doc """
   Creates a not found error (404).
+
+  Returns the same error format as Stripe's API for missing resources.
+
+  ## Param Values by Resource Type
+
+  Stripe uses different `param` values depending on the resource:
+  - `customer`, `product`, `subscription` -> `"id"`
+  - `price` -> `"price"`
+  - `plan` -> `"plan"`
+  - `invoice` -> `"invoice"`
+  - `payment_intent` -> `"intent"`
+
+  ## Examples
+
+      PaperTiger.Error.not_found("customer", "cus_123")
+      # => %PaperTiger.Error{
+      #      code: "resource_missing",
+      #      message: "No such customer: 'cus_123'",
+      #      param: "id",
+      #      status: 404,
+      #      type: "invalid_request_error"
+      #    }
   """
   @spec not_found(String.t(), String.t()) :: t()
   def not_found(resource_type, id) do
     %__MODULE__{
+      code: "resource_missing",
       message: "No such #{resource_type}: '#{id}'",
+      param: param_for_resource(resource_type),
       status: 404,
       type: "invalid_request_error"
     }
   end
+
+  # Returns the param value Stripe uses for each resource type
+  defp param_for_resource("price"), do: "price"
+  defp param_for_resource("plan"), do: "plan"
+  defp param_for_resource("invoice"), do: "invoice"
+  defp param_for_resource("payment_intent"), do: "intent"
+  defp param_for_resource("charge"), do: "charge"
+  defp param_for_resource("refund"), do: "refund"
+  defp param_for_resource("coupon"), do: "coupon"
+  defp param_for_resource(_resource_type), do: "id"
 
   @doc """
   Creates a card declined error (402).

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PaperTiger.MixProject do
   @moduledoc false
   use Mix.Project
 
-  @version "0.9.1"
+  @version "0.9.2"
   @url "https://github.com/EnaiaInc/paper_tiger"
   @maintainers ["Enaia Inc"]
 


### PR DESCRIPTION
## Summary

- Returns proper Stripe error format for missing resources instead of crashing
- Subscription create now validates customer and prices exist before proceeding
- Contract tests verify error responses match real Stripe API

## Changes

- Updated `PaperTiger.Error.not_found/2` to include `code: "resource_missing"` and proper `param` values
- Added `validate_customer_exists/1` and `validate_prices_exist/1` to subscription module
- Removed `build_minimal_price_object/1` fallback - matches real Stripe behavior of returning errors
- Added 6 new contract tests for error response format validation