### PR TITLE
Add PaymentIntent -> Charge -> BalanceTransaction chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-02-28
+
+### Added
+
+- PaymentIntent confirm endpoint (`POST /v1/payment_intents/:id/confirm`) with full Charge and BalanceTransaction creation on success.
+- `ChargeHelper` module centralizing Charge + BalanceTransaction creation from succeeded PaymentIntents, used by checkout session completion, BillingEngine, and the new confirm endpoint.
+- `latest_charge` field on PaymentIntent objects, populated after successful payment.
+- Contract test validating full PaymentIntent -> Charge -> BalanceTransaction chain against real Stripe API.
+
+### Fixed
+
+- Checkout session completion now creates Charge and BalanceTransaction (previously only created the PaymentIntent).
+- Currency derivation from `line_items[].price_data.currency` when not explicitly set on checkout session.
+
 ## [1.0.1] - 2026-02-27
 
 ### Fixed

--- a/lib/paper_tiger/billing_engine.ex
+++ b/lib/paper_tiger/billing_engine.ex
@@ -368,6 +368,7 @@ defmodule PaperTiger.BillingEngine do
       customer: invoice.customer,
       id: PaperTiger.Resource.generate_id("pi"),
       invoice: invoice.id,
+      latest_charge: nil,
       livemode: false,
       metadata: %{},
       object: "payment_intent",
@@ -378,25 +379,8 @@ defmodule PaperTiger.BillingEngine do
     :telemetry.execute([:paper_tiger, :payment_intent, :created], %{}, %{object: pi})
     :telemetry.execute([:paper_tiger, :payment_intent, :succeeded], %{}, %{object: pi})
 
-    # Create charge
-    charge = %{
-      amount: amount,
-      captured: true,
-      created: now,
-      currency: invoice.currency,
-      customer: invoice.customer,
-      id: PaperTiger.Resource.generate_id("ch"),
-      invoice: invoice.id,
-      livemode: false,
-      metadata: %{},
-      object: "charge",
-      paid: true,
-      payment_intent: pi.id,
-      status: "succeeded"
-    }
-
-    {:ok, ch} = Charges.insert(charge)
-    :telemetry.execute([:paper_tiger, :charge, :succeeded], %{}, %{object: ch})
+    # Create charge via ChargeHelper (also creates balance transaction + updates PI.latest_charge)
+    {:ok, _ch} = PaperTiger.ChargeHelper.create_for_payment_intent(pi)
 
     # Update invoice to paid
     paid_invoice =
@@ -431,6 +415,7 @@ defmodule PaperTiger.BillingEngine do
         message: decline_code_message(decline_code),
         type: "card_error"
       },
+      latest_charge: nil,
       livemode: false,
       metadata: %{},
       object: "payment_intent",

