### PR TITLE
[ENA-7703] Add test sandbox for async test support and webhook collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.3] - 2026-01-02
+
+### Added
+
+- **Test sandbox for concurrent test support**: New `PaperTiger.Test` module provides Ecto SQL Sandbox-style test isolation
+  - Use `setup :checkout_paper_tiger` to isolate test data per process
+  - Tests can now run with `async: true` without data interference
+  - All stores now support namespace-scoped operations
+  - Automatic cleanup on test exit
+- **HTTP sandbox via headers**: `PaperTiger.Plugs.Sandbox` enables sandbox isolation for HTTP API tests
+  - Include `x-paper-tiger-namespace` header to scope HTTP requests to a test namespace
+  - New `PaperTiger.Test.sandbox_headers/0` returns headers for sandbox isolation
+  - New `PaperTiger.Test.auth_headers/1` combines auth + sandbox headers
+  - New `PaperTiger.Test.base_url/1` helper for building PaperTiger URLs
+
+### Changed
+
+- **Storage layer uses namespaced keys**: All ETS stores now key data by `{namespace, id}` instead of just `id`
+  - Backwards compatible: non-sandboxed code uses `:global` namespace automatically
+  - New functions: `clear_namespace/1`, `list_namespace/1` on all stores
+  - Idempotency cache also supports namespacing
+
 ## [0.9.2] - 2026-01-02
 
 ### Fixed

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,0 +1,12 @@
+import Config
+
+# Configure stripity_stripe at runtime
+# Uses PaperTiger by default, real Stripe when VALIDATE_AGAINST_STRIPE=true
+if config_env() == :test do
+  if System.get_env("VALIDATE_AGAINST_STRIPE") == "true" do
+    config :stripity_stripe,
+      api_key: System.get_env("STRIPE_API_KEY")
+  else
+    config :stripity_stripe, PaperTiger.stripity_stripe_config()
+  end
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,7 +1,5 @@
 import Config
 
-# Stripity Stripe configuration for contract testing
-# Only used when VALIDATE_AGAINST_STRIPE=true
-config :stripity_stripe,
-  api_key: System.get_env("STRIPE_API_KEY") || "sk_test_mock",
-  log_level: :info
+# Stripity Stripe base configuration for test
+# Runtime config in runtime.exs handles PaperTiger vs real Stripe switching
+config :stripity_stripe, log_level: :info

--- a/lib/paper_tiger/application.ex
+++ b/lib/paper_tiger/application.ex
@@ -31,6 +31,7 @@ defmodule PaperTiger.Application do
   alias PaperTiger.Store.TaxRates
   alias PaperTiger.Store.Tokens
   alias PaperTiger.Store.Topups
+  alias PaperTiger.Store.WebhookDeliveries
   alias PaperTiger.Store.Webhooks
 
   require Logger
@@ -75,6 +76,7 @@ defmodule PaperTiger.Application do
         Payouts,
         CheckoutSessions,
         Events,
+        WebhookDeliveries,
         Webhooks,
         Disputes,
         ApplicationFees,

--- a/lib/paper_tiger/plugs/sandbox.ex
+++ b/lib/paper_tiger/plugs/sandbox.ex
@@ -1,0 +1,82 @@
+defmodule PaperTiger.Plugs.Sandbox do
+  @moduledoc """
+  Plug that extracts test namespace from HTTP headers for sandbox isolation.
+
+  When a request includes the `x-paper-tiger-namespace` header, this plug
+  sets the namespace in the process dictionary so that all PaperTiger
+  operations scope data to that namespace.
+
+  ## Usage in Tests
+
+      # In your test setup
+      setup :checkout_paper_tiger
+
+      # When making HTTP requests, include the namespace header
+      Req.post(url,
+        headers: [
+          {"authorization", "Bearer sk_test_mock"},
+          {"x-paper-tiger-namespace", inspect(self())}
+        ]
+      )
+
+      # Or use the helper from PaperTiger.Test
+      Req.post(url, headers: PaperTiger.Test.sandbox_headers())
+
+  ## How It Works
+
+  1. Client sends `x-paper-tiger-namespace` header with the test PID as a string
+  2. This plug parses the PID and sets it in the process dictionary
+  3. All subsequent store operations in this request use that namespace
+  4. Data is isolated from other concurrent tests
+  """
+
+  import Plug.Conn
+
+  @namespace_header "x-paper-tiger-namespace"
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    case get_req_header(conn, @namespace_header) do
+      [namespace_string | _] ->
+        # Parse the namespace (could be a PID string like "#PID<0.123.0>")
+        namespace = parse_namespace(namespace_string)
+        Process.put(:paper_tiger_namespace, namespace)
+        conn
+
+      [] ->
+        # No namespace header - use :global (default behavior)
+        conn
+    end
+  end
+
+  defp parse_namespace(string) do
+    # Try to parse as a PID string first
+    case parse_pid_string(string) do
+      {:ok, pid} -> pid
+      :error -> String.to_atom(string)
+    end
+  end
+
+  # Parse PID string like "#PID<0.123.0>" or "0.123.0"
+  defp parse_pid_string(string) do
+    # Remove #PID< and > if present
+    cleaned =
+      string
+      |> String.replace_prefix("#PID<", "")
+      |> String.replace_suffix(">", "")
+
+    case String.split(cleaned, ".") do
+      [a, b, c] ->
+        try do
+          pid = :c.pid(String.to_integer(a), String.to_integer(b), String.to_integer(c))
+          {:ok, pid}
+        rescue
+          _ -> :error
+        end
+
+      _ ->
+        :error
+    end
+  end
+end

