### PR TITLE
[codex] Preserve webhook adapter namespace context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Pluggable webhook delivery adapter.** `PaperTiger.WebhookDelivery.Adapter` behaviour with a single `deliver/1` callback taking a `PaperTiger.WebhookDelivery.Request` (the signed payload, full headers, signature header, url, event, webhook) and returning `{:ok, %PaperTiger.WebhookDelivery.Response{}}` (terminal success / ownership taken) or `{:error, reason}` (PaperTiger retries with its existing exponential backoff). Configure with `config :paper_tiger, webhook_delivery_adapter: MyApp.Sink`. Lets a host embedding PaperTiger take durable ownership of webhook delivery via an explicit, enforced contract — a missing or crashing host cannot silently drop webhooks. Default is `PaperTiger.WebhookDelivery.HTTPAdapter`, which performs the HTTP POST exactly as before; **no behavior change when the adapter is not configured.**
-- `[:paper_tiger, :webhook, :delivering]` telemetry event, emitted for every delivery in every adapter immediately before the adapter is invoked. Metadata: `event`, `webhook`, `url`, `payload` (exact signed bytes), `signature_header`, `headers`, `timestamp`. **Observability only** — not the delivery mechanism (that is the adapter behaviour). Use for metrics/tracing.
+- **Pluggable webhook delivery adapter.** `PaperTiger.WebhookDelivery.Adapter` behaviour with a single `deliver/1` callback taking a `PaperTiger.WebhookDelivery.Request` (the signed payload, full headers, signature header, url, event, webhook, namespace) and returning `{:ok, %PaperTiger.WebhookDelivery.Response{}}` (terminal success / ownership taken) or `{:error, reason}` (PaperTiger retries with its existing exponential backoff). Configure with `config :paper_tiger, webhook_delivery_adapter: MyApp.Sink`. Lets a host embedding PaperTiger take durable ownership of webhook delivery via an explicit, enforced contract — a missing or crashing host cannot silently drop webhooks. Default is `PaperTiger.WebhookDelivery.HTTPAdapter`, which performs the HTTP POST exactly as before; **no behavior change when the adapter is not configured.**
+- `[:paper_tiger, :webhook, :delivering]` telemetry event, emitted for every delivery in every adapter immediately before the adapter is invoked. Metadata: `event`, `webhook`, `url`, `payload` (exact signed bytes), `signature_header`, `headers`, `timestamp`, `namespace`. **Observability only** — not the delivery mechanism (that is the adapter behaviour). Use for metrics/tracing.
 - CI quality checks now include Elixir `1.20.0-rc.5`, and the package version requirement accepts the `1.20` release-candidate line.
 
 ### Fixed
 
 - Removed unreachable invoice-proration fallback branches flagged by the Elixir `1.20.0-rc.5` type checker; generated proration lines are unchanged.
+- Webhook delivery adapter requests now carry the captured PaperTiger namespace through chaos buffering, async task delivery, retry scheduling, telemetry, and delivery-attempt updates, so host-owned durable adapters can preserve tenant context.
 
 ### Hardened
 

--- a/lib/paper_tiger/chaos_coordinator.ex
+++ b/lib/paper_tiger/chaos_coordinator.ex
@@ -421,7 +421,7 @@ defmodule PaperTiger.ChaosCoordinator do
   # Event chaos handlers
   def handle_call({:flush_events, namespace}, _from, genserver_state) do
     state = get_namespace_state(namespace)
-    new_state = flush_event_buffer(state)
+    new_state = flush_event_buffer(namespace, state)
     put_namespace_state(namespace, new_state)
     {:reply, :ok, genserver_state}
   end
@@ -442,7 +442,7 @@ defmodule PaperTiger.ChaosCoordinator do
 
     if buffer_window > 0 do
       # Buffer the event with its delivery function
-      new_buffer = [{event, deliver_fn} | state.event_buffer]
+      new_buffer = [{namespace, event, deliver_fn} | state.event_buffer]
       put_namespace_state(namespace, %{state | event_buffer: new_buffer})
 
       # Schedule flush if not already scheduled for this namespace