--- a/lib/paper_tiger/charge_helper.ex
+++ b/lib/paper_tiger/charge_helper.ex
@@ -1,0 +1,81 @@
+defmodule PaperTiger.ChargeHelper do
+  @moduledoc """
+  Creates Charge objects from PaymentIntents.
+
+  Handles the PI -> Charge -> BalanceTransaction chain that Stripe performs
+  when a PaymentIntent succeeds. This is used by checkout session completion
+  and the billing engine to produce the same object graph that real Stripe does.
+  """
+
+  import PaperTiger.Resource, only: [generate_id: 1]
+
+  alias PaperTiger.BalanceTransactionHelper
+  alias PaperTiger.Store.{Charges, PaymentIntents}
+
+  @doc """
+  Creates a Charge (and its BalanceTransaction) for a succeeded PaymentIntent.
+
+  1. Builds a charge map from the PI fields
+  2. Inserts into the Charges store
+  3. Creates a BalanceTransaction via BalanceTransactionHelper
+  4. Updates the charge with the balance_transaction ID
+  5. Updates the PI with `latest_charge`
+  6. Fires telemetry
+  7. Returns `{:ok, charge}`
+  """
+  @spec create_for_payment_intent(map()) :: {:ok, map()}
+  def create_for_payment_intent(payment_intent) do
+    charge = build_charge(payment_intent)
+    {:ok, charge} = Charges.insert(charge)
+
+    # Create balance transaction and link it to the charge
+    {:ok, txn_id} = BalanceTransactionHelper.create_for_charge(charge)
+    charge = Map.put(charge, :balance_transaction, txn_id)
+    {:ok, charge} = Charges.update(charge)
+
+    # Update the PI with latest_charge
+    updated_pi = Map.put(payment_intent, :latest_charge, charge.id)
+    PaymentIntents.update(updated_pi)
+
+    :telemetry.execute([:paper_tiger, :charge, :succeeded], %{}, %{object: charge})
+
+    {:ok, charge}
+  end
+
+  defp build_charge(pi) do
+    %{
+      amount: Map.get(pi, :amount, 0),
+      amount_refunded: 0,
+      balance_transaction: nil,
+      billing_details: nil,
+      captured: true,
+      created: PaperTiger.now(),
+      currency: Map.get(pi, :currency),
+      customer: Map.get(pi, :customer),
+      description: Map.get(pi, :description),
+      failure_code: nil,
+      failure_message: nil,
+      fraud_details: nil,
+      id: generate_id("ch"),
+      invoice: Map.get(pi, :invoice),
+      livemode: false,
+      metadata: Map.get(pi, :metadata, %{}),
+      object: "charge",
+      outcome: %{
+        network_status: "approved_by_network",
+        reason: nil,
+        risk_level: "normal",
+        type: "authorized"
+      },
+      paid: true,
+      payment_intent: Map.get(pi, :id),
+      payment_method: Map.get(pi, :payment_method),
+      receipt_email: Map.get(pi, :receipt_email),
+      receipt_number: nil,
+      receipt_url: nil,
+      refunded: false,
+      statement_descriptor: Map.get(pi, :statement_descriptor),
+      status: "succeeded"
+    }
+  end
+end

--- a/lib/paper_tiger/resources/checkout_session.ex
+++ b/lib/paper_tiger/resources/checkout_session.ex
@@ -492,6 +492,7 @@ defmodule PaperTiger.Resources.CheckoutSession do
       id: generate_id("pi"),
       invoice: nil,
       last_payment_error: nil,
+      latest_charge: nil,
       livemode: false,
       mandate: nil,
       metadata: session.metadata || %{},
@@ -511,6 +512,12 @@ defmodule PaperTiger.Resources.CheckoutSession do
     }
 
     {:ok, payment_intent} = PaymentIntents.insert(payment_intent)
+
+    # Create charge + balance transaction chain
+    {:ok, _charge} = PaperTiger.ChargeHelper.create_for_payment_intent(payment_intent)
+    # Re-fetch to get updated latest_charge
+    {:ok, payment_intent} = PaymentIntents.get(payment_intent.id)
+
     payment_intent
   end
 
@@ -722,7 +729,9 @@ defmodule PaperTiger.Resources.CheckoutSession do
       billing_address_collection: Map.get(params, :billing_address_collection),
       shipping_address_collection: Map.get(params, :shipping_address_collection),
       consent_collection: Map.get(params, :consent_collection),
-      currency: Map.get(params, :currency),
+      currency:
+        Map.get(params, :currency) ||
+          derive_currency_from_line_items(Map.get(params, :line_items, [])),
       customer_creation: Map.get(params, :customer_creation),
       expires_at: PaperTiger.now() + 86_400,
       locale: Map.get(params, :locale),
@@ -754,4 +763,25 @@ defmodule PaperTiger.Resources.CheckoutSession do
     expand_params = parse_expand_params(params)
     PaperTiger.Hydrator.hydrate(session, expand_params)
   end
+
+  defp derive_currency_from_line_items(line_items) when is_list(line_items) do
+    Enum.find_value(line_items, fn item ->
+      get_in_flexible(item, [:price_data, :currency])
+    end)
+  end
+
+  defp derive_currency_from_line_items(_), do: nil
+
+  defp get_in_flexible(nil, _), do: nil
+
+  defp get_in_flexible(map, [key | rest]) when is_map(map) do
+    value = Map.get(map, key) || Map.get(map, to_string(key))
+
+    case rest do
+      [] -> value
+      _ -> get_in_flexible(value, rest)
+    end
+  end
+
+  defp get_in_flexible(_, _), do: nil
 end

