### PR TITLE
Transparent checkout session auto-completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.20] - 2026-01-11
+
+### Changed
+
+- **Checkout sessions now auto-complete transparently**: Checkout session URLs now point to PaperTiger's own endpoint (`/checkout/:id/complete`) instead of fake Stripe URLs. When visited, the session auto-completes and redirects to `success_url`. This eliminates the need for `paper_tiger_enabled?` checks in application code - checkout flows now work identically in dev/test and production.
+
 ## [0.9.19] - 2026-01-10
 
 ### Added

--- a/lib/paper_tiger/router.ex
+++ b/lib/paper_tiger/router.ex
@@ -180,6 +180,14 @@ defmodule PaperTiger.Router do
     CheckoutSession.complete(conn, id)
   end
 
+  # Browser-accessible checkout completion endpoint.
+  # When a checkout session URL is visited (via redirect), this auto-completes
+  # the session and redirects to the success_url. This makes checkout flows
+  # work transparently without special handling in application code.
+  get "/checkout/:id/complete" do
+    CheckoutSession.browser_complete(conn, id)
+  end
+
   ## Resource Routes
 
   # Core resources (Phase 1)

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PaperTiger.MixProject do
   @moduledoc false
   use Mix.Project
 
-  @version "0.9.19"
+  @version "0.9.20"
   @url "https://github.com/EnaiaInc/paper_tiger"
   @maintainers ["Enaia Inc"]
 


### PR DESCRIPTION
## Summary

- Checkout sessions now return URLs pointing to PaperTiger for auto-completion
- Visiting the checkout URL auto-completes the session and redirects to success_url
- Eliminates need for app code to detect PT and manually complete sessions

## Changes

Changed `generate_checkout_url/1` to return `http://localhost:PORT/checkout/:id/complete` instead of fake `https://checkout.stripe.com/...` URLs. Added `browser_complete/2` endpoint that completes the session and redirects.

This makes checkout flows work transparently - applications just redirect to the URL and everything works like production Stripe.