--- a/lib/paper_tiger/router.ex
+++ b/lib/paper_tiger/router.ex
@@ -50,6 +50,7 @@ defmodule PaperTiger.Router do
   alias PaperTiger.Plugs.Auth
   alias PaperTiger.Plugs.CORS
   alias PaperTiger.Plugs.Idempotency
+  alias PaperTiger.Plugs.Sandbox
   alias PaperTiger.Plugs.UnflattenParams
   alias PaperTiger.Resources.ApplicationFee
   alias PaperTiger.Resources.BalanceTransaction
@@ -86,6 +87,7 @@ defmodule PaperTiger.Router do
   # Plug pipeline
   plug(:match)
   plug(CORS)
+  plug(Sandbox)
 
   plug(Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],

--- a/lib/paper_tiger/store/webhook_deliveries.ex
+++ b/lib/paper_tiger/store/webhook_deliveries.ex
@@ -1,0 +1,70 @@
+defmodule PaperTiger.Store.WebhookDeliveries do
+  @moduledoc """
+  In-memory store for webhook deliveries in test mode.
+
+  When `webhook_mode: :collect` is configured, webhooks are stored here
+  instead of being delivered via HTTP. Tests can then inspect what
+  webhooks would have been delivered.
+
+  Data is namespace-scoped for test isolation with `async: true`.
+  """
+
+  use PaperTiger.Store,
+    table: :paper_tiger_webhook_deliveries,
+    resource: "webhook_delivery",
+    plural: "webhook_deliveries"
+
+  @doc """
+  Records a webhook delivery for later inspection.
+
+  Called by the telemetry handler when in `:collect` mode.
+  """
+  def record(event, webhook) do
+    delivery = %{
+      id: PaperTiger.Resource.generate_id("whd"),
+      event_id: event.id,
+      event_type: event.type,
+      event_data: event.data,
+      webhook_id: webhook[:id] || webhook["id"],
+      webhook_url: webhook[:url] || webhook["url"],
+      # Use `created` to match Stripe's convention (paginate expects this field)
+      created: System.system_time(:second)
+    }
+
+    insert(delivery)
+    delivery
+  end
+
+  @doc """
+  Gets all recorded webhook deliveries for the current namespace.
+
+  Returns deliveries in chronological order (oldest first).
+  """
+  def get_all do
+    %{data: deliveries} = list(%{limit: 100})
+    Enum.sort_by(deliveries, & &1.created)
+  end
+
+  @doc """
+  Gets webhook deliveries filtered by event type.
+
+  ## Examples
+
+      # Get all customer.created events
+      get_by_type("customer.created")
+
+      # Get all invoice events
+      get_by_type("invoice.*")
+  """
+  def get_by_type(type_pattern) do
+    get_all()
+    |> Enum.filter(fn delivery ->
+      if String.ends_with?(type_pattern, "*") do
+        prefix = String.trim_trailing(type_pattern, "*")
+        String.starts_with?(delivery.event_type, prefix)
+      else
+        delivery.event_type == type_pattern
+      end
+    end)
+  end
+end