--- a/lib/paper_tiger/resources/payment_intent.ex
+++ b/lib/paper_tiger/resources/payment_intent.ex
@@ -137,7 +137,57 @@ defmodule PaperTiger.Resources.PaymentIntent do
     json_response(conn, 200, result)
   end
 
+  @doc """
+  Confirms a payment intent, transitioning it to "succeeded" and creating
+  a charge + balance transaction.
+  """
+  @spec confirm(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def confirm(conn, id) do
+    with {:ok, pi} <- PaymentIntents.get(id),
+         :ok <- validate_confirmable(pi) do
+      # Apply payment_method from confirm params if provided
+      updated =
+        case conn.params do
+          %{payment_method: pm} when is_binary(pm) -> %{pi | payment_method: pm}
+          _ -> pi
+        end
+
+      # Transition to succeeded
+      updated = %{updated | status: "succeeded"}
+      {:ok, updated} = PaymentIntents.update(updated)
+
+      # Create charge + balance transaction
+      {:ok, _charge} = PaperTiger.ChargeHelper.create_for_payment_intent(updated)
+
+      # Re-fetch to get latest_charge
+      {:ok, final} = PaymentIntents.get(id)
+
+      :telemetry.execute([:paper_tiger, :payment_intent, :succeeded], %{}, %{object: final})
+
+      final
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("payment_intent", id))
+
+      {:error, :not_confirmable, status} ->
+        error_response(
+          conn,
+          PaperTiger.Error.invalid_request(
+            "This PaymentIntent's status (#{status}) does not allow confirmation.",
+            "status"
+          )
+        )
+    end
+  end
+
   ## Private Functions
+
+  defp validate_confirmable(%{status: status}) when status in ["requires_payment_method", "requires_confirmation"],
+    do: :ok
+
+  defp validate_confirmable(%{status: status}), do: {:error, :not_confirmable, status}
 
   defp build_payment_intent(params) do
     %{
@@ -171,6 +221,7 @@ defmodule PaperTiger.Resources.PaymentIntent do
       application: nil,
       application_fee_amount: nil,
       invoice: nil,
+      latest_charge: nil,
       mandate: nil,
       source: Map.get(params, :source)
     }

--- a/lib/paper_tiger/router.ex
+++ b/lib/paper_tiger/router.ex
@@ -207,6 +207,11 @@ defmodule PaperTiger.Router do
 
   stripe_resource("invoices", Invoice, [])
   stripe_resource("payment_methods", PaymentMethod, [])
+  # Custom payment intent endpoint — must come BEFORE stripe_resource
+  post "/v1/payment_intents/:id/confirm" do
+    PaymentIntent.confirm(conn, id)
+  end
+
   stripe_resource("payment_intents", PaymentIntent, except: [:delete])
   stripe_resource("setup_intents", SetupIntent, except: [:delete])
   stripe_resource("charges", Charge, except: [:delete])

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PaperTiger.MixProject do
   @moduledoc false
   use Mix.Project
 
-  @version "1.0.1"
+  @version "1.0.2"
   @url "https://github.com/EnaiaInc/paper_tiger"
   @maintainers ["Enaia Inc"]
 

