### PR TITLE
[0.9.9] Add pre-defined Stripe test payment method tokens

### DIFF
--- a/lib/paper_tiger.ex
+++ b/lib/paper_tiger.ex
@@ -159,6 +159,9 @@ defmodule PaperTiger do
     # Reset chaos coordinator
     PaperTiger.ChaosCoordinator.reset()
 
+    # Reload pre-defined Stripe test tokens (pm_card_visa, tok_visa, etc.)
+    {:ok, _stats} = PaperTiger.TestTokens.load()
+
     :ok
   end
 

--- a/lib/paper_tiger/application.ex
+++ b/lib/paper_tiger/application.ex
@@ -90,6 +90,8 @@ defmodule PaperTiger.Application do
 
     case Supervisor.start_link(children, opts) do
       {:ok, pid} ->
+        # Load pre-defined Stripe test tokens (pm_card_visa, tok_visa, etc.)
+        load_test_tokens()
         # Load init_data after stores are initialized
         load_init_data()
         # Register configured webhooks
@@ -102,6 +104,12 @@ defmodule PaperTiger.Application do
   end
 
   ## Private Functions
+
+  # Loads pre-defined Stripe test tokens (pm_card_visa, tok_visa, etc.)
+  defp load_test_tokens do
+    {:ok, _stats} = PaperTiger.TestTokens.load()
+    :ok
+  end
 
   # Loads init_data if configured
   defp load_init_data do

