### PR TITLE
Pluggable webhook delivery adapter + delivering telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Pluggable webhook delivery adapter.** `PaperTiger.WebhookDelivery.Adapter` behaviour with a single `deliver/1` callback taking a `PaperTiger.WebhookDelivery.Request` (the signed payload, full headers, signature header, url, event, webhook) and returning `{:ok, %PaperTiger.WebhookDelivery.Response{}}` (terminal success / ownership taken) or `{:error, reason}` (PaperTiger retries with its existing exponential backoff). Configure with `config :paper_tiger, webhook_delivery_adapter: MyApp.Sink`. Lets a host embedding PaperTiger take durable ownership of webhook delivery via an explicit, enforced contract — a missing or crashing host cannot silently drop webhooks. Default is `PaperTiger.WebhookDelivery.HTTPAdapter`, which performs the HTTP POST exactly as before; **no behavior change when the adapter is not configured.**
+- `[:paper_tiger, :webhook, :delivering]` telemetry event, emitted for every delivery in every adapter immediately before the adapter is invoked. Metadata: `event`, `webhook`, `url`, `payload` (exact signed bytes), `signature_header`, `headers`, `timestamp`. **Observability only** — not the delivery mechanism (that is the adapter behaviour). Use for metrics/tracing.
+
+### Hardened
+
+- Adapter invocation is wrapped: a raising, exiting, throwing, undefined, missing-`deliver/1`, or wrong-shape-returning adapter is normalized into `{:error, reason}` so PaperTiger's own backoff/retry runs and a delivery attempt is recorded — instead of the spawned delivery task crashing before the retry machinery (and, in sync mode, the linked `Task.async` taking down `PaperTiger.WebhookDelivery`). This is what actually enforces the "a missing or crashing host cannot silently drop webhooks" guarantee.
+
+### Notes
+
+- The `:webhook_mode` config (`:sync` / `:async` / `:collect`) is unchanged and continues to control *when* delivery is dispatched. The new adapter controls *where/how* the signed request goes. The two are orthogonal.
+- `deliver_event_sync/2`'s public contract is unchanged (`{:ok, :delivered | :failed} | {:error, term()}`); adapter handoff does not leak a new return value.
+
 ## [1.0.2] - 2026-02-28
 
 ### Added

--- a/lib/paper_tiger/webhook_delivery.ex
+++ b/lib/paper_tiger/webhook_delivery.ex
@@ -19,6 +19,40 @@ defmodule PaperTiger.WebhookDelivery do
   In sync mode, `deliver_event_sync/2` is used which blocks until the webhook
   is delivered (or fails after all retries).
 
+  ## Delivery adapter (host-owned delivery)
+
+  How and where the signed request is sent is a pluggable
+  `PaperTiger.WebhookDelivery.Adapter`:
+
+      config :paper_tiger, webhook_delivery_adapter: MyApp.WebhookSink
+
+  The default is `PaperTiger.WebhookDelivery.HTTPAdapter`, which performs the
+  HTTP POST itself (historical behavior). A host embedding PaperTiger
+  implements the behaviour to take durable ownership of delivery — persist
+  the webhook so it survives restarts, then deliver/retry on its own
+  schedule. The adapter contract (`{:ok, %Response{}}` = terminal success /
+  ownership taken; `{:error, reason}` = PaperTiger retries) is explicit and
+  enforced by a real function return, so a missing or crashing host cannot
+  silently drop webhooks. See `PaperTiger.WebhookDelivery.Adapter`.
+
+  This is separate from `:webhook_mode` (`:sync`/`:async`/`:collect`), which
+  controls *when* delivery is dispatched, not *where* it goes.
+
+  ## Telemetry
+
+  `[:paper_tiger, :webhook, :delivering]` is emitted for **every** delivery,
+  in every adapter, immediately after the payload is signed and the headers
+  are built and immediately before the adapter is called.
+
+  - measurements: `%{system_time: System.system_time()}`
+  - metadata: `%{event: map, webhook: map, url: String.t(), payload: String.t(),
+    headers: [{String.t(), String.t()}], signature_header: String.t(),
+    timestamp: integer()}`
+
+  This event is **observability only** — it is not the delivery mechanism.
+  Delivery handoff is the `Adapter` behaviour. Use this event for metrics and
+  tracing, not for correctness-critical work.
+
   ## Architecture
 
   - **Async delivery**: `deliver_event/2` - Queues a delivery task (default)