--- a/test/paper_tiger/charge_helper_test.exs
+++ b/test/paper_tiger/charge_helper_test.exs
@@ -1,0 +1,108 @@
+defmodule PaperTiger.ChargeHelperTest do
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
+
+  alias PaperTiger.ChargeHelper
+  alias PaperTiger.Store.{BalanceTransactions, Charges, PaymentIntents}
+
+  setup :checkout_paper_tiger
+
+  defp build_payment_intent(overrides \\ %{}) do
+    Map.merge(
+      %{
+        amount: 2000,
+        amount_details: nil,
+        application: nil,
+        application_fee_amount: nil,
+        cancellation_reason: nil,
+        capture_method: "automatic",
+        client_secret: "pi_secret_test",
+        confirmation_method: "automatic",
+        created: PaperTiger.now(),
+        currency: "usd",
+        customer: "cus_test123",
+        description: nil,
+        id: PaperTiger.Resource.generate_id("pi"),
+        invoice: nil,
+        last_payment_error: nil,
+        latest_charge: nil,
+        livemode: false,
+        mandate: nil,
+        metadata: %{},
+        next_action: nil,
+        object: "payment_intent",
+        off_session: nil,
+        on_behalf_of: nil,
+        payment_method: "pm_test456",
+        processing: nil,
+        receipt_email: nil,
+        review: nil,
+        setup_future_usage: nil,
+        shipping: nil,
+        source: nil,
+        statement_descriptor: nil,
+        status: "succeeded"
+      },
+      overrides
+    )
+  end
+
+  describe "create_for_payment_intent/1" do
+    test "creates charge and balance transaction for succeeded PI" do
+      pi = build_payment_intent()
+      {:ok, pi} = PaymentIntents.insert(pi)
+
+      {:ok, charge} = ChargeHelper.create_for_payment_intent(pi)
+
+      # Charge has correct fields from PI
+      assert String.starts_with?(charge.id, "ch_")
+      assert charge.object == "charge"
+      assert charge.amount == 2000
+      assert charge.currency == "usd"
+      assert charge.customer == "cus_test123"
+      assert charge.payment_method == "pm_test456"
+      assert charge.status == "succeeded"
+      assert charge.paid == true
+      assert charge.captured == true
+      assert charge.refunded == false
+      assert charge.amount_refunded == 0
+      assert charge.livemode == false
+      assert charge.metadata == %{}
+      assert is_integer(charge.created)
+
+      # Balance transaction was created and linked
+      assert charge.balance_transaction != nil
+      assert String.starts_with?(charge.balance_transaction, "txn_")
+
+      {:ok, txn} = BalanceTransactions.get(charge.balance_transaction)
+      assert txn.amount == 2000
+      assert txn.source == charge.id
+      assert txn.type == "charge"
+
+      # Charge is persisted in the store
+      {:ok, stored_charge} = Charges.get(charge.id)
+      assert stored_charge.id == charge.id
+      assert stored_charge.balance_transaction == charge.balance_transaction
+    end
+
+    test "updates PaymentIntent with latest_charge" do
+      pi = build_payment_intent()
+      {:ok, pi} = PaymentIntents.insert(pi)
+
+      {:ok, charge} = ChargeHelper.create_for_payment_intent(pi)
+
+      {:ok, updated_pi} = PaymentIntents.get(pi.id)
+      assert updated_pi.latest_charge == charge.id
+    end
+
+    test "charge inherits invoice field from PI when present" do
+      pi = build_payment_intent(%{invoice: "in_test789"})
+      {:ok, pi} = PaymentIntents.insert(pi)
+
+      {:ok, charge} = ChargeHelper.create_for_payment_intent(pi)
+
+      assert charge.invoice == "in_test789"
+    end
+  end
+end

--- a/test/paper_tiger/contract/payment_intent_chain_test.exs
+++ b/test/paper_tiger/contract/payment_intent_chain_test.exs
@@ -1,0 +1,90 @@
+defmodule PaperTiger.Contract.PaymentIntentChainTest do
+  @moduledoc """
+  Contract test: verifies PaymentIntent -> Charge -> BalanceTransaction chain
+  works identically against PaperTiger and real Stripe.
+
+  Run against PaperTiger (default):
+      mix test test/paper_tiger/contract/payment_intent_chain_test.exs
+
+  Run against real Stripe:
+      VALIDATE_AGAINST_STRIPE=true STRIPE_API_KEY=sk_test_xxx mix test test/paper_tiger/contract/payment_intent_chain_test.exs
+  """
+
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
+
+  alias PaperTiger.TestClient
+
+  setup do
+    if !TestClient.real_stripe?() do
+      checkout_paper_tiger(%{})
+    end
+
+    :ok
+  end
+
+  describe "PaymentIntent confirm creates full chain" do
+    test "confirm produces Charge with BalanceTransaction" do
+      # Create customer
+      {:ok, customer} = TestClient.create_customer(%{"email" => "chain-test@example.com"})
+
+      # Create PI with payment method
+      # Real Stripe: use pm_card_visa token (avoids raw card number restrictions)
+      # PaperTiger: create a PM and attach it
+      {pm_id, pi_params} =
+        if TestClient.real_stripe?() do
+          {"pm_card_visa",
+           %{
+             "amount" => 2500,
+             "currency" => "usd",
+             "customer" => customer["id"],
+             "payment_method" => "pm_card_visa",
+             "payment_method_types" => ["card"]
+           }}
+        else
+          {:ok, pm} =
+            TestClient.create_payment_method(%{
+              "card" => TestClient.test_card_simple(),
+              "type" => "card"
+            })
+
+          {:ok, _} =
+            TestClient.attach_payment_method(pm["id"], %{"customer" => customer["id"]})
+
+          {pm["id"],
+           %{
+             "amount" => 2500,
+             "currency" => "usd",
+             "customer" => customer["id"],
+             "payment_method" => pm["id"]
+           }}
+        end
+
+      {:ok, pi} = TestClient.create_payment_intent(pi_params)
+
+      assert pi["status"] in ["requires_confirmation", "requires_payment_method"]
+
+      # Confirm PI
+      {:ok, confirmed} =
+        TestClient.confirm_payment_intent(pi["id"], %{"payment_method" => pm_id})
+
+      assert confirmed["status"] == "succeeded"
+      assert confirmed["latest_charge"] != nil
+
+      # Retrieve charge
+      {:ok, charge} = TestClient.get_charge(confirmed["latest_charge"])
+      assert charge["amount"] == 2500
+      assert charge["currency"] == "usd"
+      assert charge["status"] == "succeeded"
+      assert charge["payment_intent"] == pi["id"]
+      assert charge["balance_transaction"] != nil
+
+      # Retrieve balance transaction
+      {:ok, bt} = TestClient.get_balance_transaction(charge["balance_transaction"])
+      assert bt["amount"] == 2500
+      assert bt["type"] == "charge"
+      assert bt["source"] == charge["id"]
+    end
+  end
+end