--- a/lib/paper_tiger/test.ex
+++ b/lib/paper_tiger/test.ex
@@ -1,0 +1,396 @@
+defmodule PaperTiger.Test do
+  @moduledoc """
+  Test helpers for running PaperTiger tests concurrently.
+
+  Provides a sandbox mechanism similar to Ecto.Adapters.SQL.Sandbox that
+  isolates test data by namespace, allowing tests to run with `async: true`.
+
+  ## Usage
+
+      defmodule MyApp.StripeTest do
+        use ExUnit.Case, async: true
+
+        setup :checkout_paper_tiger
+
+        test "creates a customer" do
+          # Data is isolated to this test process
+          {:ok, customer} = PaperTiger.TestClient.create_customer(%{...})
+        end
+      end
+
+  ## How It Works
+
+  When `checkout_paper_tiger/1` is called:
+
+  1. Stores the test process PID as a namespace in the process dictionary
+  2. All subsequent PaperTiger operations scope data to that namespace
+  3. On test exit, only that namespace's data is cleaned up
+
+  This allows multiple tests to run concurrently without interfering
+  with each other's data.
+  """
+
+  alias PaperTiger.Store.ApplicationFees
+  alias PaperTiger.Store.BalanceTransactions
+  alias PaperTiger.Store.BankAccounts
+  alias PaperTiger.Store.Cards
+  alias PaperTiger.Store.Charges
+  alias PaperTiger.Store.CheckoutSessions
+  alias PaperTiger.Store.Coupons
+  alias PaperTiger.Store.Customers
+  alias PaperTiger.Store.Disputes
+  alias PaperTiger.Store.Events
+  alias PaperTiger.Store.InvoiceItems
+  alias PaperTiger.Store.Invoices
+  alias PaperTiger.Store.PaymentIntents
+  alias PaperTiger.Store.PaymentMethods
+  alias PaperTiger.Store.Payouts
+  alias PaperTiger.Store.Plans
+  alias PaperTiger.Store.Prices
+  alias PaperTiger.Store.Products
+  alias PaperTiger.Store.Refunds
+  alias PaperTiger.Store.Reviews
+  alias PaperTiger.Store.SetupIntents
+  alias PaperTiger.Store.Sources
+  alias PaperTiger.Store.SubscriptionItems
+  alias PaperTiger.Store.Subscriptions
+  alias PaperTiger.Store.SubscriptionSchedules
+  alias PaperTiger.Store.TaxRates
+  alias PaperTiger.Store.Tokens
+  alias PaperTiger.Store.Topups
+  alias PaperTiger.Store.WebhookDeliveries
+  alias PaperTiger.Store.Webhooks
+
+  @namespace_key :paper_tiger_namespace
+  @namespace_header "x-paper-tiger-namespace"
+  @default_api_key "sk_test_mock"
+
+  @doc """
+  Returns the base URL for PaperTiger HTTP requests.
+
+  Uses the configured port from application config.
+
+  ## Example
+
+      iex> PaperTiger.Test.base_url()
+      "http://localhost:4001"
+
+      iex> PaperTiger.Test.base_url("/v1/customers")
+      "http://localhost:4001/v1/customers"
+  """
+  @spec base_url(String.t()) :: String.t()
+  def base_url(path \\ "") do
+    port = Application.get_env(:paper_tiger, :port, 4001)
+    "http://localhost:#{port}#{path}"
+  end
+
+  @doc """
+  Returns HTTP headers for authenticated sandbox requests.
+
+  Combines authorization header with sandbox namespace headers.
+  Use this helper for most HTTP requests to PaperTiger.
+
+  ## Options
+
+  - `:api_key` - Override the default API key (default: "sk_test_mock")
+
+  ## Example
+
+      Req.post(base_url("/v1/customers"),
+        form: [email: "test@example.com"],
+        headers: auth_headers()
+      )
+
+      # With custom API key
+      Req.get(url, headers: auth_headers(api_key: "sk_test_custom"))
+  """
+  @spec auth_headers(keyword()) :: [{String.t(), String.t()}]
+  def auth_headers(opts \\ []) do
+    api_key = Keyword.get(opts, :api_key, @default_api_key)
+    [{"authorization", "Bearer #{api_key}"}] ++ sandbox_headers()
+  end
+
+  @doc """
+  Returns HTTP headers needed for sandbox isolation.
+
+  Include these headers in HTTP requests to PaperTiger to ensure
+  data is scoped to the current test's namespace.
+
+  ## Example
+
+      Req.post(url, headers: PaperTiger.Test.sandbox_headers())
+
+      # Or merge with other headers:
+      Req.get(url,
+        headers: [{"authorization", "Bearer sk_test_mock"}] ++ PaperTiger.Test.sandbox_headers()
+      )
+  """
+  @spec sandbox_headers() :: [{String.t(), String.t()}]
+  def sandbox_headers do
+    case current_namespace() do
+      :global -> []
+      pid when is_pid(pid) -> [{@namespace_header, inspect(pid)}]
+    end
+  end
+
+  @doc """
+  Checks out a PaperTiger sandbox for the current test.
+
+  Use as a setup callback:
+
+      setup :checkout_paper_tiger
+
+  Or call directly in setup block:
+
+      setup do
+        PaperTiger.Test.checkout_paper_tiger(%{})
+        :ok
+      end
+
+  Returns `:ok` for use with ExUnit's setup callbacks.
+  """
+  @spec checkout_paper_tiger(map()) :: :ok
+  def checkout_paper_tiger(_context \\ %{}) do
+    namespace = self()
+    Process.put(@namespace_key, namespace)
+
+    ExUnit.Callbacks.on_exit(fn ->
+      cleanup_namespace(namespace)
+    end)
+
+    :ok
+  end
+
+  @doc """
+  Returns the current namespace, or `:global` if not in a sandboxed test.
+  """
+  @spec current_namespace() :: pid() | :global
+  def current_namespace do
+    Process.get(@namespace_key, :global)
+  end
+
+  @doc """
+  Cleans up all data for the given namespace.
+
+  Called automatically on test exit when using `checkout_paper_tiger/1`.
+  """
+  @spec cleanup_namespace(pid() | :global) :: :ok
+  def cleanup_namespace(namespace) do
+    stores = [
+      ApplicationFees,
+      BalanceTransactions,
+      BankAccounts,
+      Cards,
+      Charges,
+      CheckoutSessions,
+      Coupons,
+      Customers,
+      Disputes,
+      Events,
+      InvoiceItems,
+      Invoices,
+      PaymentIntents,
+      PaymentMethods,
+      Payouts,
+      Plans,
+      Prices,
+      Products,
+      Refunds,
+      Reviews,
+      SetupIntents,
+      Sources,
+      SubscriptionItems,
+      Subscriptions,
+      SubscriptionSchedules,
+      TaxRates,
+      Tokens,
+      Topups,
+      WebhookDeliveries,
+      Webhooks
+    ]
+
+    Enum.each(stores, fn store ->
+      store.clear_namespace(namespace)
+    end)
+
+    # Also clear idempotency keys for this namespace
+    PaperTiger.Idempotency.clear_namespace(namespace)
+
+    :ok
+  end
+
+  # =============================================================================
+  # Webhook Delivery Helpers (for :collect mode)
+  # =============================================================================
+
+  @doc """
+  Enables webhook collection mode for the current test.
+
+  Call this in your test setup to capture webhooks instead of delivering them.
+  Automatically restores the previous mode on test exit.
+
+  ## Example
+
+      setup do
+        :ok = checkout_paper_tiger(%{})
+        :ok = enable_webhook_collection()
+        :ok
+      end
+
+      test "creates customer and triggers webhook" do
+        {:ok, _customer} = Stripe.Customer.create(%{email: "test@example.com"})
+        [delivery] = PaperTiger.Test.assert_webhook_delivered("customer.created")
+        assert delivery.event_data.object.email == "test@example.com"
+      end
+  """
+  @spec enable_webhook_collection() :: :ok
+  def enable_webhook_collection do
+    previous_mode = Application.get_env(:paper_tiger, :webhook_mode)
+    Application.put_env(:paper_tiger, :webhook_mode, :collect)
+
+    ExUnit.Callbacks.on_exit(fn ->
+      if previous_mode do
+        Application.put_env(:paper_tiger, :webhook_mode, previous_mode)
+      else
+        Application.delete_env(:paper_tiger, :webhook_mode)
+      end
+    end)
+
+    :ok
+  end
+
+  @doc """
+  Gets all webhook deliveries collected during the test.
+
+  Only works when `webhook_mode: :collect` is configured.
+
+  Returns a list of delivery records sorted by creation time (oldest first).
+
+  ## Example
+
+      setup do
+        Application.put_env(:paper_tiger, :webhook_mode, :collect)
+        on_exit(fn -> Application.delete_env(:paper_tiger, :webhook_mode) end)
+        :ok
+      end
+
+      test "creates customer and triggers webhook" do
+        {:ok, _customer} = Stripe.Customer.create(%{email: "test@example.com"})
+
+        deliveries = PaperTiger.Test.get_delivered_webhooks()
+        assert [%{event_type: "customer.created"}] = deliveries
+      end
+  """
+  @spec get_delivered_webhooks() :: [map()]
+  def get_delivered_webhooks do
+    WebhookDeliveries.get_all()
+  end
+
+  @doc """
+  Gets webhook deliveries filtered by event type.
+
+  Supports wildcard patterns like "customer.*" or "invoice.payment_*".
+
+  ## Examples
+
+      # Get all customer.created events
+      get_delivered_webhooks("customer.created")
+
+      # Get all customer events
+      get_delivered_webhooks("customer.*")
+
+      # Get all invoice payment events
+      get_delivered_webhooks("invoice.payment_*")
+  """
+  @spec get_delivered_webhooks(String.t()) :: [map()]
+  def get_delivered_webhooks(type_pattern) do
+    WebhookDeliveries.get_by_type(type_pattern)
+  end
+
+  @doc """
+  Clears all collected webhook deliveries for the current namespace.
+
+  Useful when testing multiple operations and wanting to verify
+  webhooks from a specific action.
+
+  ## Example
+
+      test "verifies webhooks for second operation only" do
+        {:ok, _} = Stripe.Customer.create(%{email: "first@example.com"})
+        PaperTiger.Test.clear_delivered_webhooks()
+
+        {:ok, _} = Stripe.Customer.create(%{email: "second@example.com"})
+
+        # Only sees the second customer's webhook
+        assert [%{event_type: "customer.created"}] = PaperTiger.Test.get_delivered_webhooks()
+      end
+  """
+  @spec clear_delivered_webhooks() :: :ok
+  def clear_delivered_webhooks do
+    WebhookDeliveries.clear_namespace(current_namespace())
+  end
+
+  @doc """
+  Asserts that a webhook was delivered with the given event type.
+
+  This is a convenience helper that combines getting deliveries and asserting.
+  Returns the matching deliveries for further assertions.
+
+  ## Example
+
+      test "customer creation triggers webhook" do
+        {:ok, customer} = Stripe.Customer.create(%{email: "test@example.com"})
+
+        [delivery] = PaperTiger.Test.assert_webhook_delivered("customer.created")
+        assert delivery.event_data.object.email == "test@example.com"
+      end
+  """
+  @spec assert_webhook_delivered(String.t()) :: [map()]
+  def assert_webhook_delivered(type_pattern) do
+    deliveries = get_delivered_webhooks(type_pattern)
+
+    if deliveries == [] do
+      all_deliveries = get_delivered_webhooks()
+      types = Enum.map(all_deliveries, & &1.event_type)
+
+      raise ExUnit.AssertionError,
+        message: """
+        Expected webhook delivery matching "#{type_pattern}" but none found.
+
+        Delivered webhooks: #{inspect(types)}
+        """
+    end
+
+    deliveries
+  end
+
+  @doc """
+  Asserts that no webhook was delivered with the given event type.
+
+  ## Example
+
+      test "soft delete doesn't trigger delete webhook" do
+        {:ok, customer} = Stripe.Customer.create(%{email: "test@example.com"})
+        PaperTiger.Test.clear_delivered_webhooks()
+
+        soft_delete_customer(customer)
+
+        PaperTiger.Test.refute_webhook_delivered("customer.deleted")
+      end
+  """
+  @spec refute_webhook_delivered(String.t()) :: :ok
+  def refute_webhook_delivered(type_pattern) do
+    deliveries = get_delivered_webhooks(type_pattern)
+
+    if deliveries != [] do
+      raise ExUnit.AssertionError,
+        message: """
+        Expected no webhook delivery matching "#{type_pattern}" but found #{length(deliveries)}.
+
+        Deliveries: #{inspect(deliveries, pretty: true)}
+        """
+    end
+
+    :ok
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PaperTiger.MixProject do
   @moduledoc false
   use Mix.Project
 