@@ -457,7 +457,7 @@ defmodule PaperTiger.ChaosCoordinator do
       {:noreply, %{genserver_state | timers: new_timers}}
     else
       # No buffering - deliver immediately with possible duplication
-      new_state = deliver_event_with_chaos(event, deliver_fn, state)
+      new_state = deliver_event_with_chaos(namespace, event, deliver_fn, state)
       put_namespace_state(namespace, new_state)
       {:noreply, genserver_state}
     end
@@ -468,7 +468,7 @@ defmodule PaperTiger.ChaosCoordinator do
     # Flush the buffer for the specific namespace
     case :ets.lookup(@table, {namespace, :state}) do
       [{{^namespace, :state}, state}] ->
-        new_state = flush_event_buffer(state)
+        new_state = flush_event_buffer(namespace, state)
         :ets.insert(@table, {{namespace, :state}, new_state})
 
       [] ->
@@ -622,7 +622,7 @@ defmodule PaperTiger.ChaosCoordinator do
 
   ## Private - Event Chaos
 
-  defp flush_event_buffer(state) do
+  defp flush_event_buffer(namespace, state) do
     buffer = state.event_buffer
 
     if Enum.empty?(buffer) do
@@ -644,8 +644,12 @@ defmodule PaperTiger.ChaosCoordinator do
 
       # Deliver each event with possible duplication
       new_state =