--- a/test/paper_tiger/resources/checkout_session_test.exs
+++ b/test/paper_tiger/resources/checkout_session_test.exs
@@ -211,6 +211,28 @@ defmodule PaperTiger.Resources.CheckoutSessionTest do
       pi = json_response(pi_conn)
       assert pi["status"] == "succeeded"
       assert pi["customer"] == customer_id
+
+      # Verify payment intent has latest_charge
+      assert pi["latest_charge"] != nil
+      assert String.starts_with?(pi["latest_charge"], "ch_")
+
+      # Verify charge was created
+      ch_conn = request(:get, "/v1/charges/#{pi["latest_charge"]}")
+      assert ch_conn.status == 200
+      ch = json_response(ch_conn)
+      assert ch["amount"] == 2000
+      assert ch["currency"] == "usd"
+      assert ch["payment_intent"] == pi["id"]
+      assert ch["status"] == "succeeded"
+
+      # Verify balance transaction was created
+      assert ch["balance_transaction"] != nil
+      assert String.starts_with?(ch["balance_transaction"], "txn_")
+      bt_conn = request(:get, "/v1/balance_transactions/#{ch["balance_transaction"]}")
+      assert bt_conn.status == 200
+      bt = json_response(bt_conn)
+      assert bt["amount"] == 2000
+      assert bt["type"] == "charge"
     end
 
     test "completes a subscription mode session and creates subscription" do
@@ -344,6 +366,39 @@ defmodule PaperTiger.Resources.CheckoutSessionTest do
       conn = request(:post, "/_test/checkout/sessions/cs_nonexistent/complete")
 
       assert conn.status == 404
+    end
+
+    test "derives currency from line_items price_data when not explicitly set" do
+      cust_conn = request(:post, "/v1/customers", %{"email" => "currency@example.com"})
+      customer_id = json_response(cust_conn)["id"]
+
+      params = %{
+        "cancel_url" => "https://example.com/cancel",
+        "customer" => customer_id,
+        "line_items" => [
+          %{
+            "price_data" => %{
+              "currency" => "gbp",
+              "product_data" => %{"name" => "Test"},
+              "unit_amount" => 1500
+            },
+            "quantity" => 2
+          }
+        ],
+        "mode" => "payment",
+        "success_url" => "https://example.com/success"
+      }
+
+      create_conn = request(:post, "/v1/checkout/sessions", params)
+      session = json_response(create_conn)
+      assert session["currency"] == "gbp"
+
+      # Complete and verify PI currency
+      complete_conn = request(:post, "/_test/checkout/sessions/#{session["id"]}/complete")
+      completed = json_response(complete_conn)
+      pi_conn = request(:get, "/v1/payment_intents/#{completed["payment_intent"]}")
+      pi = json_response(pi_conn)
+      assert pi["currency"] == "gbp"
     end
   end
 

