### PR TITLE
Fix format: move @compile after @moduledoc

### DIFF
--- a/lib/paper_tiger/stripity_stripe_hackney.ex
+++ b/lib/paper_tiger/stripity_stripe_hackney.ex
@@ -1,5 +1,4 @@
 defmodule PaperTiger.StripityStripeHackney do
-  @compile {:no_warn_undefined, :hackney}
   @moduledoc """
   HTTP module for stripity_stripe that enables PaperTiger sandbox isolation.
 
@@ -51,6 +50,7 @@ defmodule PaperTiger.StripityStripeHackney do
       end
   """
 
+  @compile {:no_warn_undefined, :hackney}
   @namespace_key :paper_tiger_namespace
   @namespace_header "x-paper-tiger-namespace"
   @shared_namespace_key :paper_tiger_shared_namespace


### PR DESCRIPTION
Fixes CI format check failure from previous commit.