### PR TITLE
v0.9.23 - Fix random port with runtime config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.23] - 2026-01-30
+
+### Fixed
+
+- **Random port with runtime config**: Port selection is now deterministic even when called from `config/runtime.exs` before PaperTiger starts. The new `PaperTiger.Port` resolver caches the selected port on first call, ensuring both config evaluation and server startup use the same port. This eliminates connection refused errors when using `stripity_stripe_config()` without explicit port. Works with any HTTP client - not tied to stripity_stripe.
+
 ## [0.9.22] - 2026-01-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Add `paper_tiger` to your dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:paper_tiger, "~> 0.9.22"}
+    {:paper_tiger, "~> 0.9.23"}
   ]
 end
 ```
@@ -322,7 +322,7 @@ PaperTiger automatically picks a random available port in the 59000-60000 range 
 **Port selection:**
 
 - **Random by default** - Picks available port, retries if conflict detected
-- **Auto-discovery** - `stripity_stripe_config()` auto-detects the running port
+- **Early resolution** - `stripity_stripe_config()` and `PaperTiger.get_port()` resolve and cache the port before startup
 - **Manual override** - Set explicit port via env var or config
 
 If you need a specific port:

--- a/lib/paper_tiger/application.ex
+++ b/lib/paper_tiger/application.ex
@@ -120,7 +120,7 @@ defmodule PaperTiger.Application do
   end
 
   defp maybe_add_http_server(children) do
-    port = get_port()
+    port = PaperTiger.Port.resolve()
 
     # Store the actual port for PaperTiger.get_port/0
     Application.put_env(:paper_tiger, :actual_port, port)
@@ -178,55 +178,6 @@ defmodule PaperTiger.Application do
   defp mix_task_running? do
     # Mix.TasksServer only exists during mix tasks, not in releases
     Process.whereis(Mix.TasksServer) != nil
-  end
-
-  # Get port from env var or config, with random fallback to avoid conflicts
-  # Precedence: PAPER_TIGER_PORT > config > random high port (checked for availability)
-  defp get_port do
-    case System.get_env("PAPER_TIGER_PORT") do
-      nil ->
-        case Application.get_env(:paper_tiger, :port) do
-          nil -> find_available_port()
-          port -> port
-        end
-
-      port_string ->
-        String.to_integer(port_string)
-    end
-  end
-
-  # Find an available port in the high range, trying multiple times if needed
-  defp find_available_port(attempts \\ 10) do
-    port = random_high_port()
-
-    if port_available?(port) do
-      port
-    else
-      if attempts > 1 do
-        find_available_port(attempts - 1)
-      else
-        # Fallback to letting the OS fail with EADDRINUSE
-        port
-      end
-    end
-  end
-
-  # Pick a random port in range 59000-60000 to avoid conflicts with common dev tools
-  # Higher range than 51000-52000 to avoid tools like webpack dev servers
-  defp random_high_port do
-    59_000 + :rand.uniform(1000)
-  end
-
-  # Check if a port is available by attempting to bind to it
-  defp port_available?(port) do
-    case :gen_tcp.listen(port, [:binary, active: false, reuseaddr: true]) do
-      {:ok, socket} ->
-        :gen_tcp.close(socket)
-        true
-
-      {:error, _} ->
-        false
-    end
   end
 
   defp maybe_add_workers(children) do

--- a/lib/paper_tiger/port.ex
+++ b/lib/paper_tiger/port.ex
@@ -1,0 +1,64 @@
+defmodule PaperTiger.Port do
+  @moduledoc false
+
+  @min_port 59_000
+  @max_port 60_000
+  @attempts 10
+
+  @spec resolve() :: integer()
+  def resolve do
+    case Application.get_env(:paper_tiger, :actual_port) do
+      nil -> resolve_unstarted()
+      port -> port
+    end
+  end
+
+  defp resolve_unstarted do
+    case System.get_env("PAPER_TIGER_PORT") do
+      nil ->
+        case Application.get_env(:paper_tiger, :port) do
+          nil ->
+            port = find_available_port(@attempts)
+            Application.put_env(:paper_tiger, :port, port)
+            port
+
+          port ->
+            port
+        end
+
+      port_string ->
+        port = String.to_integer(port_string)
+        Application.put_env(:paper_tiger, :port, port)
+        port
+    end
+  end
+
+  defp find_available_port(attempts) when attempts > 1 do
+    port = random_high_port()
+
+    if port_available?(port) do
+      port
+    else
+      find_available_port(attempts - 1)
+    end
+  end
+
+  defp find_available_port(_attempts) do
+    random_high_port()
+  end
+
+  defp random_high_port do
+    @min_port + :rand.uniform(@max_port - @min_port)
+  end
+
+  defp port_available?(port) do
+    case :gen_tcp.listen(port, [:binary, active: false, reuseaddr: true]) do
+      {:ok, socket} ->
+        :gen_tcp.close(socket)
+        true
+
+      {:error, _} ->
+        false
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PaperTiger.MixProject do
   @moduledoc false
   use Mix.Project
 
-  @version "0.9.22"
+  @version "0.9.23"
   @url "https://github.com/EnaiaInc/paper_tiger"
   @maintainers ["Enaia Inc"]
 

--- a/test/paper_tiger/port_test.exs
+++ b/test/paper_tiger/port_test.exs
@@ -1,0 +1,45 @@
+defmodule PaperTiger.PortTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    env_port = System.get_env("PAPER_TIGER_PORT")
+    config_port = Application.get_env(:paper_tiger, :port)
+    actual_port = Application.get_env(:paper_tiger, :actual_port)
+
+    on_exit(fn ->
+      if is_nil(env_port) do
+        System.delete_env("PAPER_TIGER_PORT")
+      else
+        System.put_env("PAPER_TIGER_PORT", env_port)
+      end
+
+      if is_nil(config_port) do
+        Application.delete_env(:paper_tiger, :port)
+      else
+        Application.put_env(:paper_tiger, :port, config_port)
+      end
+
+      if is_nil(actual_port) do
+        Application.delete_env(:paper_tiger, :actual_port)
+      else
+        Application.put_env(:paper_tiger, :actual_port, actual_port)
+      end
+    end)
+
+    :ok
+  end
+
+  test "get_port resolves and caches before startup" do
+    System.delete_env("PAPER_TIGER_PORT")
+    Application.delete_env(:paper_tiger, :port)
+    Application.delete_env(:paper_tiger, :actual_port)
+
+    port = PaperTiger.get_port()
+
+    assert is_integer(port)
+    assert port >= 59_000
+    assert port <= 60_000
+    assert Application.get_env(:paper_tiger, :port) == port
+    assert PaperTiger.get_port() == port
+  end
+end


### PR DESCRIPTION
## Summary

Port selection is now deterministic even when called from `config/runtime.exs` before PaperTiger starts. This eliminates connection refused errors when using random ports.

## Problem

Applications configure their Stripe client in `runtime.exs` which is evaluated before PaperTiger starts:
- Config calls `stripity_stripe_config()` → needs port
- But PaperTiger hasn't started yet → no port selected
- Result: connection refused errors

## Solution

New `PaperTiger.Port` resolver caches the selected port on first call:
1. `runtime.exs` calls `stripity_stripe_config()` → calls `Port.resolve()` → picks random port and caches it
2. PaperTiger starts → calls `Port.resolve()` → returns cached port
3. Both use the same port!

## Changes

- New `PaperTiger.Port` module for centralized port resolution  
- Application startup uses `Port.resolve()`
- `PaperTiger.get_port()` uses `Port.resolve()`
- `stripity_stripe_config()` uses `Port.resolve()` 
- Port cached in Application env on first call
- Added test coverage

## Client-Agnostic

Works with ANY HTTP client (stripity_stripe, req, httpoison, etc.) - not tied to any specific library. Any client can call `PaperTiger.get_port()` in config.

## Testing

- All 535 PaperTiger tests pass
- Tested with Enaia using `stripity_stripe_config()` without explicit port
- Port resolution is deterministic and consistent