--- a/test/paper_tiger/resources/payment_intent_confirm_test.exs
+++ b/test/paper_tiger/resources/payment_intent_confirm_test.exs
@@ -1,0 +1,131 @@
+defmodule PaperTiger.Resources.PaymentIntentConfirmTest do
+  @moduledoc """
+  Tests for the POST /v1/payment_intents/:id/confirm endpoint.
+
+  Verifies:
+  1. Confirming a PI transitions it to "succeeded", creates a charge and balance transaction
+  2. Confirming an already-succeeded PI returns 400
+  3. Confirming a non-existent PI returns 404
+  """
+
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
+
+  alias PaperTiger.Router
+
+  setup :checkout_paper_tiger
+
+  defp conn(method, path, params, headers) do
+    conn = Plug.Test.conn(method, path, params)
+
+    headers_with_defaults =
+      headers ++
+        [
+          {"content-type", "application/json"},
+          {"authorization", "Bearer sk_test_pi_confirm_key"}
+        ] ++ sandbox_headers()
+
+    Enum.reduce(headers_with_defaults, conn, fn {key, value}, acc ->
+      Plug.Conn.put_req_header(acc, key, value)
+    end)
+  end
+
+  defp request(method, path, params \\ nil, headers \\ []) do
+    conn = conn(method, path, params, headers)
+    Router.call(conn, [])
+  end
+
+  defp json_response(conn) do
+    Jason.decode!(conn.resp_body)
+  end
+
+  describe "POST /v1/payment_intents/:id/confirm" do
+    test "confirms a PI and creates charge + balance transaction" do
+      # Create customer
+      cust_conn = request(:post, "/v1/customers", %{"email" => "confirm@example.com"})
+      customer_id = json_response(cust_conn)["id"]
+
+      # Create payment method
+      pm_conn = request(:post, "/v1/payment_methods", %{"type" => "card"})
+      pm_id = json_response(pm_conn)["id"]
+
+      # Attach PM to customer
+      request(:post, "/v1/payment_methods/#{pm_id}/attach", %{"customer" => customer_id})
+
+      # Create PI with amount/currency/customer/payment_method
+      pi_conn =
+        request(:post, "/v1/payment_intents", %{
+          "amount" => 5000,
+          "currency" => "usd",
+          "customer" => customer_id,
+          "payment_method" => pm_id
+        })
+
+      assert pi_conn.status == 200
+      pi = json_response(pi_conn)
+      pi_id = pi["id"]
+      assert pi["status"] == "requires_payment_method"
+
+      # Confirm the PI
+      confirm_conn = request(:post, "/v1/payment_intents/#{pi_id}/confirm")
+
+      assert confirm_conn.status == 200
+      confirmed = json_response(confirm_conn)
+      assert confirmed["id"] == pi_id
+      assert confirmed["status"] == "succeeded"
+      assert confirmed["latest_charge"] != nil
+      assert String.starts_with?(confirmed["latest_charge"], "ch_")
+
+      # Verify charge is retrievable with correct fields
+      ch_conn = request(:get, "/v1/charges/#{confirmed["latest_charge"]}")
+      assert ch_conn.status == 200
+      ch = json_response(ch_conn)
+      assert ch["amount"] == 5000
+      assert ch["currency"] == "usd"
+      assert ch["payment_intent"] == pi_id
+      assert ch["status"] == "succeeded"
+      assert ch["customer"] == customer_id
+      assert ch["payment_method"] == pm_id
+
+      # Verify balance transaction exists
+      assert ch["balance_transaction"] != nil
+      assert String.starts_with?(ch["balance_transaction"], "txn_")
+      bt_conn = request(:get, "/v1/balance_transactions/#{ch["balance_transaction"]}")
+      assert bt_conn.status == 200
+      bt = json_response(bt_conn)
+      assert bt["amount"] == 5000
+      assert bt["type"] == "charge"
+    end
+
+    test "returns error when confirming already succeeded PI" do
+      # Create and confirm a PI
+      pi_conn =
+        request(:post, "/v1/payment_intents", %{
+          "amount" => 1000,
+          "currency" => "usd"
+        })
+
+      pi_id = json_response(pi_conn)["id"]
+
+      # First confirm
+      confirm_conn = request(:post, "/v1/payment_intents/#{pi_id}/confirm")
+      assert confirm_conn.status == 200
+
+      # Second confirm should fail
+      retry_conn = request(:post, "/v1/payment_intents/#{pi_id}/confirm")
+      assert retry_conn.status == 400
+      error = json_response(retry_conn)
+      assert error["error"]["type"] == "invalid_request_error"
+      assert error["error"]["message"] =~ "does not allow confirmation"
+    end
+
+    test "returns 404 for non-existent PI" do
+      conn = request(:post, "/v1/payment_intents/pi_nonexistent/confirm")
+
+      assert conn.status == 404
+      error = json_response(conn)
+      assert error["error"]["type"] == "invalid_request_error"
+    end
+  end
+end