@@ -55,12 +89,14 @@ defmodule PaperTiger.WebhookDelivery do
 
   alias PaperTiger.Store.Events
   alias PaperTiger.Store.Webhooks
+  alias PaperTiger.WebhookDelivery.HTTPAdapter
+  alias PaperTiger.WebhookDelivery.Request
+  alias PaperTiger.WebhookDelivery.Response
 
   require Logger
 
   @max_retries 5
   @base_backoff_ms 1000
-  @timeout_ms 30_000
 
   ## Client API
 
@@ -228,20 +264,12 @@ defmodule PaperTiger.WebhookDelivery do
 
   defp deliver_with_retries_sync(event, webhook, attempt) do
     case perform_delivery(event, webhook) do
-      {:ok, status_code, response_body} when status_code >= 200 and status_code < 300 ->
+      {:ok, %Response{} = response} ->
+        # Terminal success: the adapter delivered, or durably accepted
+        # ownership. No retry.
         Logger.info("WebhookDelivery: Event #{event.id} delivered to #{webhook.url} (attempt #{attempt + 1})")
-        update_event_delivery_attempts(event, webhook, attempt, :delivered, response_body)
+        update_event_delivery_attempts(event, webhook, attempt, :delivered, response.body)
         {:ok, :delivered}
-
-      {:ok, status_code, _response_body} ->
-        Logger.warning(
-          "WebhookDelivery: Event #{event.id} rejected by #{webhook.url} with status #{status_code} (attempt #{attempt + 1}/#{@max_retries})"
-        )
-
-        # Wait for backoff, then retry synchronously
-        delay_ms = @base_backoff_ms * Integer.pow(2, attempt)
-        Process.sleep(delay_ms)
-        deliver_with_retries_sync(event, webhook, attempt + 1)
 
       {:error, reason} ->
         Logger.warning(
@@ -265,19 +293,11 @@ defmodule PaperTiger.WebhookDelivery do
 
   defp deliver_with_retries(event, webhook, attempt, _ref) do
     case perform_delivery(event, webhook) do
-      {:ok, status_code, response_body} when status_code >= 200 and status_code < 300 ->
+      {:ok, %Response{} = response} ->
+        # Terminal success: the adapter delivered, or durably accepted
+        # ownership. No retry.
         Logger.info("WebhookDelivery: Event #{event.id} delivered to #{webhook.url} (attempt #{attempt + 1})")
-
-        # Update event with successful delivery
-        update_event_delivery_attempts(event, webhook, attempt, :delivered, response_body)
-
-      {:ok, status_code, _response_body} ->
-        Logger.warning(
-          "WebhookDelivery: Event #{event.id} rejected by #{webhook.url} with status #{status_code} (attempt #{attempt + 1}/#{@max_retries})"
-        )
-
-        # Schedule retry with exponential backoff
-        schedule_retry(event, webhook, attempt)
+        update_event_delivery_attempts(event, webhook, attempt, :delivered, response.body)
 
       {:error, reason} ->
         Logger.warning(
@@ -289,7 +309,10 @@ defmodule PaperTiger.WebhookDelivery do
     end
   end
 
-  # Performs the actual HTTP POST to the webhook endpoint
+  # Signs the payload, emits the observability telemetry event, then hands a
+  # fully-prepared Request to the configured delivery adapter. The adapter's
+  # `{:ok, %Response{}} | {:error, reason}` return is interpreted by the
+  # retry machinery (success is terminal; error retries with backoff).
   defp perform_delivery(event, webhook) do
     timestamp = PaperTiger.Clock.now()
     payload = Jason.encode!(event)
@@ -307,33 +330,90 @@ defmodule PaperTiger.WebhookDelivery do
       {"User-Agent", "Stripe/1.0 (+https://stripe.com/docs/webhooks)"}
     ]
 
-    Logger.debug("WebhookDelivery: Posting event #{event.id} to #{webhook.url} with timestamp #{timestamp}")
+    request = %Request{
+      event: event,
+      headers: headers,
+      payload: payload,
+      signature_header: stripe_signature,
+      timestamp: timestamp,
+      url: webhook.url,
+      webhook: webhook
+    }
 
-    # Use Req library for HTTP POST
-    try do
-      response =
-        Req.post!(
-          webhook.url,
-          body: payload,
-          headers: headers,
-          receive_timeout: @timeout_ms,
-          connect_options: [timeout: @timeout_ms]
-        )
+    # Observability ONLY. This telemetry event is emitted for every delivery
+    # in every adapter, but it is not load-bearing — delivery handoff happens
+    # via the explicit `Adapter` behaviour below, not via whoever may or may
+    # not be attached to this event. Use it for metrics/tracing.
+    :telemetry.execute(
+      [:paper_tiger, :webhook, :delivering],
+      %{system_time: System.system_time()},
+      %{
+        event: event,
+        headers: headers,
+        payload: payload,
+        signature_header: stripe_signature,
+        timestamp: timestamp,
+        url: webhook.url,
+        webhook: webhook
+      }
+    )
 
-      {:ok, response.status, response.body || ""}
-    rescue
-      e in Req.HTTPError ->
-        {:error, {:http_error, inspect(e)}}
+    safe_adapter_deliver(delivery_adapter(), request)
+  end
 
-      e ->
-        {:error, {:unexpected_error, inspect(e)}}
-    catch
-      :exit, {:timeout, _} ->
-        {:error, :timeout}
+  # Invokes the configured adapter and guarantees a normalized
+  # `{:ok, %Response{}} | {:error, reason}` result no matter how badly the
+  # adapter misbehaves. This is what actually enforces the "a missing or
+  # crashing host cannot silently drop webhooks" guarantee: a raising,
+  # exiting, throwing, undefined, or wrong-shape-returning adapter is turned
+  # into an `{:error, reason}` so `deliver_with_retries/{3,4}` apply
+  # PaperTiger's own backoff/retry and record a delivery attempt, instead of
+  # the spawned delivery task crashing before the retry machinery runs (and,
+  # in sync mode, taking the linked `Task.async` / GenServer down with it).
+  defp safe_adapter_deliver(adapter, request) do
+    cond do
+      not is_atom(adapter) ->
+        {:error, {:invalid_adapter, adapter}}
 
-      :exit, reason ->
-        {:error, {:exit, reason}}
+      not Code.ensure_loaded?(adapter) ->
+        {:error, {:adapter_not_loaded, adapter}}
+
+      not function_exported?(adapter, :deliver, 1) ->
+        {:error, {:adapter_missing_deliver, adapter}}
+
+      true ->
+        invoke_adapter(adapter, request)
     end
+  end
+
+  defp invoke_adapter(adapter, request) do
+    case adapter.deliver(request) do
+      {:ok, %Response{}} = ok -> ok
+      {:error, _reason} = err -> err
+      other -> {:error, {:invalid_adapter_response, other}}
+    end
+  rescue
+    e ->
+      {:error, {:adapter_raised, Exception.format(:error, e, __STACKTRACE__)}}
+  catch
+    :throw, value ->
+      {:error, {:adapter_threw, value}}
+
+    :exit, reason ->
+      {:error, {:adapter_exited, reason}}
+  end
+
+  # Resolves the configured webhook delivery adapter. Defaults to the
+  # built-in HTTP adapter (historical behavior). A host embedding PaperTiger
+  # sets `config :paper_tiger, webhook_delivery_adapter: MyApp.WebhookSink`
+  # to take durable ownership of delivery.
+  @spec delivery_adapter() :: module()
+  defp delivery_adapter do
+    Application.get_env(
+      :paper_tiger,
+      :webhook_delivery_adapter,
+      HTTPAdapter
+    )
   end
 
   # Schedules a retry after exponential backoff delay

--- a/lib/paper_tiger/webhook_delivery/adapter.ex
+++ b/lib/paper_tiger/webhook_delivery/adapter.ex
@@ -1,0 +1,45 @@
+defmodule PaperTiger.WebhookDelivery.Adapter do
+  @moduledoc """
+  Behaviour for delivering a signed webhook request.
+
+  PaperTiger signs the payload, builds the `Stripe-Signature` header, emits
+  the `[:paper_tiger, :webhook, :delivering]` telemetry event (observability
+  only), then calls the configured adapter's `deliver/1` with a
+  `PaperTiger.WebhookDelivery.Request`.
+
+  Configure with:
+
+      config :paper_tiger,
+        webhook_delivery_adapter: MyApp.WebhookSink
+
+  The default is `PaperTiger.WebhookDelivery.HTTPAdapter`, which performs the
+  HTTP POST itself (the historical behavior). Override it when embedding
+  PaperTiger inside a system that must own webhook delivery durably (e.g. a
+  hosting layer that persists webhooks so they survive node restarts).
+
+  ## Return contract
+
+  - `{:ok, %PaperTiger.WebhookDelivery.Response{}}` — the adapter has taken
+    terminal ownership of this webhook. Either it delivered successfully, or
+    it durably enqueued it and will deliver/retry itself. PaperTiger records a
+    successful delivery attempt on the event and does **not** apply its own
+    retry. A durable-enqueue adapter should return `%Response{status: 202}`.
+
+  - `{:error, reason}` — the adapter could not take ownership (HTTP non-2xx,
+    transport error, failed to enqueue, ...). PaperTiger applies its own
+    exponential-backoff retry exactly as it does for a failed built-in POST,
+    and records `:failed` after the retry budget is exhausted.
+
+  An adapter must never return `{:ok, ...}` unless it has genuinely accepted
+  responsibility for the webhook. Returning `{:ok, ...}` after a best-effort
+  non-durable attempt is the one way to cause silent webhook loss; that is the
+  adapter's contract to uphold, and the reason delivery is an explicit
+  behaviour rather than a telemetry side effect.
+  """
+
+  alias PaperTiger.WebhookDelivery.Request
+  alias PaperTiger.WebhookDelivery.Response
+
+  @callback deliver(Request.t()) ::
+              {:ok, Response.t()} | {:error, term()}
+end

--- a/lib/paper_tiger/webhook_delivery/http_adapter.ex
+++ b/lib/paper_tiger/webhook_delivery/http_adapter.ex
@@ -1,0 +1,61 @@
+defmodule PaperTiger.WebhookDelivery.HTTPAdapter do
+  @moduledoc """
+  Default `PaperTiger.WebhookDelivery.Adapter` — performs the HTTP POST
+  itself using `Req`. This is the historical PaperTiger behavior and the
+  adapter in effect when `:webhook_delivery_adapter` is not configured.
+
+  - 2xx response → `{:ok, %Response{status: code, body: body}}` (terminal
+    success; PaperTiger records the body on the delivery attempt).
+  - non-2xx response → `{:error, {:http_status, code}}` (PaperTiger retries).
+  - transport error / timeout → `{:error, reason}` (PaperTiger retries).
+  """
+
+  @behaviour PaperTiger.WebhookDelivery.Adapter
+
+  alias PaperTiger.WebhookDelivery.Request
+  alias PaperTiger.WebhookDelivery.Response
+
+  require Logger
+
+  @timeout_ms 30_000
+
+  @impl true
+  def deliver(%Request{} = request) do
+    Logger.debug(
+      "WebhookDelivery.HTTPAdapter: POST event #{request.event.id} to #{request.url} (t=#{request.timestamp})"
+    )
+
+    response =
+      Req.post!(
+        request.url,
+        body: request.payload,
+        headers: request.headers,
+        receive_timeout: @timeout_ms,
+        connect_options: [timeout: @timeout_ms]
+      )
+
+    if response.status >= 200 and response.status < 300 do
+      {:ok, %Response{body: response.body || "", status: response.status}}
+    else
+      # Preserve the operator-facing "rejected with status" detail that the
+      # pre-adapter code logged; the retry layer only sees {:error, reason}.
+      Logger.warning(
+        "WebhookDelivery.HTTPAdapter: event #{request.event.id} rejected by #{request.url} with status #{response.status}"
+      )
+
+      {:error, {:http_status, response.status}}
+    end
+  rescue
+    e in Req.HTTPError ->
+      {:error, {:http_error, inspect(e)}}
+
+    e ->
+      {:error, {:unexpected_error, inspect(e)}}
+  catch
+    :exit, {:timeout, _} ->
+      {:error, :timeout}
+
+    :exit, reason ->
+      {:error, {:exit, reason}}
+  end
+end

--- a/lib/paper_tiger/webhook_delivery/request.ex
+++ b/lib/paper_tiger/webhook_delivery/request.ex
@@ -1,0 +1,38 @@
+defmodule PaperTiger.WebhookDelivery.Request do
+  @moduledoc """
+  A fully-prepared webhook delivery request handed to a
+  `PaperTiger.WebhookDelivery.Adapter`.
+
+  PaperTiger has already JSON-encoded the event, computed the
+  Stripe-compatible HMAC signature, and built the header list. An adapter
+  has everything required to deliver (or durably enqueue) the webhook
+  without re-encoding or re-signing.
+
+  Fields:
+
+  - `:url` — destination URL of the registered webhook endpoint.
+  - `:payload` — the exact JSON byte string that was signed. Send this
+    verbatim; re-encoding the event would invalidate the signature.
+  - `:headers` — the full header list, including `Stripe-Signature`,
+    `Content-Type`, and `User-Agent`.
+  - `:signature_header` — the `t=...,v1=...` value (also present in
+    `:headers`), exposed separately for convenience.
+  - `:timestamp` — the Unix timestamp used in the signed content.
+  - `:event` — the source PaperTiger event map.
+  - `:webhook` — the source webhook-endpoint map (`:id`, `:url`,
+    `:secret`, ...).
+  """
+
+  @enforce_keys [:url, :payload, :headers, :signature_header, :timestamp, :event, :webhook]
+  defstruct [:event, :headers, :payload, :signature_header, :timestamp, :url, :webhook]
+
+  @type t :: %__MODULE__{
+          event: map(),
+          headers: [{String.t(), String.t()}],
+          payload: String.t(),
+          signature_header: String.t(),
+          timestamp: integer(),
+          url: String.t(),
+          webhook: map()
+        }
+end

--- a/lib/paper_tiger/webhook_delivery/response.ex
+++ b/lib/paper_tiger/webhook_delivery/response.ex
@@ -1,0 +1,21 @@
+defmodule PaperTiger.WebhookDelivery.Response do
+  @moduledoc """
+  The successful result of a `PaperTiger.WebhookDelivery.Adapter.deliver/1`
+  call.
+
+  Returned inside `{:ok, %Response{}}` to signal the webhook was either
+  delivered or durably accepted by the adapter. PaperTiger treats any
+  `{:ok, %Response{}}` as terminal success and does not retry.
+
+  - `:status` — for the built-in HTTP adapter, the 2xx status code from the
+    endpoint. A host adapter that durably enqueues should use a synthetic
+    `202` to mean "accepted, will deliver".
+  - `:body` — response body if any (the built-in adapter records this on the
+    event's delivery attempt). Empty string is fine.
+  """
+
+  @enforce_keys [:status]
+  defstruct body: "", status: nil
+
+  @type t :: %__MODULE__{body: String.t(), status: non_neg_integer()}
+end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PaperTiger.MixProject do
   @moduledoc false
   use Mix.Project
 
-  @version "1.0.2"
+  @version "1.1.0"
   @url "https://github.com/EnaiaInc/paper_tiger"
   @maintainers ["Enaia Inc"]
 

--- a/test/paper_tiger/webhook_delivery_test.exs
+++ b/test/paper_tiger/webhook_delivery_test.exs
@@ -1,13 +1,37 @@
 defmodule PaperTiger.WebhookDeliveryTest do
   use ExUnit.Case, async: false
 
+  alias NoSuch.Adapter.Nope
   alias PaperTiger.Store.Events
   alias PaperTiger.Store.Webhooks
+  alias PaperTiger.WebhookDelivery.Request
+  alias PaperTiger.WebhookDelivery.Response
 
   setup do
     # Clear all data between tests
     PaperTiger.flush()
     :ok
+  end
+
+  # Polls `fun` until it returns true or the deadline passes. Used for
+  # asserting on async retry outcomes without a fixed sleep.
+  defp wait_for(fun, timeout \\ 6_000, interval \\ 50) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_wait_for(fun, deadline, interval)
+  end
+
+  defp do_wait_for(fun, deadline, interval) do
+    cond do
+      fun.() ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        flunk("wait_for/1 timed out")
+
+      true ->
+        Process.sleep(interval)
+        do_wait_for(fun, deadline, interval)
+    end
   end
 
   describe "sign_payload/2" do
@@ -110,6 +134,286 @@ defmodule PaperTiger.WebhookDeliveryTest do
 
       assert {:ok, ref} = result
       assert is_reference(ref)
+    end
+  end
+
+  describe "webhook_delivery_adapter (host-owned delivery)" do
+    defmodule CapturingAdapter do
+      @behaviour PaperTiger.WebhookDelivery.Adapter
+
+      @impl true
+      def deliver(request) do
+        pid = :persistent_term.get({__MODULE__, :pid})
+        send(pid, {:adapter_called, request})
+
+        case :persistent_term.get({__MODULE__, :reply}) do
+          :ok ->
+            {:ok, %Response{body: "enqueued", status: 202}}
+
+          :error ->
+            {:error, :sink_unavailable}
+
+          :error_once ->
+            key = {__MODULE__, :calls}
+            n = :persistent_term.get(key, 0)
+            :persistent_term.put(key, n + 1)
+            if n == 0, do: {:error, :sink_unavailable}, else: {:ok, %Response{body: "ok", status: 202}}
+        end
+      end
+    end
+
+    setup do
+      webhook = %{
+        created: PaperTiger.now(),
+        enabled_events: ["charge.succeeded"],
+        id: "we_adapter_1",
+        metadata: %{},
+        object: "webhook_endpoint",
+        secret: "whsec_adapter_secret",
+        status: "enabled",
+        # Unroutable: if the default HTTP adapter were used instead of ours,
+        # the test would see a connection error, not our synthetic 202.
+        url: "http://127.0.0.1:1/never"
+      }
+
+      {:ok, _} = Webhooks.insert(webhook)
+
+      event = %{
+        created: PaperTiger.now(),
+        data: %{object: %{amount: 4242, currency: "usd", id: "ch_a"}},
+        delivery_attempts: [],
+        id: "evt_adapter_1",
+        livemode: false,
+        metadata: %{},
+        object: "event",
+        type: "charge.succeeded"
+      }
+
+      {:ok, _} = Events.insert(event)
+
+      :persistent_term.put({CapturingAdapter, :pid}, self())
+      :persistent_term.put({CapturingAdapter, :reply}, :ok)
+      :persistent_term.erase({CapturingAdapter, :calls})
+      prev = Application.get_env(:paper_tiger, :webhook_delivery_adapter)
+      Application.put_env(:paper_tiger, :webhook_delivery_adapter, CapturingAdapter)
+
+      on_exit(fn ->
+        if prev == nil do
+          Application.delete_env(:paper_tiger, :webhook_delivery_adapter)
+        else
+          Application.put_env(:paper_tiger, :webhook_delivery_adapter, prev)
+        end
+      end)
+
+      {:ok, webhook: webhook, event: event}
+    end
+
+    test "the configured adapter receives a fully-prepared Request and PT does not POST",
+         %{event: event, webhook: webhook} do
+      :persistent_term.put({CapturingAdapter, :reply}, :ok)
+
+      result = PaperTiger.WebhookDelivery.deliver_event_sync(event.id, webhook.id)
+
+      # Adapter accepted ownership → terminal success. No :queued leak in the
+      # public return contract.
+      assert result == {:ok, :delivered}
+
+      assert_receive {:adapter_called, %Request{} = req}, 2_000
+      assert req.url == webhook.url
+      assert req.event.id == event.id
+      assert req.webhook.id == webhook.id
+      # Exact signed bytes + full signature header — adapter delivers without
+      # re-signing.
+      assert req.payload == Jason.encode!(event)
+      assert req.signature_header =~ ~r/^t=\d+,v1=[0-9a-f]{64}$/
+      assert {"Stripe-Signature", req.signature_header} in req.headers
+
+      {:ok, reloaded} = Events.get(event.id)
+
+      assert [%{status: :delivered, webhook_endpoint_id: "we_adapter_1"}] =
+               reloaded.delivery_attempts
+    end
+
+    test "adapter {:error, _} drives the async retry path and recovers (no leaked timers)",
+         %{event: event, webhook: webhook} do
+      # Async dispatch covers the schedule_retry/Process.send_after branch
+      # that deliver_event_sync/2 does not. Fail once then succeed so the
+      # single scheduled retry resolves to a terminal success ~1 backoff
+      # later, leaving no always-failing retry timer to bleed into the rest
+      # of the suite.
+      :persistent_term.put({CapturingAdapter, :reply}, :error_once)
+
+      assert {:ok, ref} = PaperTiger.WebhookDelivery.deliver_event(event.id, webhook.id)
+      assert is_reference(ref)
+
+      # First attempt (error) and the retried attempt (ok) both hit the
+      # adapter.
+      assert_receive {:adapter_called, %Request{}}, 2_000
+      assert_receive {:adapter_called, %Request{}}, 5_000
+
+      # The retried attempt recorded a successful delivery on the event.
+      wait_for(fn ->
+        {:ok, reloaded} = Events.get(event.id)
+        match?([%{status: :delivered} | _], Enum.reverse(reloaded.delivery_attempts))
+      end)
+    end
+
+    test "[:paper_tiger, :webhook, :delivering] still fires (observability), even with a custom adapter",
+         %{event: event, webhook: webhook} do
+      test_pid = self()
+      handler_id = "adapter-telemetry-#{System.unique_integer([:positive])}"
+
+      event_id = event.id
+
+      :telemetry.attach(
+        handler_id,
+        [:paper_tiger, :webhook, :delivering],
+        fn _name, measurements, metadata, _config ->
+          # Filter to THIS test's event so a stale :delivering from any
+          # other in-flight delivery (e.g. an async retry elsewhere in the
+          # suite) cannot satisfy the assertion. A non-matching event is
+          # ignored (not a handler crash → no auto-detach).
+          if metadata.event.id == event_id do
+            send(test_pid, {:webhook_delivering, measurements, metadata})
+          end
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      PaperTiger.WebhookDelivery.deliver_event_sync(event.id, webhook.id)
+
+      assert_receive {:webhook_delivering, measurements, metadata}, 2_000
+      assert is_integer(measurements.system_time)
+      assert metadata.event.id == event.id
+      assert metadata.url == webhook.url
+      assert metadata.payload == Jason.encode!(event)
+    end
+  end
+
+  describe "misbehaving adapter cannot silently drop or crash" do
+    # Each adapter faults on its FIRST call then succeeds on the SECOND.
+    # Driven through deliver_event_sync/2, whose retry path uses Process.sleep
+    # recursion inside its own awaited Task — it does NOT Process.send_after
+    # to the singleton GenServer — so the whole thing is terminal in ~1
+    # backoff (@base_backoff_ms = 1s), deterministic, and leaves no scheduled
+    # retry messages to contaminate later tests. A terminal {:ok, :delivered}
+    # proves the fault was normalized into PaperTiger's retry path (not a
+    # crash / silent drop) and that the WebhookDelivery GenServer survived.
+    defmodule RaisingThenOkAdapter do
+      @behaviour PaperTiger.WebhookDelivery.Adapter
+
+      @impl true
+      def deliver(_request) do
+        key = {__MODULE__, :calls}
+        n = :persistent_term.get(key, 0)
+        :persistent_term.put(key, n + 1)
+        send(:persistent_term.get({__MODULE__, :pid}), {:called, n})
+        if n == 0, do: raise("sink blew up"), else: {:ok, %Response{body: "", status: 202}}
+      end
+    end
+
+    defmodule BadShapeThenOkAdapter do
+      @behaviour PaperTiger.WebhookDelivery.Adapter
+
+      @impl true
+      def deliver(_request) do
+        key = {__MODULE__, :calls}
+        n = :persistent_term.get(key, 0)
+        :persistent_term.put(key, n + 1)
+        send(:persistent_term.get({__MODULE__, :pid}), {:called, n})
+        if n == 0, do: :banana, else: {:ok, %Response{body: "", status: 202}}
+      end
+    end
+
+    setup do
+      webhook = %{
+        created: PaperTiger.now(),
+        enabled_events: ["charge.succeeded"],
+        id: "we_misbehave_1",
+        metadata: %{},
+        object: "webhook_endpoint",
+        secret: "whsec_misbehave",
+        status: "enabled",
+        url: "http://127.0.0.1:1/never"
+      }
+
+      {:ok, _} = Webhooks.insert(webhook)
+
+      event = %{
+        created: PaperTiger.now(),
+        data: %{object: %{amount: 7, currency: "usd", id: "ch_m"}},
+        delivery_attempts: [],
+        id: "evt_misbehave_1",
+        livemode: false,
+        metadata: %{},
+        object: "event",
+        type: "charge.succeeded"
+      }
+
+      {:ok, _} = Events.insert(event)
+
+      prev = Application.get_env(:paper_tiger, :webhook_delivery_adapter)
+      :persistent_term.erase({RaisingThenOkAdapter, :calls})
+      :persistent_term.erase({BadShapeThenOkAdapter, :calls})
+
+      on_exit(fn ->
+        if prev == nil do
+          Application.delete_env(:paper_tiger, :webhook_delivery_adapter)
+        else
+          Application.put_env(:paper_tiger, :webhook_delivery_adapter, prev)
+        end
+      end)
+
+      {:ok, webhook: webhook, event: event}
+    end
+
+    test "a raising adapter is normalized into the retry path, recovers, GenServer survives",
+         %{event: event, webhook: webhook} do
+      :persistent_term.put({RaisingThenOkAdapter, :pid}, self())
+      Application.put_env(:paper_tiger, :webhook_delivery_adapter, RaisingThenOkAdapter)
+      pid_before = Process.whereis(PaperTiger.WebhookDelivery)
+
+      assert {:ok, :delivered} =
+               PaperTiger.WebhookDelivery.deliver_event_sync(event.id, webhook.id)
+
+      assert_received {:called, 0}
+      assert_received {:called, 1}
+      # The raise did not cascade through the linked Task and kill the server.
+      assert Process.whereis(PaperTiger.WebhookDelivery) == pid_before
+    end
+
+    test "an invalid return shape is normalized into the retry path, recovers",
+         %{event: event, webhook: webhook} do
+      :persistent_term.put({BadShapeThenOkAdapter, :pid}, self())
+      Application.put_env(:paper_tiger, :webhook_delivery_adapter, BadShapeThenOkAdapter)
+
+      assert {:ok, :delivered} =
+               PaperTiger.WebhookDelivery.deliver_event_sync(event.id, webhook.id)
+
+      assert_received {:called, 0}
+      assert_received {:called, 1}
+    end
+
+    test "an undefined adapter module is normalized (no crash), recovers when config is fixed",
+         %{event: event, webhook: webhook} do
+      :persistent_term.put({RaisingThenOkAdapter, :pid}, self())
+      Application.put_env(:paper_tiger, :webhook_delivery_adapter, Nope)
+
+      caller =
+        Task.async(fn ->
+          PaperTiger.WebhookDelivery.deliver_event_sync(event.id, webhook.id)
+        end)
+
+      # First attempt: module undefined → safe_adapter_deliver returns
+      # {:error, {:adapter_not_loaded, _}} (no crash). Fix the config before
+      # the retry budget runs out; RaisingThenOk still faults once then ok.
+      Process.sleep(300)
+      Application.put_env(:paper_tiger, :webhook_delivery_adapter, RaisingThenOkAdapter)
+
+      assert {:ok, :delivered} = Task.await(caller, 20_000)
+      assert Process.alive?(Process.whereis(PaperTiger.WebhookDelivery))
     end
   end
 


### PR DESCRIPTION
Adds `PaperTiger.WebhookDelivery.Adapter` — a behaviour with a single `deliver/1` callback (Request in; `{:ok, %Response{}}` = terminal success/ownership taken, `{:error, reason}` = PaperTiger retries with existing backoff). Configure via `config :paper_tiger, webhook_delivery_adapter: MyModule`.

The default `PaperTiger.WebhookDelivery.HTTPAdapter` performs the HTTP POST exactly as before — **no behavior change when unconfigured**. An embedding application can implement the behaviour to take durable ownership of webhook delivery.

Adapter invocation is wrapped: a raising/exiting/throwing/undefined/missing-`deliver/1`/wrong-shape adapter is normalized to `{:error, reason}` so the existing retry path runs and a delivery attempt is recorded — a misbehaving adapter cannot crash `WebhookDelivery` or silently drop.

Also adds the observability-only `[:paper_tiger, :webhook, :delivering]` telemetry event (emitted before the adapter is invoked; not the delivery mechanism).

`deliver_event_sync/2` public contract unchanged. `:sync`/`:async`/`:collect` webhook_mode behavior untouched. 582 tests, 0 failures.