-  @version "0.9.2"
+  @version "0.9.3"
   @url "https://github.com/EnaiaInc/paper_tiger"
   @maintainers ["Enaia Inc"]
 

--- a/test/paper_tiger/resources/checkout_session_test.exs
+++ b/test/paper_tiger/resources/checkout_session_test.exs
@@ -10,14 +10,13 @@ defmodule PaperTiger.Resources.CheckoutSessionTest do
   5. POST /_test/checkout/sessions/:id/complete - Complete checkout session (test helper)
   """
 
-  use ExUnit.Case
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
 
   alias PaperTiger.Router
 
-  setup do
-    PaperTiger.flush()
-    :ok
-  end
+  setup :checkout_paper_tiger
 
   defp conn(method, path, params, headers) do
     conn = Plug.Test.conn(method, path, params)

--- a/test/paper_tiger/resources/customer_test.exs
+++ b/test/paper_tiger/resources/customer_test.exs
@@ -10,15 +10,13 @@ defmodule PaperTiger.Resources.CustomerTest do
   5. GET /v1/customers - List customers
   """
 
-  use ExUnit.Case
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
 
   alias PaperTiger.Router
 
-  setup do
-    # Clear all data before each test
-    PaperTiger.flush()
-    :ok
-  end
+  setup :checkout_paper_tiger
 
   # Helper function to create a test connection with proper setup
   defp conn(method, path, params, headers) do