--- a/test/support/test_client.ex
+++ b/test/support/test_client.ex
@@ -514,6 +514,21 @@ defmodule PaperTiger.TestClient do
     end
   end
 
+  ## BalanceTransaction Operations
+
+  @doc """
+  Retrieves a balance transaction by ID.
+  """
+  def get_balance_transaction(txn_id) do
+    case mode() do
+      :real_stripe ->
+        get_balance_transaction_real(txn_id)
+
+      :paper_tiger ->
+        get_balance_transaction_mock(txn_id)
+    end
+  end
+
   ## PaymentIntent Operations
 
   @doc """
@@ -539,6 +554,19 @@ defmodule PaperTiger.TestClient do
 
       :paper_tiger ->
         get_payment_intent_mock(payment_intent_id)
+    end
+  end
+
+  @doc """
+  Confirms a payment intent.
+  """
+  def confirm_payment_intent(payment_intent_id, params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        confirm_payment_intent_real(payment_intent_id, params)
+
+      :paper_tiger ->
+        confirm_payment_intent_mock(payment_intent_id, params)
     end
   end
 
@@ -957,6 +985,20 @@ defmodule PaperTiger.TestClient do
     end
   end
 
+  defp confirm_payment_intent_real(payment_intent_id, params) do
+    case Stripe.PaymentIntent.confirm(payment_intent_id, normalize_params(params), stripe_opts()) do
+      {:ok, pi} -> {:ok, stripe_to_map(pi)}
+      {:error, error} -> {:error, stripe_error_to_map(error)}
+    end
+  end
+
+  defp get_balance_transaction_real(txn_id) do
+    case Stripe.BalanceTransaction.retrieve(txn_id, %{}, stripe_opts()) do
+      {:ok, txn} -> {:ok, stripe_to_map(txn)}
+      {:error, error} -> {:error, stripe_error_to_map(error)}
+    end
+  end
+
   defp create_refund_real(params) do
     case Stripe.Refund.create(normalize_params(params), stripe_opts()) do
       {:ok, refund} -> {:ok, stripe_to_map(refund)}
@@ -1141,6 +1183,16 @@ defmodule PaperTiger.TestClient do
 
   defp get_payment_intent_mock(payment_intent_id) do
     conn = request(:get, "/v1/payment_intents/#{payment_intent_id}", %{})
+    handle_response(conn)
+  end
+
+  defp confirm_payment_intent_mock(payment_intent_id, params) do
+    conn = request(:post, "/v1/payment_intents/#{payment_intent_id}/confirm", params)
+    handle_response(conn)
+  end
+
+  defp get_balance_transaction_mock(txn_id) do
+    conn = request(:get, "/v1/balance_transactions/#{txn_id}", %{})
     handle_response(conn)
   end
 


### PR DESCRIPTION
## Summary

- Adds `ChargeHelper.create_for_payment_intent/1` — centralized function that creates a Charge + BalanceTransaction when a PaymentIntent succeeds, and sets `latest_charge` on the PI
- Checkout session completion now produces the full chain (fixes #56)
- BillingEngine refactored to use the same helper
- New `POST /v1/payment_intents/:id/confirm` endpoint
- Session currency derived from `line_items[].price_data.currency` when not explicitly set
- Contract test validated against real Stripe test API

## Test plan

Validated against real Stripe with `VALIDATE_AGAINST_STRIPE=true STRIPE_API_KEY=sk_test_... mix test test/paper_tiger/contract/payment_intent_chain_test.exs`