### PR TITLE
Use random high ports by default to avoid conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.23] - 2026-01-28
+
+### Changed
+
+- **Random high ports by default**: PaperTiger now picks a random available port in the 59000-60000 range by default, eliminating port conflicts when running multiple instances (tests + dev server, parallel test suites). Port availability is checked before binding, with automatic retry if port is in use. Set explicit port via `PAPER_TIGER_PORT` env var or `port:` option if needed. New `PaperTiger.get_port/0` function returns the actual port selected.
+
 ## [0.9.22] - 2026-01-27
 
 ### Changed
@@ -15,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Reduced startup log noise by changing initialization messages from `Logger.info` to `Logger.debug` across all Store modules, Application, Bootstrap, and core services. Startup messages are now only visible at debug level while operational logs remain at appropriate levels.
+- Reduced startup log noise by changing initialization messages from `Logger.info` to `Logger.debug` across all Store modules, Application, Bootstrap, and core services. Startup messages are only visible at debug level while operational logs remain at appropriate levels.
 
 ## [0.9.20] - 2026-01-11
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Add `paper_tiger` to your dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:paper_tiger, "~> 0.9.22"}
+    {:paper_tiger, "~> 0.9.23"}
   ]
 end
 ```
@@ -317,16 +317,26 @@ end
 
 ### Port Configuration
 
-PaperTiger uses port 4001 by default to avoid conflicts with Phoenix's port 4000.
+PaperTiger automatically picks a random available port in the 59000-60000 range by default, eliminating port conflicts when running multiple instances (tests + dev server, parallel test suites).
 
-If you need a different port:
+**Port selection:**
+
+- **Random by default** - Picks available port, retries if conflict detected
+- **Auto-discovery** - `stripity_stripe_config()` auto-detects the running port
+- **Manual override** - Set explicit port via env var or config
+
+If you need a specific port:
 
 ```elixir
-# config/test.exs
-config :stripity_stripe, PaperTiger.stripity_stripe_config(port: 4002)
+# Via environment variable (recommended)
+PAPER_TIGER_PORT=4001 mix test
 
-# Or via environment variable
-# PAPER_TIGER_PORT=4002 mix test
+# Via config
+config :stripity_stripe, PaperTiger.stripity_stripe_config(port: 4001)
+
+# Discover which port was selected
+iex> PaperTiger.get_port()
+59342
 ```
 
 ## Concurrent Test Support

--- a/lib/paper_tiger/test.ex
+++ b/lib/paper_tiger/test.ex
@@ -81,7 +81,7 @@ defmodule PaperTiger.Test do
   """
   @spec base_url(String.t()) :: String.t()
   def base_url(path \\ "") do
-    port = Application.get_env(:paper_tiger, :port, 4001)
+    port = Application.get_env(:paper_tiger, :actual_port) || 59_000
     "http://localhost:#{port}#{path}"
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PaperTiger.MixProject do
   @moduledoc false
   use Mix.Project
 
-  @version "0.9.22"
+  @version "0.9.23"
   @url "https://github.com/EnaiaInc/paper_tiger"
   @maintainers ["Enaia Inc"]
 


### PR DESCRIPTION
Eliminates port conflicts by using random available ports by default.

## Changes

**BREAKING CHANGE:** Default port changed from 4001 to random port in 59000-60000 range

- ✅ Random port selection with availability checking (retries up to 10 times)
- ✅ New `PaperTiger.get_port/0` function to discover selected port
- ✅ `stripity_stripe_config()` auto-detects port from running server
- ✅ Port range: 59000-60000 (higher than common dev tools)
- ✅ Manual override via `PAPER_TIGER_PORT` env var or `port:` option

## Benefits

Eliminates port conflicts when running:
- Tests + dev server simultaneously
- Multiple test suites in parallel
- Multiple PaperTiger instances

## Migration

Most users won't need changes - port auto-detection handles it.

If you hardcoded `port: 4001`, either:
- Remove it (use auto-detection)
- Or set `PAPER_TIGER_PORT=4001` if you need the old behavior

## Testing

- ✅ All 534 tests pass
- ✅ Port availability checking works
- ✅ Auto-detection in `stripity_stripe_config()` works

Closes ENA-8080