--- a/test/paper_tiger/resources/invoice_test.exs
+++ b/test/paper_tiger/resources/invoice_test.exs
@@ -26,15 +26,13 @@ defmodule PaperTiger.Resources.InvoiceTest do
      - GET /v1/invoices - List with pagination
   """
 
-  use ExUnit.Case
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
 
   alias PaperTiger.Router
 
-  setup do
-    # Clear all data before each test
-    PaperTiger.flush()
-    :ok
-  end
+  setup :checkout_paper_tiger
 
   # Helper function to create a test connection with proper setup
   defp conn(method, path, params, headers) do

--- a/test/paper_tiger/resources/payment_method_test.exs
+++ b/test/paper_tiger/resources/payment_method_test.exs
@@ -22,15 +22,13 @@ defmodule PaperTiger.Resources.PaymentMethodTest do
      - GET /v1/payment_methods - List with pagination
   """
 
-  use ExUnit.Case
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
 
   alias PaperTiger.Router
 
-  setup do
-    # Clear all data before each test
-    PaperTiger.flush()
-    :ok
-  end
+  setup :checkout_paper_tiger
 
   # Helper function to create a test connection with proper setup
   defp conn(method, path, params, headers) do

--- a/test/paper_tiger/resources/product_price_test.exs
+++ b/test/paper_tiger/resources/product_price_test.exs
@@ -26,15 +26,13 @@ defmodule PaperTiger.Resources.ProductPriceTest do
   3. Delete product (verify prices still exist)
   """
 
-  use ExUnit.Case
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
 
   alias PaperTiger.Router
 
-  setup do
-    # Clear all data before each test
-    PaperTiger.flush()
-    :ok
-  end
+  setup :checkout_paper_tiger
 
   # Helper function to create a test connection with proper setup
   defp conn(method, path, params, headers) do

--- a/test/paper_tiger/resources/subscription_test.exs
+++ b/test/paper_tiger/resources/subscription_test.exs
@@ -11,7 +11,9 @@ defmodule PaperTiger.Resources.SubscriptionTest do
   6. GET /v1/subscriptions - List subscriptions
   """
 