-        Enum.reduce(events_to_deliver, state, fn {event, deliver_fn}, acc ->
-          deliver_event_with_chaos(event, deliver_fn, acc)
+        Enum.reduce(events_to_deliver, state, fn
+          {entry_namespace, event, deliver_fn}, acc ->
+            deliver_event_with_chaos(entry_namespace, event, deliver_fn, acc)
+
+          {event, deliver_fn}, acc ->
+            deliver_event_with_chaos(namespace, event, deliver_fn, acc)
         end)
 
       # Update reorder stats and clear buffer
@@ -654,21 +658,29 @@ defmodule PaperTiger.ChaosCoordinator do
     end
   end
 
-  defp deliver_event_with_chaos(event, deliver_fn, state) do
+  defp deliver_event_with_chaos(namespace, event, deliver_fn, state) do
     events_config = state.config.events
     duplicate_rate = events_config[:duplicate_rate] || 0.0
 
     # Always deliver once
-    deliver_fn.(event)
+    deliver_event(namespace, event, deliver_fn)
 
     # Maybe duplicate
     if duplicate_rate > 0.0 and :rand.uniform() < duplicate_rate do
-      deliver_fn.(event)
+      deliver_event(namespace, event, deliver_fn)
       stats = Map.update!(state.stats, :events_duplicated, &(&1 + 1))
       %{state | stats: stats}
     else
       state
     end
+  end
+
+  defp deliver_event(namespace, event, deliver_fn) when is_function(deliver_fn, 2) do
+    deliver_fn.(event, namespace)
+  end
+
+  defp deliver_event(_namespace, event, deliver_fn) when is_function(deliver_fn, 1) do
+    deliver_fn.(event)
   end
 
   ## Private - Helpers

--- a/lib/paper_tiger/telemetry_handler.ex
+++ b/lib/paper_tiger/telemetry_handler.ex
@@ -184,20 +184,20 @@ defmodule PaperTiger.TelemetryHandler do
   defp build_delivery_fn(matching_webhooks, event_type) do
     sync_mode? = Application.get_env(:paper_tiger, :webhook_mode) == :sync
 
-    fn evt ->
+    fn evt, namespace ->
       Enum.each(matching_webhooks, fn webhook ->
-        deliver_to_webhook(evt, webhook, event_type, sync_mode?)
+        deliver_to_webhook(evt, webhook, event_type, sync_mode?, namespace)
       end)
     end
   end
 
-  defp deliver_to_webhook(evt, webhook, event_type, sync_mode?) do
+  defp deliver_to_webhook(evt, webhook, event_type, sync_mode?, namespace) do
     Logger.debug("Delivering #{event_type} to webhook #{webhook.id}")
 
     if sync_mode? do
-      WebhookDelivery.deliver_event_sync(evt.id, webhook.id)
+      WebhookDelivery.deliver_event_sync(evt.id, webhook.id, namespace)
     else
-      WebhookDelivery.deliver_event(evt.id, webhook.id)
+      WebhookDelivery.deliver_event(evt.id, webhook.id, namespace)
     end
   end
 

--- a/lib/paper_tiger/webhook_delivery.ex
+++ b/lib/paper_tiger/webhook_delivery.ex
@@ -47,7 +47,7 @@ defmodule PaperTiger.WebhookDelivery do
   - measurements: `%{system_time: System.system_time()}`
   - metadata: `%{event: map, webhook: map, url: String.t(), payload: String.t(),
     headers: [{String.t(), String.t()}], signature_header: String.t(),
-    timestamp: integer()}`
+    timestamp: integer(), namespace: term()}`
 
   This event is **observability only** — it is not the delivery mechanism.
   Delivery handoff is the `Adapter` behaviour. Use this event for metrics and
@@ -97,6 +97,7 @@ defmodule PaperTiger.WebhookDelivery do
 
   @max_retries 5
   @base_backoff_ms 1000
+  @namespace_key :paper_tiger_namespace
 
   ## Client API
 
@@ -130,7 +131,14 @@ defmodule PaperTiger.WebhookDelivery do
   """
   @spec deliver_event(String.t(), String.t()) :: {:ok, reference()} | {:error, term()}
   def deliver_event(event_id, webhook_endpoint_id) when is_binary(event_id) and is_binary(webhook_endpoint_id) do
-    GenServer.call(__MODULE__, {:deliver_event, event_id, webhook_endpoint_id})
+    deliver_event(event_id, webhook_endpoint_id, PaperTiger.Test.current_namespace())
+  end
+
+  @doc false
+  @spec deliver_event(String.t(), String.t(), term()) :: {:ok, reference()} | {:error, term()}
+  def deliver_event(event_id, webhook_endpoint_id, namespace)
+      when is_binary(event_id) and is_binary(webhook_endpoint_id) do
+    GenServer.call(__MODULE__, {:deliver_event, namespace, event_id, webhook_endpoint_id})
   end
 
   @doc """
@@ -157,7 +165,14 @@ defmodule PaperTiger.WebhookDelivery do
   """
   @spec deliver_event_sync(String.t(), String.t()) :: {:ok, :delivered | :failed} | {:error, term()}
   def deliver_event_sync(event_id, webhook_endpoint_id) when is_binary(event_id) and is_binary(webhook_endpoint_id) do
-    GenServer.call(__MODULE__, {:deliver_event_sync, event_id, webhook_endpoint_id}, :infinity)
+    deliver_event_sync(event_id, webhook_endpoint_id, PaperTiger.Test.current_namespace())
+  end
+
+  @doc false
+  @spec deliver_event_sync(String.t(), String.t(), term()) :: {:ok, :delivered | :failed} | {:error, term()}
+  def deliver_event_sync(event_id, webhook_endpoint_id, namespace)
+      when is_binary(event_id) and is_binary(webhook_endpoint_id) do
+    GenServer.call(__MODULE__, {:deliver_event_sync, namespace, event_id, webhook_endpoint_id}, :infinity)
   end
 
   @doc """
@@ -195,17 +210,17 @@ defmodule PaperTiger.WebhookDelivery do
   end
 
   @impl true
-  def handle_call({:deliver_event, event_id, webhook_endpoint_id}, _from, state) do
-    result = dispatch_delivery(event_id, webhook_endpoint_id)
+  def handle_call({:deliver_event, namespace, event_id, webhook_endpoint_id}, _from, state) do
+    result = dispatch_delivery(namespace, event_id, webhook_endpoint_id)
     {:reply, result, state}
   end
 
   @impl true
-  def handle_call({:deliver_event_sync, event_id, webhook_endpoint_id}, _from, state) do
+  def handle_call({:deliver_event_sync, namespace, event_id, webhook_endpoint_id}, _from, state) do
     # Spawn a task so we don't block the GenServer during retries/backoff
     task =
       Task.async(fn ->
-        dispatch_delivery_sync(event_id, webhook_endpoint_id)
+        dispatch_delivery_sync(namespace, event_id, webhook_endpoint_id)
       end)
 
     # Wait indefinitely for the task to complete
@@ -216,34 +231,36 @@ defmodule PaperTiger.WebhookDelivery do
   ## Private Functions
 
   # Dispatches a delivery by spawning an async task
-  defp dispatch_delivery(event_id, webhook_endpoint_id) do
-    # Fetch the event and webhook endpoint
-    case {Events.get(event_id), Webhooks.get(webhook_endpoint_id)} do
-      {{:ok, event}, {:ok, webhook}} ->
-        # Spawn task under supervisor to isolate failures from WebhookDelivery GenServer
-        ref = make_ref()
-
-        Task.Supervisor.start_child(PaperTiger.TaskSupervisor, fn ->
-          deliver_with_retries(event, webhook, 0, ref)
-        end)
-
-        {:ok, ref}
-
-      {{:error, :not_found}, _} ->
-        Logger.warning("WebhookDelivery: Event not found: #{event_id}")
-        {:error, :event_not_found}
-
-      {_, {:error, :not_found}} ->
-        Logger.warning("WebhookDelivery: Webhook endpoint not found: #{webhook_endpoint_id}")
-        {:error, :webhook_not_found}
+  defp dispatch_delivery(namespace, event_id, webhook_endpoint_id) do
+    case fetch_delivery_resources(namespace, event_id, webhook_endpoint_id) do
+      {:ok, event, webhook} -> start_delivery_task(namespace, event, webhook)
+      {:error, reason} -> {:error, reason}
     end
   end
 
   # Dispatches a delivery synchronously, waiting for completion
-  defp dispatch_delivery_sync(event_id, webhook_endpoint_id) do
+  defp dispatch_delivery_sync(namespace, event_id, webhook_endpoint_id) do
+    case fetch_delivery_resources(namespace, event_id, webhook_endpoint_id) do
+      {:ok, event, webhook} ->
+        with_namespace(namespace, fn ->
+          deliver_with_retries_sync(event, webhook, namespace, 0)
+        end)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp fetch_delivery_resources(namespace, event_id, webhook_endpoint_id) do
+    with_namespace(namespace, fn ->
+      do_fetch_delivery_resources(event_id, webhook_endpoint_id)
+    end)
+  end
+
+  defp do_fetch_delivery_resources(event_id, webhook_endpoint_id) do
     case {Events.get(event_id), Webhooks.get(webhook_endpoint_id)} do
       {{:ok, event}, {:ok, webhook}} ->
-        deliver_with_retries_sync(event, webhook, 0)
+        {:ok, event, webhook}
 
       {{:error, :not_found}, _} ->
         Logger.warning("WebhookDelivery: Event not found: #{event_id}")
@@ -255,15 +272,27 @@ defmodule PaperTiger.WebhookDelivery do
     end
   end
 
+  defp start_delivery_task(namespace, event, webhook) do
+    ref = make_ref()
+
+    Task.Supervisor.start_child(PaperTiger.TaskSupervisor, fn ->
+      with_namespace(namespace, fn ->
+        deliver_with_retries(event, webhook, namespace, 0, ref)
+      end)
+    end)
+
+    {:ok, ref}
+  end
+
   # Synchronous version of deliver_with_retries - blocks until complete
-  defp deliver_with_retries_sync(event, webhook, attempt) when attempt >= @max_retries do
+  defp deliver_with_retries_sync(event, webhook, _namespace, attempt) when attempt >= @max_retries do
     Logger.error("WebhookDelivery: Max retries (#{@max_retries}) exceeded for event #{event.id} to #{webhook.url}")
     update_event_delivery_attempts(event, webhook, attempt, :failed, nil)
     {:ok, :failed}
   end
 
-  defp deliver_with_retries_sync(event, webhook, attempt) do
-    case perform_delivery(event, webhook) do
+  defp deliver_with_retries_sync(event, webhook, namespace, attempt) do
+    case perform_delivery(event, webhook, namespace) do
       {:ok, %Response{} = response} ->
         # Terminal success: the adapter delivered, or durably accepted
         # ownership. No retry.
@@ -279,20 +308,20 @@ defmodule PaperTiger.WebhookDelivery do
         # Wait for backoff, then retry synchronously
         delay_ms = @base_backoff_ms * Integer.pow(2, attempt)
         Process.sleep(delay_ms)
-        deliver_with_retries_sync(event, webhook, attempt + 1)
+        deliver_with_retries_sync(event, webhook, namespace, attempt + 1)
     end
   end
 
   # Delivers with exponential backoff retry logic
-  defp deliver_with_retries(event, webhook, attempt, _ref) when attempt >= @max_retries do
+  defp deliver_with_retries(event, webhook, _namespace, attempt, _ref) when attempt >= @max_retries do
     Logger.error("WebhookDelivery: Max retries (#{@max_retries}) exceeded for event #{event.id} to #{webhook.url}")
 
     # Update event with final failed delivery attempt
     update_event_delivery_attempts(event, webhook, attempt, :failed, nil)
   end
 
-  defp deliver_with_retries(event, webhook, attempt, _ref) do
-    case perform_delivery(event, webhook) do
+  defp deliver_with_retries(event, webhook, namespace, attempt, _ref) do
+    case perform_delivery(event, webhook, namespace) do
       {:ok, %Response{} = response} ->
         # Terminal success: the adapter delivered, or durably accepted
         # ownership. No retry.
@@ -305,7 +334,7 @@ defmodule PaperTiger.WebhookDelivery do
         )
 
         # Schedule retry with exponential backoff
-        schedule_retry(event, webhook, attempt)
+        schedule_retry(event, webhook, namespace, attempt)
     end
   end
 
@@ -313,7 +342,7 @@ defmodule PaperTiger.WebhookDelivery do
   # fully-prepared Request to the configured delivery adapter. The adapter's
   # `{:ok, %Response{}} | {:error, reason}` return is interpreted by the
   # retry machinery (success is terminal; error retries with backoff).
-  defp perform_delivery(event, webhook) do
+  defp perform_delivery(event, webhook, namespace) do
     timestamp = PaperTiger.Clock.now()
     payload = Jason.encode!(event)
 
@@ -333,6 +362,7 @@ defmodule PaperTiger.WebhookDelivery do
     request = %Request{
       event: event,
       headers: headers,
+      namespace: namespace,
       payload: payload,
       signature_header: stripe_signature,
       timestamp: timestamp,
@@ -350,6 +380,7 @@ defmodule PaperTiger.WebhookDelivery do
       %{
         event: event,
         headers: headers,
+        namespace: namespace,
         payload: payload,
         signature_header: stripe_signature,
         timestamp: timestamp,
@@ -417,7 +448,7 @@ defmodule PaperTiger.WebhookDelivery do
   end
 
   # Schedules a retry after exponential backoff delay
-  defp schedule_retry(event, webhook, attempt) do
+  defp schedule_retry(event, webhook, namespace, attempt) do
     # Calculate backoff: 1s, 2s, 4s, 8s, 16s
     delay_ms = @base_backoff_ms * Integer.pow(2, attempt)
 
@@ -428,7 +459,7 @@ defmodule PaperTiger.WebhookDelivery do
     # Send to GenServer, not to spawned process (which exits immediately)
     Process.send_after(
       __MODULE__,
-      {:retry_delivery, event, webhook, attempt + 1},
+      {:retry_delivery, namespace, event, webhook, attempt + 1},
       delay_ms
     )
   end
@@ -462,12 +493,35 @@ defmodule PaperTiger.WebhookDelivery do
 
   # Handle info messages for retries (if using handle_info pattern)
   @impl true
-  def handle_info({:retry_delivery, event, webhook, attempt}, state) do
-    deliver_with_retries(event, webhook, attempt, make_ref())
+  def handle_info({:retry_delivery, namespace, event, webhook, attempt}, state) do
+    with_namespace(namespace, fn ->
+      deliver_with_retries(event, webhook, namespace, attempt, make_ref())
+    end)
+
     {:noreply, state}
   end
 
   def handle_info(_msg, state) do
     {:noreply, state}
+  end
+
+  defp with_namespace(namespace, fun) do
+    unset = make_ref()
+    previous = Process.get(@namespace_key, unset)
+    Process.put(@namespace_key, namespace)
+
+    try do
+      fun.()
+    after
+      restore_namespace(previous, unset)
+    end
+  end
+
+  defp restore_namespace(previous, unset) when previous == unset do
+    Process.delete(@namespace_key)
+  end
+
+  defp restore_namespace(previous, _unset) do
+    Process.put(@namespace_key, previous)
   end
 end

--- a/lib/paper_tiger/webhook_delivery/adapter.ex
+++ b/lib/paper_tiger/webhook_delivery/adapter.ex
@@ -5,7 +5,10 @@ defmodule PaperTiger.WebhookDelivery.Adapter do
   PaperTiger signs the payload, builds the `Stripe-Signature` header, emits
   the `[:paper_tiger, :webhook, :delivering]` telemetry event (observability
   only), then calls the configured adapter's `deliver/1` with a
-  `PaperTiger.WebhookDelivery.Request`.
+  `PaperTiger.WebhookDelivery.Request`. The request includes the sandbox or
+  tenant namespace captured when the delivery was queued, so durable adapters
+  can persist work with the same context even though delivery runs in a
+  detached task.
 
   Configure with:
 

--- a/lib/paper_tiger/webhook_delivery/request.ex
+++ b/lib/paper_tiger/webhook_delivery/request.ex
@@ -21,14 +21,18 @@ defmodule PaperTiger.WebhookDelivery.Request do
   - `:event` — the source PaperTiger event map.
   - `:webhook` — the source webhook-endpoint map (`:id`, `:url`,
     `:secret`, ...).
+  - `:namespace` — the PaperTiger sandbox/tenant namespace captured when
+    delivery was queued. Adapters that persist work can use this to retain
+    tenant context outside the delivery task.
   """
 
-  @enforce_keys [:url, :payload, :headers, :signature_header, :timestamp, :event, :webhook]
-  defstruct [:event, :headers, :payload, :signature_header, :timestamp, :url, :webhook]
+  @enforce_keys [:url, :payload, :headers, :signature_header, :timestamp, :event, :webhook, :namespace]
+  defstruct [:event, :headers, :namespace, :payload, :signature_header, :timestamp, :url, :webhook]
 
   @type t :: %__MODULE__{
           event: map(),
           headers: [{String.t(), String.t()}],
+          namespace: term(),
           payload: String.t(),
           signature_header: String.t(),
           timestamp: integer(),

--- a/test/paper_tiger/chaos_coordinator_test.exs
+++ b/test/paper_tiger/chaos_coordinator_test.exs
@@ -22,6 +22,20 @@ defmodule PaperTiger.ChaosCoordinatorTest do
     Jason.decode!(conn.resp_body)
   end
 
+  defp with_process_namespace(namespace, fun) do
+    previous = Process.get(:paper_tiger_namespace, :__paper_tiger_unset__)
+    Process.put(:paper_tiger_namespace, namespace)
+
+    try do
+      fun.()
+    after
+      case previous do
+        :__paper_tiger_unset__ -> Process.delete(:paper_tiger_namespace)
+        value -> Process.put(:paper_tiger_namespace, value)
+      end
+    end
+  end
+
   describe "configuration" do
     test "starts with default config (no chaos)" do
       config = ChaosCoordinator.get_config()
@@ -194,6 +208,28 @@ defmodule PaperTiger.ChaosCoordinatorTest do
       # Now wait for the buffer to actually flush (50ms + some margin)
       # Use assert_receive with a timeout that's long enough
       assert_receive {:delivered, ^event}, 200
+    end
+
+    test "queue_event/2 passes captured namespace to arity-2 delivery functions" do
+      test_pid = self()
+      namespace = :"queue_namespace_#{System.unique_integer([:positive])}"
+
+      with_process_namespace(namespace, fn ->
+        ChaosCoordinator.reset()
+        ChaosCoordinator.configure(%{events: %{buffer_window_ms: 10_000}})
+
+        event = %{id: "evt_namespaced", type: "test.event"}
+
+        ChaosCoordinator.queue_event(event, fn evt, delivered_namespace ->
+          send(test_pid, {:delivered, evt, delivered_namespace})
+        end)
+
+        _ = ChaosCoordinator.get_config()
+        refute_receive {:delivered, _, _}, 10
+
+        ChaosCoordinator.flush_events()
+        assert_receive {:delivered, ^event, ^namespace}, 100
+      end)
     end
 
     test "flush_events/0 delivers buffered events immediately" do
@@ -388,9 +424,12 @@ defmodule PaperTiger.ChaosCoordinatorTest do
     end
 
     test "simulate_failure/2 rejects invalid decline codes" do
-      assert_raise ArgumentError, ~r/Invalid decline code/, fn ->
-        ChaosCoordinator.simulate_failure("cus_123", :not_a_real_code)
-      end
+      error =
+        assert_raise ArgumentError, fn ->
+          ChaosCoordinator.simulate_failure("cus_123", :not_a_real_code)
+        end
+
+      assert String.contains?(error.message, "Invalid decline code")
     end
   end
 end

--- a/test/paper_tiger/webhook_collection_test.exs
+++ b/test/paper_tiger/webhook_collection_test.exs
@@ -273,9 +273,12 @@ defmodule PaperTiger.WebhookCollectionTest do
     test "raises when no matching webhook found" do
       {:ok, _} = TestClient.create_customer(%{"email" => "test@example.com"})
 
-      assert_raise ExUnit.AssertionError, ~r/Expected webhook delivery/, fn ->
-        assert_webhook_delivered("invoice.paid")
-      end
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_webhook_delivered("invoice.paid")
+        end
+
+      assert String.contains?(error.message, "Expected webhook delivery")
     end
 
     test "error message includes delivered webhook types" do
@@ -305,9 +308,12 @@ defmodule PaperTiger.WebhookCollectionTest do
     test "raises when matching webhook is found" do
       {:ok, _} = TestClient.create_customer(%{"email" => "test@example.com"})
 
-      assert_raise ExUnit.AssertionError, ~r/Expected no webhook delivery/, fn ->
-        refute_webhook_delivered("customer.created")
-      end
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          refute_webhook_delivered("customer.created")
+        end
+
+      assert String.contains?(error.message, "Expected no webhook delivery")
     end
   end
 end

--- a/test/paper_tiger/webhook_delivery_test.exs
+++ b/test/paper_tiger/webhook_delivery_test.exs
@@ -34,6 +34,57 @@ defmodule PaperTiger.WebhookDeliveryTest do
     end
   end
 
+  defp with_process_namespace(namespace, fun) do
+    previous = Process.get(:paper_tiger_namespace, :__paper_tiger_unset__)
+    Process.put(:paper_tiger_namespace, namespace)
+
+    try do
+      fun.()
+    after
+      case previous do
+        :__paper_tiger_unset__ -> Process.delete(:paper_tiger_namespace)
+        value -> Process.put(:paper_tiger_namespace, value)
+      end
+    end
+  end
+
+  defp insert_adapter_fixture(namespace, suffix) do
+    with_process_namespace(namespace, fn ->
+      webhook = %{
+        created: PaperTiger.now(),
+        enabled_events: ["charge.succeeded"],
+        id: "we_adapter_#{suffix}",
+        metadata: %{},
+        object: "webhook_endpoint",
+        secret: "whsec_adapter_secret_#{suffix}",
+        status: "enabled",
+        url: "http://127.0.0.1:1/#{suffix}"
+      }
+
+      {:ok, _} = Webhooks.insert(webhook)
+
+      event = %{
+        created: PaperTiger.now(),
+        data: %{object: %{amount: 4242, currency: "usd", id: "ch_#{suffix}"}},
+        delivery_attempts: [],
+        id: "evt_adapter_#{suffix}",
+        livemode: false,
+        metadata: %{},
+        object: "event",
+        type: "charge.succeeded"
+      }
+
+      {:ok, _} = Events.insert(event)
+      {event, webhook}
+    end)
+  end
+
+  defp lowercase_hex?(value) do
+    value
+    |> String.to_charlist()
+    |> Enum.all?(fn char -> char in ?0..?9 or char in ?a..?f end)
+  end
+
   describe "sign_payload/2" do
     test "creates HMAC SHA256 signature" do
       payload = "test_payload"
@@ -71,7 +122,7 @@ defmodule PaperTiger.WebhookDeliveryTest do
       signature = PaperTiger.WebhookDelivery.sign_payload("test", "secret")
 
       # Verify it's all lowercase hex characters
-      assert signature =~ ~r/^[0-9a-f]+$/
+      assert lowercase_hex?(signature)
     end
   end
 
@@ -225,7 +276,10 @@ defmodule PaperTiger.WebhookDeliveryTest do
       # Exact signed bytes + full signature header — adapter delivers without
       # re-signing.
       assert req.payload == Jason.encode!(event)
-      assert req.signature_header =~ ~r/^t=\d+,v1=[0-9a-f]{64}$/
+      assert ["t=" <> timestamp, "v1=" <> signature] = String.split(req.signature_header, ",")
+      assert {_timestamp, ""} = Integer.parse(timestamp)
+      assert String.length(signature) == 64
+      assert lowercase_hex?(signature)
       assert {"Stripe-Signature", req.signature_header} in req.headers
 
       {:ok, reloaded} = Events.get(event.id)
@@ -289,6 +343,59 @@ defmodule PaperTiger.WebhookDeliveryTest do
       assert metadata.event.id == event.id
       assert metadata.url == webhook.url
       assert metadata.payload == Jason.encode!(event)
+    end
+
+    test "sync adapter request carries the namespace captured by the caller" do
+      namespace = self()
+      suffix = "sync_ns_#{System.unique_integer([:positive])}"
+      {event, webhook} = insert_adapter_fixture(namespace, suffix)
+
+      on_exit(fn -> PaperTiger.Test.cleanup_namespace(namespace) end)
+
+      assert {:ok, :delivered} =
+               with_process_namespace(namespace, fn ->
+                 PaperTiger.WebhookDelivery.deliver_event_sync(event.id, webhook.id)
+               end)
+
+      assert_receive {:adapter_called, %Request{namespace: ^namespace} = req}, 2_000
+      assert req.event.id == event.id
+      assert req.webhook.id == webhook.id
+
+      with_process_namespace(namespace, fn ->
+        assert {:ok, reloaded} = Events.get(event.id)
+        assert [%{status: :delivered, webhook_endpoint_id: webhook_id}] = reloaded.delivery_attempts
+        assert webhook_id == webhook.id
+      end)
+    end
+
+    test "async adapter request and delivery-attempt update keep the captured namespace" do
+      namespace = self()
+      suffix = "async_ns_#{System.unique_integer([:positive])}"
+      {event, webhook} = insert_adapter_fixture(namespace, suffix)
+
+      on_exit(fn -> PaperTiger.Test.cleanup_namespace(namespace) end)
+
+      assert {:ok, ref} =
+               with_process_namespace(namespace, fn ->
+                 PaperTiger.WebhookDelivery.deliver_event(event.id, webhook.id)
+               end)
+
+      assert is_reference(ref)
+      assert_receive {:adapter_called, %Request{namespace: ^namespace} = req}, 2_000
+      assert req.event.id == event.id
+      assert req.webhook.id == webhook.id
+
+      with_process_namespace(namespace, fn ->
+        wait_for(fn ->
+          expected_webhook_id = webhook.id
+          {:ok, reloaded} = Events.get(event.id)
+
+          match?(
+            [%{status: :delivered, webhook_endpoint_id: ^expected_webhook_id}],
+            reloaded.delivery_attempts
+          )
+        end)
+      end)
     end
   end
 


### PR DESCRIPTION
Fixes #72.

## What changed
- Add `namespace` to `PaperTiger.WebhookDelivery.Request` and `[:paper_tiger, :webhook, :delivering]` metadata.
- Capture namespace at delivery enqueue time and propagate it through sync dispatch, async tasks, retry messages, and delivery-attempt updates.
- Teach `ChaosCoordinator.queue_event/2` to pass the captured namespace to arity-2 delivery callbacks while keeping arity-1 callbacks compatible.
- Update adapter docs/changelog and add regression coverage for buffered chaos delivery plus sync/async adapter delivery.

## Validation
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix credo --strict --all`
- `mix test --warnings-as-errors`
- `mix dialyzer`