--- a/lib/paper_tiger/store/payment_methods.ex
+++ b/lib/paper_tiger/store/payment_methods.ex
@@ -32,6 +32,41 @@ defmodule PaperTiger.Store.PaymentMethods do
     prefix: "pm"
 
   @doc """
+  Retrieves a payment method by ID.
+
+  Overrides the default `get/1` to also check the global namespace
+  for pre-defined test tokens (pm_card_visa, pm_card_mastercard, etc.).
+
+  This allows tests running in isolated namespaces to use the standard
+  Stripe test tokens without explicitly creating them.
+  """
+  @spec get(String.t()) :: {:ok, map()} | {:error, :not_found}
+  def get(id) when is_binary(id) do
+    namespace = PaperTiger.Test.current_namespace()
+    key = {namespace, id}
+
+    case :ets.lookup(@table, key) do
+      [{^key, item}] ->
+        {:ok, item}
+
+      [] ->
+        # Fall back to global namespace for pre-defined test tokens
+        get_from_global_namespace(namespace, id)
+    end
+  end
+
+  defp get_from_global_namespace(:global, _id), do: {:error, :not_found}
+
+  defp get_from_global_namespace(_namespace, id) do
+    global_key = {:global, id}
+
+    case :ets.lookup(@table, global_key) do
+      [{^global_key, item}] -> {:ok, item}
+      [] -> {:error, :not_found}
+    end
+  end
+
+  @doc """
   Finds payment methods by customer ID.
 
   **Direct ETS access** - does not go through GenServer.

--- a/lib/paper_tiger/store/tokens.ex
+++ b/lib/paper_tiger/store/tokens.ex
@@ -27,4 +27,39 @@ defmodule PaperTiger.Store.Tokens do
     table: :paper_tiger_tokens,
     resource: "token",
     prefix: "tok"
+
+  @doc """
+  Retrieves a token by ID.
+
+  Overrides the default `get/1` to also check the global namespace
+  for pre-defined test tokens (tok_visa, tok_mastercard, etc.).
+
+  This allows tests running in isolated namespaces to use the standard
+  Stripe test tokens without explicitly creating them.
+  """
+  @spec get(String.t()) :: {:ok, map()} | {:error, :not_found}
+  def get(id) when is_binary(id) do
+    namespace = PaperTiger.Test.current_namespace()
+    key = {namespace, id}
+
+    case :ets.lookup(@table, key) do
+      [{^key, item}] ->
+        {:ok, item}
+
+      [] ->
+        # Fall back to global namespace for pre-defined test tokens
+        get_from_global_namespace(namespace, id)
+    end
+  end
+
+  defp get_from_global_namespace(:global, _id), do: {:error, :not_found}
+
+  defp get_from_global_namespace(_namespace, id) do
+    global_key = {:global, id}
+
+    case :ets.lookup(@table, global_key) do
+      [{^global_key, item}] -> {:ok, item}
+      [] -> {:error, :not_found}
+    end
+  end
 end

--- a/lib/paper_tiger/test_tokens.ex
+++ b/lib/paper_tiger/test_tokens.ex
@@ -1,0 +1,351 @@
+defmodule PaperTiger.TestTokens do
+  @moduledoc """
+  Pre-defined Stripe test tokens that are always available in PaperTiger.
+
+  Stripe provides special test tokens like `pm_card_visa` and `tok_visa` that work
+  without creating payment methods from card details. PaperTiger must provide these
+  same tokens so that library users don't have to change their code when switching
+  between real Stripe and PaperTiger.
+
+  ## Supported Payment Method Tokens (pm_card_*)
+
+  ### By Card Brand
+  - `pm_card_visa` - Visa (4242424242424242)
+  - `pm_card_visa_debit` - Visa Debit
+  - `pm_card_mastercard` - Mastercard (5555555555554444)
+  - `pm_card_mastercard_debit` - Mastercard Debit
+  - `pm_card_mastercard_prepaid` - Mastercard Prepaid
+  - `pm_card_amex` - American Express (378282246310005)
+  - `pm_card_discover` - Discover (6011111111111117)
+  - `pm_card_diners` - Diners Club (3056930009020004)
+  - `pm_card_jcb` - JCB (3566002020360505)
+  - `pm_card_unionpay` - UnionPay (6200000000000005)
+
+  ### Special Behavior Cards
+  - `pm_card_chargeDeclined` - Always declines
+  - `pm_card_chargeDeclinedInsufficientFunds` - Declines with insufficient funds
+  - `pm_card_chargeDeclinedFraudulent` - Declines as fraudulent
+
+  ## Supported Token Tokens (tok_*)
+
+  - `tok_visa`, `tok_mastercard`, `tok_amex`, etc. (same brands as pm_card_*)
+
+  ## Usage
+
+  These tokens are automatically loaded when PaperTiger starts.
+  """
+
+  alias PaperTiger.Store.PaymentMethods
+  alias PaperTiger.Store.Tokens
+
+  require Logger
+
+  # Card brand configurations
+  @card_brands %{
+    "amex" => %{
+      country: "US",
+      exp_month: 12,
+      exp_year: 2030,
+      fingerprint: "pm_card_amex_fingerprint",
+      funding: "credit",
+      last4: "0005"
+    },
+    "diners" => %{
+      country: "US",
+      exp_month: 12,
+      exp_year: 2030,
+      fingerprint: "pm_card_diners_fingerprint",
+      funding: "credit",
+      last4: "0004"
+    },
+    "discover" => %{
+      country: "US",
+      exp_month: 12,
+      exp_year: 2030,
+      fingerprint: "pm_card_discover_fingerprint",
+      funding: "credit",
+      last4: "1117"
+    },
+    "jcb" => %{
+      country: "JP",
+      exp_month: 12,
+      exp_year: 2030,
+      fingerprint: "pm_card_jcb_fingerprint",
+      funding: "credit",
+      last4: "0505"
+    },
+    "mastercard" => %{
+      country: "US",
+      exp_month: 12,
+      exp_year: 2030,
+      fingerprint: "pm_card_mastercard_fingerprint",
+      funding: "credit",
+      last4: "4444"
+    },
+    "mastercard_debit" => %{
+      brand: "mastercard",
+      country: "US",
+      exp_month: 12,
+      exp_year: 2030,
+      fingerprint: "pm_card_mastercard_debit_fingerprint",
+      funding: "debit",
+      last4: "0000"
+    },
+    "mastercard_prepaid" => %{
+      brand: "mastercard",
+      country: "US",
+      exp_month: 12,
+      exp_year: 2030,
+      fingerprint: "pm_card_mastercard_prepaid_fingerprint",
+      funding: "prepaid",
+      last4: "5100"
+    },
+    "unionpay" => %{
+      country: "CN",
+      exp_month: 12,
+      exp_year: 2030,
+      fingerprint: "pm_card_unionpay_fingerprint",
+      funding: "credit",
+      last4: "0005"
+    },
+    "visa" => %{
+      country: "US",
+      exp_month: 12,
+      exp_year: 2030,
+      fingerprint: "pm_card_visa_fingerprint",
+      funding: "credit",
+      last4: "4242"
+    },
+    "visa_debit" => %{
+      brand: "visa",
+      country: "US",
+      exp_month: 12,
+      exp_year: 2030,
+      fingerprint: "pm_card_visa_debit_fingerprint",
+      funding: "debit",
+      last4: "5556"
+    }
+  }
+
+  # Special decline cards
+  @decline_cards %{
+    "chargeDeclined" => %{
+      brand: "visa",
+      decline_code: "generic_decline",
+      last4: "0002"
+    },
+    "chargeDeclinedExpiredCard" => %{
+      brand: "visa",
+      decline_code: "expired_card",
+      last4: "0069"
+    },
+    "chargeDeclinedFraudulent" => %{
+      brand: "visa",
+      decline_code: "fraudulent",
+      last4: "0019"
+    },
+    "chargeDeclinedIncorrectCvc" => %{
+      brand: "visa",
+      decline_code: "incorrect_cvc",
+      last4: "0127"
+    },
+    "chargeDeclinedInsufficientFunds" => %{
+      brand: "visa",
+      decline_code: "insufficient_funds",
+      last4: "9995"
+    },
+    "chargeDeclinedProcessingError" => %{
+      brand: "visa",
+      decline_code: "processing_error",
+      last4: "0119"
+    }
+  }
+
+  @doc """
+  Loads all pre-defined test tokens into PaperTiger stores.
+
+  Called automatically on PaperTiger startup.
+  Returns `{:ok, stats}` with counts of loaded tokens.
+  """
+  @spec load() :: {:ok, map()}
+  def load do
+    pm_count = load_payment_methods()
+    tok_count = load_tokens()
+
+    stats = %{payment_methods: pm_count, tokens: tok_count}
+
+    if pm_count > 0 or tok_count > 0 do
+      Logger.info("PaperTiger loaded #{pm_count} test payment methods, #{tok_count} test tokens")
+    end
+
+    {:ok, stats}
+  end
+
+  @doc """
+  Returns a list of all supported pm_card_* token IDs.
+  """
+  @spec payment_method_ids() :: [String.t()]
+  def payment_method_ids do
+    brand_ids = Enum.map(Map.keys(@card_brands), &"pm_card_#{&1}")
+    decline_ids = Enum.map(Map.keys(@decline_cards), &"pm_card_#{&1}")
+    brand_ids ++ decline_ids
+  end
+
+  @doc """
+  Returns a list of all supported tok_* token IDs.
+  """
+  @spec token_ids() :: [String.t()]
+  def token_ids do
+    Enum.map(Map.keys(@card_brands), &"tok_#{&1}")
+  end
+
+  ## Private Functions
+
+  defp load_payment_methods do
+    count = load_brand_payment_methods() + load_decline_payment_methods()
+    count
+  end
+
+  defp load_brand_payment_methods do
+    Enum.reduce(@card_brands, 0, fn {name, config}, count ->
+      id = "pm_card_#{name}"
+      brand = Map.get(config, :brand, name)
+
+      payment_method = %{
+        billing_details: %{
+          address: %{
+            city: nil,
+            country: nil,
+            line1: nil,
+            line2: nil,
+            postal_code: nil,
+            state: nil
+          },
+          email: nil,
+          name: nil,
+          phone: nil
+        },
+        card: %{
+          brand: normalize_brand(brand),
+          checks: %{
+            address_line1_check: nil,
+            address_postal_code_check: nil,
+            cvc_check: "pass"
+          },
+          country: config.country,
+          exp_month: config.exp_month,
+          exp_year: config.exp_year,
+          fingerprint: config.fingerprint,
+          funding: config.funding,
+          last4: config.last4,
+          three_d_secure_usage: %{supported: true},
+          wallet: nil
+        },
+        created: PaperTiger.now(),
+        customer: nil,
+        id: id,
+        livemode: false,
+        metadata: %{},
+        object: "payment_method",
+        type: "card"
+      }
+
+      {:ok, _} = PaymentMethods.insert(payment_method)
+      count + 1
+    end)
+  end
+
+  defp load_decline_payment_methods do
+    Enum.reduce(@decline_cards, 0, fn {name, config}, count ->
+      id = "pm_card_#{name}"
+
+      payment_method = %{
+        id: id,
+        object: "payment_method",
+        created: PaperTiger.now(),
+        type: "card",
+        customer: nil,
+        metadata: %{
+          # Store decline code in metadata for PaperTiger to use
+          _paper_tiger_decline_code: config.decline_code
+        },
+        livemode: false,
+        billing_details: %{
+          address: %{
+            city: nil,
+            country: nil,
+            line1: nil,
+            line2: nil,
+            postal_code: nil,
+            state: nil
+          },
+          email: nil,
+          name: nil,
+          phone: nil
+        },
+        card: %{
+          brand: config.brand,
+          checks: %{
+            address_line1_check: nil,
+            address_postal_code_check: nil,
+            cvc_check: "pass"
+          },
+          country: "US",
+          exp_month: 12,
+          exp_year: 2030,
+          fingerprint: "pm_card_#{name}_fingerprint",
+          funding: "credit",
+          last4: config.last4,
+          three_d_secure_usage: %{supported: true},
+          wallet: nil
+        }
+      }
+
+      {:ok, _} = PaymentMethods.insert(payment_method)
+      count + 1
+    end)
+  end
+
+  defp load_tokens do
+    Enum.reduce(@card_brands, 0, fn {name, config}, count ->
+      id = "tok_#{name}"
+      brand = Map.get(config, :brand, name)
+
+      token = %{
+        card: %{
+          brand: normalize_brand(brand),
+          country: config.country,
+          exp_month: config.exp_month,
+          exp_year: config.exp_year,
+          fingerprint: "tok_#{name}_fingerprint",
+          funding: config.funding,
+          id: "card_#{name}",
+          last4: config.last4,
+          object: "card"
+        },
+        created: PaperTiger.now(),
+        id: id,
+        livemode: false,
+        object: "token",
+        type: "card",
+        used: false
+      }
+
+      {:ok, _} = Tokens.insert(token)
+      count + 1
+    end)
+  end
+
+  # Normalize brand names to match Stripe's format
+  defp normalize_brand("visa"), do: "visa"
+  defp normalize_brand("visa_debit"), do: "visa"
+  defp normalize_brand("mastercard"), do: "mastercard"
+  defp normalize_brand("mastercard_debit"), do: "mastercard"
+  defp normalize_brand("mastercard_prepaid"), do: "mastercard"
+  defp normalize_brand("amex"), do: "amex"
+  defp normalize_brand("discover"), do: "discover"
+  defp normalize_brand("diners"), do: "diners"
+  defp normalize_brand("jcb"), do: "jcb"
+  defp normalize_brand("unionpay"), do: "unionpay"
+  defp normalize_brand(brand), do: brand
+end


### PR DESCRIPTION
## Summary

- Add pre-defined Stripe test payment method tokens (pm_card_visa, pm_card_mastercard, etc.)
- Tokens are loaded at startup and reloaded after flush() to persist across tests
- Store get/1 functions fall back to global namespace for test tokens

## Changes

Stripe provides special test tokens that work without creating payment methods from card data. This commit adds the same tokens to PaperTiger so library users don't have to change their code when switching between real Stripe and PaperTiger for testing.

Tokens supported:
- Brand tokens: pm_card_visa, pm_card_mastercard, pm_card_amex, pm_card_discover, pm_card_diners, pm_card_jcb, pm_card_unionpay
- Debit/prepaid: pm_card_visa_debit, pm_card_mastercard_debit, pm_card_mastercard_prepaid
- Decline cards: pm_card_chargeDeclined, pm_card_chargeDeclinedInsufficientFunds, pm_card_chargeDeclinedFraudulent, etc.
- Legacy tokens: tok_visa, tok_mastercard, tok_amex, etc.

Fixes CI failure where contract tests using pm_card_visa tokens were failing.