### PR TITLE
[0.9.13] Fix Mix.env() runtime check for test environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.13] - 2026-01-04
+
+### Fixed
+
+- **Mix.env() check at runtime, not compile time**: Dependencies are compiled in `:dev` environment by default, so the compile-time `@mix_env` module attribute was always `:dev` even when running tests. Now checks `Mix.env()` at runtime (after verifying Mix is available) to correctly detect test environment.
+
+## [0.9.12] - 2026-01-04
+
+### Fixed
+
+- **Namespace isolation for InvoiceItem**: Fixed `InvoiceItem.list` to properly filter by namespace, preventing test isolation leaks when listing invoice items.
+
 ## [0.9.11] - 2026-01-04
 
 ### Fixed

--- a/lib/paper_tiger/application.ex
+++ b/lib/paper_tiger/application.ex
@@ -37,9 +37,6 @@ defmodule PaperTiger.Application do
 
   require Logger
 
-  # Capture Mix.env at compile time since Mix isn't available in releases
-  @mix_env Mix.env()
-
   @impl true
   def start(_type, _args) do
     if should_start?() do
@@ -172,8 +169,8 @@ defmodule PaperTiger.Application do
     cond do
       # In a release (no Mix module) - always start, user controls via config/env
       not Code.ensure_loaded?(Mix) -> true
-      # Always start in test environment (compare atoms dynamically to avoid dialyzer warning)
-      Atom.to_string(@mix_env) == "test" -> true
+      # Always start in test environment - Mix.env() is safe here since we already checked Mix is loaded
+      Mix.env() == :test -> true
       # Start if running phx.server
       running_phx_server?() -> true
       # Start in interactive iex session (no Mix.TasksServer means not a mix task)

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PaperTiger.MixProject do
   @moduledoc false
   use Mix.Project
 
-  @version "0.9.12"
+  @version "0.9.13"
   @url "https://github.com/EnaiaInc/paper_tiger"
   @maintainers ["Enaia Inc"]
 


### PR DESCRIPTION
## Summary

- Fix Mix.env() check to happen at runtime instead of compile time
- Dependencies are compiled in :dev by default, so @mix_env was always :dev
- Now checks Mix.env() at runtime after verifying Mix is available

Also adds missing 0.9.12 changelog entry.