### PR TITLE
Add invoice upcoming/preview endpoints + tests, Nix dev env, and fix Elixir 1.19 deprecation

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ paper_tiger-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+
+.direnv/
+.nix-hex/
+.nix-mix/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1770562336,
+        "narHash": "sha256-ub1gpAONMFsT/GU2hV6ZWJjur8rJ6kKxdm9IlCT0j84=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d6c71932130818840fc8fe9509cf50be8c64634f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "PaperTiger development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            elixir_1_19
+            erlang_28
+            rebar3
+
+            # For file watching
+            inotify-tools
+          ];
+
+          shellHook = ''
+            export MIX_HOME=$PWD/.nix-mix
+            export HEX_HOME=$PWD/.nix-hex
+            export PATH=$MIX_HOME/bin:$HEX_HOME/bin:$PATH
+            export ERL_AFLAGS="-kernel shell_history enabled"
+          '';
+        };
+      }
+    );
+}

--- a/lib/paper_tiger/plugs/get_form_body.ex
+++ b/lib/paper_tiger/plugs/get_form_body.ex
@@ -1,0 +1,31 @@
+defmodule PaperTiger.Plugs.GetFormBody do
+  @moduledoc """
+  Parses form-encoded body params for GET requests.
+
+  Plug.Parsers only parses request bodies for POST/PUT/PATCH/DELETE.
+  Some HTTP clients (e.g. Stripe SDK wrappers using Req with `form:` option)
+  send form-encoded params in the body even for GET requests. This plug reads
+  the body and sets `body_params` so that Plug.Parsers merges them with
+  query params correctly.
+  """
+
+  @behaviour Plug
+
+  alias Plug.Conn.Query
+  alias Plug.Conn.Unfetched
+
+  def init(opts), do: opts
+
+  def call(%{body_params: %Unfetched{}, method: "GET"} = conn, _opts) do
+    case Plug.Conn.get_req_header(conn, "content-type") do
+      ["application/x-www-form-urlencoded" <> _] ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        %{conn | body_params: Query.decode(body)}
+
+      _ ->
+        conn
+    end
+  end
+
+  def call(conn, _opts), do: conn
+end

--- a/lib/paper_tiger/router.ex
+++ b/lib/paper_tiger/router.ex
@@ -50,6 +50,7 @@ defmodule PaperTiger.Router do
   alias PaperTiger.Plug.APIChaos
   alias PaperTiger.Plugs.Auth
   alias PaperTiger.Plugs.CORS
+  alias PaperTiger.Plugs.GetFormBody
   alias PaperTiger.Plugs.Idempotency
   alias PaperTiger.Plugs.Sandbox
   alias PaperTiger.Plugs.UnflattenParams
@@ -88,6 +89,7 @@ defmodule PaperTiger.Router do
   plug(CORS)
   plug(Sandbox)
   plug(APIChaos)
+  plug(GetFormBody)
 
   plug(Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
@@ -193,6 +195,16 @@ defmodule PaperTiger.Router do
   stripe_resource("subscriptions", Subscription, [])
   stripe_resource("products", Product, [])
   stripe_resource("prices", Price, except: [:delete])
+  # Custom invoice endpoints — must come BEFORE stripe_resource so they
+  # match before the generic GET /v1/invoices/:id route.
+  get "/v1/invoices/upcoming" do
+    Invoice.upcoming(conn)
+  end
+
+  post "/v1/invoices/create_preview" do
+    Invoice.create_preview(conn)
+  end
+
   stripe_resource("invoices", Invoice, [])
   stripe_resource("payment_methods", PaymentMethod, [])
   stripe_resource("payment_intents", PaymentIntent, except: [:delete])

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,7 @@ defmodule PaperTiger.MixProject do
       name: "PaperTiger",
       app: :paper_tiger,
       version: @version,
-      elixir: "~> 1.16 or ~> 1.17 or ~> 1.18",
+      elixir: "~> 1.16 or ~> 1.17 or ~> 1.18 or ~> 1.19",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env()),
@@ -32,8 +32,13 @@ defmodule PaperTiger.MixProject do
       ],
 
       # Test coverage
-      test_coverage: [tool: ExCoveralls],
-      preferred_cli_env: [
+      test_coverage: [tool: ExCoveralls]
+    ]
+  end
+
+  def cli do
+    [
+      preferred_envs: [
         coveralls: :test,
         "coveralls.detail": :test,
         "coveralls.html": :test


### PR DESCRIPTION
## Summary
  - Add `GET /v1/invoices/upcoming` and `POST /v1/invoices/create_preview` endpoints for previewing subscription invoices
  - Add `GetFormBody` plug to handle form-encoded body params on GET requests (needed by some Stripe SDK wrappers)
  - Add Nix flake dev environment (Elixir 1.19 + Erlang 28)
  - Fix Elixir 1.19 deprecation: move `preferred_cli_env` to new `cli/0` callback
  - Support Elixir 1.19 in version constraint

  ## Test plan
  - [ ] Verify `GET /v1/invoices/upcoming?subscription=sub_xxx` returns correct line items and totals
  - [ ] Verify `POST /v1/invoices/create_preview` computes totals for proposed item changes
  - [ ] Verify 404/error responses for missing or invalid subscriptions
  - [ ] Confirm `mix format` runs without deprecation warnings
  - [ ] Confirm `nix develop` provides working Elixir/Erlang environment