-  use ExUnit.Case
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
 
   alias PaperTiger.Router
 
@@ -20,11 +22,7 @@ defmodule PaperTiger.Resources.SubscriptionTest do
     :ok
   end
 
-  setup do
-    # Clear all data before each test
-    PaperTiger.flush()
-    :ok
-  end
+  setup :checkout_paper_tiger
 
   # Helper function to create a test connection with proper setup
   defp conn(method, path, params, headers) do

--- a/test/paper_tiger/resources/webhook_test.exs
+++ b/test/paper_tiger/resources/webhook_test.exs
@@ -10,15 +10,13 @@ defmodule PaperTiger.Resources.WebhookTest do
   5. GET /v1/webhook_endpoints - List webhook endpoints
   """
 
-  use ExUnit.Case
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
 
   alias PaperTiger.Router
 
-  setup do
-    # Clear all data before each test
-    PaperTiger.flush()
-    :ok
-  end
+  setup :checkout_paper_tiger
 
   # Helper function to create a test connection with proper setup
   defp conn(method, path, params, headers) do

--- a/test/paper_tiger/webhook_collection_test.exs
+++ b/test/paper_tiger/webhook_collection_test.exs
@@ -1,0 +1,218 @@
+defmodule PaperTiger.WebhookCollectionTest do
+  @moduledoc """
+  Tests for webhook collection mode (`:collect`).
+
+  This mode stores webhooks in-memory for test inspection instead of
+  delivering them via HTTP, enabling assertions about what webhooks
+  would fire without needing a running web server.
+
+  Note: Uses TestClient for HTTP requests since that handles namespace
+  headers correctly. Apps using stripity_stripe need to configure
+  the HTTP middleware to add namespace headers for async tests.
+  """
+  use ExUnit.Case, async: false
+
+  import PaperTiger.Test
+
+  alias PaperTiger.TestClient
+
+  setup do
+    PaperTiger.flush()
+    :ok
+  end
+
+  describe "enable_webhook_collection/0" do
+    test "sets webhook_mode to :collect" do
+      enable_webhook_collection()
+
+      assert Application.get_env(:paper_tiger, :webhook_mode) == :collect
+    end
+
+    test "restores previous mode on test exit" do
+      # This is hard to test directly since on_exit runs after the test
+      # but we can verify the function doesn't crash
+      assert :ok = enable_webhook_collection()
+    end
+  end
+
+  describe "webhook collection with API calls" do
+    setup do
+      enable_webhook_collection()
+      :ok
+    end
+
+    test "customer creation triggers customer.created webhook" do
+      {:ok, customer} = TestClient.create_customer(%{"email" => "test@example.com"})
+
+      [delivery] = assert_webhook_delivered("customer.created")
+
+      assert delivery.event_type == "customer.created"
+      assert delivery.event_data.object.id == customer["id"]
+      assert delivery.event_data.object.email == "test@example.com"
+    end
+
+    test "customer update triggers customer.updated webhook" do
+      {:ok, customer} = TestClient.create_customer(%{"email" => "test@example.com"})
+      clear_delivered_webhooks()
+
+      {:ok, _updated} = TestClient.update_customer(customer["id"], %{"name" => "Updated Name"})
+
+      [delivery] = assert_webhook_delivered("customer.updated")
+      assert delivery.event_data.object.name == "Updated Name"
+    end
+
+    test "subscription creation triggers customer.subscription.created webhook" do
+      # Create customer first
+      {:ok, customer} = TestClient.create_customer(%{"email" => "test@example.com"})
+
+      # Create product and price
+      {:ok, product} = TestClient.create_product(%{"name" => "Test Product"})
+
+      {:ok, price} =
+        TestClient.create_price(%{
+          "currency" => "usd",
+          "product" => product["id"],
+          "recurring" => %{"interval" => "month"},
+          "unit_amount" => 1000
+        })
+
+      clear_delivered_webhooks()
+
+      # Create subscription
+      {:ok, subscription} =
+        TestClient.create_subscription(%{
+          "customer" => customer["id"],
+          "items" => [%{"price" => price["id"]}]
+        })
+
+      [delivery] = assert_webhook_delivered("customer.subscription.created")
+      assert delivery.event_data.object.id == subscription["id"]
+      assert delivery.event_data.object.status == "active"
+    end
+  end
+
+  describe "get_delivered_webhooks/0" do
+    setup do
+      enable_webhook_collection()
+      :ok
+    end
+
+    test "returns empty list when no webhooks delivered" do
+      assert get_delivered_webhooks() == []
+    end
+
+    test "returns all delivered webhooks in order" do
+      {:ok, _} = TestClient.create_customer(%{"email" => "first@example.com"})
+      {:ok, _} = TestClient.create_customer(%{"email" => "second@example.com"})
+
+      deliveries = get_delivered_webhooks()
+
+      assert length(deliveries) == 2
+      assert Enum.all?(deliveries, &(&1.event_type == "customer.created"))
+    end
+  end
+
+  describe "get_delivered_webhooks/1 with type filter" do
+    setup do
+      enable_webhook_collection()
+
+      # Create customer and product to generate different webhook types
+      {:ok, _customer} = TestClient.create_customer(%{"email" => "test@example.com"})
+      {:ok, _product} = TestClient.create_product(%{"name" => "Test Product"})
+
+      :ok
+    end
+
+    test "filters by exact event type" do
+      deliveries = get_delivered_webhooks("customer.created")
+
+      assert length(deliveries) == 1
+      assert hd(deliveries).event_type == "customer.created"
+    end
+
+    test "filters by wildcard pattern" do
+      # Test prefix wildcard
+      customer_events = get_delivered_webhooks("customer.*")
+
+      assert length(customer_events) == 1
+      assert hd(customer_events).event_type == "customer.created"
+    end
+
+    test "returns empty list when no matches" do
+      deliveries = get_delivered_webhooks("invoice.paid")
+
+      assert deliveries == []
+    end
+  end
+
+  describe "clear_delivered_webhooks/0" do
+    setup do
+      enable_webhook_collection()
+      :ok
+    end
+
+    test "clears all collected webhooks" do
+      {:ok, _} = TestClient.create_customer(%{"email" => "test@example.com"})
+      assert length(get_delivered_webhooks()) == 1
+
+      clear_delivered_webhooks()
+
+      assert get_delivered_webhooks() == []
+    end
+  end
+
+  describe "assert_webhook_delivered/1" do
+    setup do
+      enable_webhook_collection()
+      :ok
+    end
+
+    test "returns matching deliveries when found" do
+      {:ok, customer} = TestClient.create_customer(%{"email" => "test@example.com"})
+
+      [delivery] = assert_webhook_delivered("customer.created")
+
+      assert delivery.event_data.object.id == customer["id"]
+    end
+
+    test "raises when no matching webhook found" do
+      {:ok, _} = TestClient.create_customer(%{"email" => "test@example.com"})
+
+      assert_raise ExUnit.AssertionError, ~r/Expected webhook delivery/, fn ->
+        assert_webhook_delivered("invoice.paid")
+      end
+    end
+
+    test "error message includes delivered webhook types" do
+      {:ok, _} = TestClient.create_customer(%{"email" => "test@example.com"})
+
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_webhook_delivered("invoice.paid")
+        end
+
+      assert error.message =~ "customer.created"
+    end
+  end
+
+  describe "refute_webhook_delivered/1" do
+    setup do
+      enable_webhook_collection()
+      :ok
+    end
+
+    test "passes when webhook type not found" do
+      {:ok, _} = TestClient.create_customer(%{"email" => "test@example.com"})
+
+      assert :ok = refute_webhook_delivered("invoice.paid")
+    end
+
+    test "raises when matching webhook is found" do
+      {:ok, _} = TestClient.create_customer(%{"email" => "test@example.com"})
+
+      assert_raise ExUnit.AssertionError, ~r/Expected no webhook delivery/, fn ->
+        refute_webhook_delivered("customer.created")
+      end
+    end
+  end
+end

--- a/test/paper_tiger_test.exs
+++ b/test/paper_tiger_test.exs
@@ -1,15 +1,13 @@
 defmodule PaperTigerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
 
   alias PaperTiger.Store.Customers
 
   doctest PaperTiger
 
-  setup do
-    # Clear all data between tests
-    PaperTiger.flush()
-    :ok
-  end
+  setup :checkout_paper_tiger
 
   describe "Clock" do
     test "real mode returns system time" do


### PR DESCRIPTION
## Summary

- Adds namespace-based isolation enabling `async: true` tests with PaperTiger
- Adds webhook collection mode for asserting on webhooks without HTTP delivery

## Changes

**Sandbox/Namespace support:**
- `checkout_paper_tiger/0` helper in `PaperTiger.Test` for test setup
- Process dictionary-based namespace isolation per test process
- All stores, idempotency cache respect namespaces
- Sandbox plug extracts namespace from `x-paper-tiger-namespace` header

**Webhook collection mode:**
- New `:collect` mode stores webhooks in-memory instead of HTTP delivery
- `enable_webhook_collection/0`, `get_delivered_webhooks/0-1`, `clear_delivered_webhooks/0`
- `assert_webhook_delivered/1` and `refute_webhook_delivered/1` for test assertions
- Supports wildcard patterns like `"customer.*"`

Version bumped to 0.10.0.