### PR TITLE
Add automatic tax totals for checkout and subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `[:paper_tiger, :webhook, :delivering]` telemetry event, emitted for every delivery in every adapter immediately before the adapter is invoked. Metadata: `event`, `webhook`, `url`, `payload` (exact signed bytes), `signature_header`, `headers`, `timestamp`, `namespace`. **Observability only** — not the delivery mechanism (that is the adapter behaviour). Use for metrics/tracing.
 - CI quality checks now include Elixir `1.20.0-rc.5`, and the package version requirement accepts the `1.20` release-candidate line.
 - Side-by-side contract drift harness for running a scenario against both PaperTiger and Stripe test mode in the same test, normalizing volatile fields, and reporting the first mismatch with both backend shapes. The first live drift scenario covers customer create/retrieve/update/delete.
+- Deterministic automatic-tax fixtures for Checkout Session totals, PaymentIntent amounts, initial subscription invoices, and subscription renewal invoices.
 
 ### Fixed
 

--- a/lib/paper_tiger/automatic_tax.ex
+++ b/lib/paper_tiger/automatic_tax.ex
@@ -1,0 +1,241 @@
+defmodule PaperTiger.AutomaticTax do
+  @moduledoc """
+  Deterministic Stripe Tax helpers for PaperTiger's local test surface.
+
+  This intentionally models only the automatic-tax totals that tests need.
+  It is not a standalone Tax Calculations/Transactions API implementation.
+  """
+
+  @default_fixture_rates %{
+    "CA" => 1300,
+    "EU" => 2100,
+    "GB" => 2000,
+    "US" => 750
+  }
+
+  @doc """
+  Returns a Stripe-shaped automatic_tax map from request params or a resource.
+  """
+  @spec automatic_tax(map(), atom()) :: map()
+  def automatic_tax(source, resource \\ :checkout_session)
+
+  def automatic_tax(source, resource) when is_map(source) do
+    enabled = source |> value(:automatic_tax) |> value(:enabled) |> truthy?()
+
+    resource_automatic_tax(enabled, resource)
+  end
+
+  @doc """
+  True when `automatic_tax[enabled]=true` was requested.
+  """
+  @spec enabled?(map()) :: boolean()
+  def enabled?(source) when is_map(source) do
+    source |> automatic_tax(:checkout_session) |> Map.fetch!(:enabled)
+  end
+
+  @doc """
+  Applies deterministic automatic-tax fields to line items and returns totals.
+  """
+  @spec apply_to_line_items([map()], map(), atom()) :: {[map()], map()}
+  def apply_to_line_items(line_items, source, resource \\ :invoice)
+
+  def apply_to_line_items(line_items, source, resource) when is_list(line_items) and is_map(source) do
+    if enabled?(source) do
+      jurisdiction = jurisdiction(source)
+      rate_bps = rate_bps(jurisdiction)
+
+      taxed_lines =
+        Enum.map(line_items, fn line ->
+          taxable_amount = line_amount(line)
+          tax_amount = calculate_tax(taxable_amount, rate_bps)
+
+          line
+          |> Map.put(:amount_subtotal, taxable_amount)
+          |> Map.put(:amount_tax, tax_amount)
+          |> Map.put(:amount_total, taxable_amount + tax_amount)
+          |> Map.put(:amount_excluding_tax, taxable_amount)
+          |> Map.put(:subtotal, taxable_amount)
+          |> Map.put(:taxes, [tax(tax_amount, taxable_amount)])
+          |> Map.put(:unit_amount_excluding_tax, unit_amount_excluding_tax(line))
+          |> Map.put(:tax_amounts, [
+            legacy_tax_amount(tax_amount, taxable_amount)
+          ])
+        end)
+
+      subtotal = Enum.reduce(taxed_lines, 0, &(&2 + line_amount(&1)))
+      amount_tax = Enum.reduce(taxed_lines, 0, &(&2 + line_tax_amount(&1)))
+
+      {taxed_lines,
+       %{
+         amount_tax: amount_tax,
+         automatic_tax: automatic_tax(source, resource),
+         subtotal: subtotal,
+         total: subtotal + amount_tax,
+         total_details: %{amount_discount: 0, amount_shipping: 0, amount_tax: amount_tax}
+       }}
+    else
+      subtotal = Enum.reduce(line_items, 0, &(&2 + line_amount(&1)))
+
+      {line_items,
+       %{
+         amount_tax: 0,
+         automatic_tax: automatic_tax(source, resource),
+         subtotal: subtotal,
+         total: subtotal,
+         total_details: %{amount_discount: 0, amount_shipping: 0, amount_tax: 0}
+       }}
+    end
+  end
+
+  def apply_to_line_items(_line_items, source, resource) when is_map(source) do
+    {[], apply_to_line_items([], source, resource) |> elem(1)}
+  end
+
+  def apply_to_line_items(_line_items, _source, _resource), do: {[], %{amount_tax: 0, subtotal: 0, total: 0}}
+
+  defp resource_automatic_tax(enabled, :subscription) do
+    %{
+      disabled_reason: nil,
+      enabled: enabled,
+      liability: nil
+    }
+  end
+
+  defp resource_automatic_tax(enabled, :invoice) do
+    %{
+      disabled_reason: nil,
+      enabled: enabled,
+      liability: nil,
+      status: if(enabled, do: "complete")
+    }
+  end
+
+  defp resource_automatic_tax(enabled, _resource) do
+    %{
+      enabled: enabled,
+      liability: nil,
+      status: if(enabled, do: "complete")
+    }
+  end
+
+  defp tax(amount, taxable_amount) do
+    %{
+      amount: amount,
+      tax_behavior: "exclusive",
+      taxable_amount: taxable_amount
+    }
+  end
+
+  defp legacy_tax_amount(amount, taxable_amount) do
+    %{
+      amount: amount,
+      inclusive: false,
+      tax_rate: nil,
+      taxable_amount: taxable_amount
+    }
+  end
+
+  defp jurisdiction(source) do
+    value(source, :tax_jurisdiction) ||
+      source |> value(:automatic_tax) |> value(:jurisdiction) ||
+      source |> value(:metadata) |> value(:tax_country) ||
+      source |> value(:customer_details) |> value(:address) |> value(:country) ||
+      source |> value(:shipping) |> value(:address) |> value(:country) ||
+      "US"
+  end
+
+  defp rate_bps(jurisdiction) do
+    fixtures = Application.get_env(:paper_tiger, :tax_fixtures, @default_fixture_rates)
+
+    fixture_value =
+      Map.get(fixtures, to_string(jurisdiction)) ||
+        Map.get(@default_fixture_rates, to_string(jurisdiction))
+
+    normalize_rate_bps(fixture_value || @default_fixture_rates["US"])
+  end
+
+  defp normalize_rate_bps(rate) when is_integer(rate), do: rate
+  defp normalize_rate_bps(rate) when is_float(rate), do: round(rate * 100)
+
+  defp normalize_rate_bps(rate) when is_binary(rate) do
+    case Integer.parse(rate) do
+      {integer, ""} -> integer
+      _ -> 0
+    end
+  end
+
+  defp normalize_rate_bps(_), do: 0
+
+  defp calculate_tax(amount, rate_bps), do: round(amount * rate_bps / 10_000)
+
+  defp line_tax_amount(line) do
+    cond do
+      tax_amount = first_tax_amount(line, :tax_amounts) ->
+        tax_amount
+
+      tax_amount = first_tax_amount(line, :taxes) ->
+        tax_amount
+
+      true ->
+        0
+    end
+  end
+
+  defp first_tax_amount(line, key) do
+    line
+    |> value(key)
+    |> case do
+      [%{} = tax | _] -> value(tax, :amount) || 0
+      _ -> nil
+    end
+  end
+
+  defp line_amount(line) do
+    unit_amount =
+      value(line, :unit_amount_excluding_tax) ||
+        value(line, :unit_amount) ||
+        line |> value(:price) |> value(:unit_amount) ||
+        line |> value(:price_data) |> value(:unit_amount)
+
+    quantity = value(line, :quantity) || 1
+
+    if unit_amount do
+      to_integer(unit_amount) * to_integer(quantity)
+    else
+      line |> value(:amount) |> to_integer()
+    end
+  end
+
+  defp unit_amount_excluding_tax(line) do
+    value(line, :unit_amount_excluding_tax) ||
+      value(line, :unit_amount) ||
+      line |> value(:price) |> value(:unit_amount) ||
+      line |> value(:price_data) |> value(:unit_amount) ||
+      line_amount(line)
+  end
+
+  defp value(nil, _key), do: nil
+
+  defp value(map, key) when is_map(map) and is_atom(key) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  defp value(_other, _key), do: nil
+
+  defp truthy?(true), do: true
+  defp truthy?("true"), do: true
+  defp truthy?("1"), do: true
+  defp truthy?(1), do: true
+  defp truthy?(_), do: false
+
+  defp to_integer(value) when is_integer(value), do: value
+
+  defp to_integer(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {integer, _} -> integer
+      :error -> 0
+    end
+  end
+
+  defp to_integer(_), do: 0
+end

--- a/lib/paper_tiger/billing_engine.ex
+++ b/lib/paper_tiger/billing_engine.ex
@@ -41,6 +41,7 @@ defmodule PaperTiger.BillingEngine do
 
   use GenServer
 
+  alias PaperTiger.AutomaticTax
   alias PaperTiger.ChaosCoordinator
   alias PaperTiger.Store.Charges
   alias PaperTiger.Store.Customers
@@ -300,11 +301,31 @@ defmodule PaperTiger.BillingEngine do
     now = PaperTiger.now()
     invoice_id = PaperTiger.Resource.generate_id("in")
 
+    line_item = %{
+      amount: amount,
+      created: now,
+      currency: currency,
+      customer: customer.id,
+      description: "Subscription renewal",
+      id: PaperTiger.Resource.generate_id("ii"),
+      invoice: invoice_id,
+      livemode: false,
+      metadata: %{},
+      object: "invoiceitem",
+      quantity: 1,
+      subscription: subscription.id,
+      unit_amount_excluding_tax: amount
+    }
+
+    {[line_item], totals} = AutomaticTax.apply_to_line_items([line_item], subscription, :invoice)
+    total = if(AutomaticTax.enabled?(subscription), do: totals.total, else: amount)
+
     invoice = %{
-      amount_due: amount,
+      amount_due: total,
       amount_paid: 0,
-      amount_remaining: amount,
+      amount_remaining: total,
       auto_advance: true,
+      automatic_tax: AutomaticTax.automatic_tax(subscription, :invoice),
       billing_reason: "subscription_cycle",
       collection_method: "charge_automatically",
       created: now,
@@ -321,25 +342,13 @@ defmodule PaperTiger.BillingEngine do
       status: "draft",
       subscription: subscription.id,
       subtotal: amount,
-      total: amount
+      tax: totals.amount_tax,
+      total: total,
+      total_details: totals.total_details
     }
 
     # Create invoice item
-    invoice_item = %{
-      amount: amount,
-      created: now,
-      currency: currency,
-      customer: customer.id,
-      description: "Subscription renewal",
-      id: PaperTiger.Resource.generate_id("ii"),
-      invoice: invoice_id,
-      livemode: false,
-      metadata: %{},
-      object: "invoiceitem",
-      subscription: subscription.id
-    }
-
-    {:ok, _item} = InvoiceItems.insert(invoice_item)
+    {:ok, _item} = InvoiceItems.insert(line_item)
     {:ok, inv} = Invoices.insert(invoice)
 
     # Fire invoice.created event
@@ -357,8 +366,9 @@ defmodule PaperTiger.BillingEngine do
     end
   end
 
-  defp finalize_successful_payment(invoice, subscription, amount) do
+  defp finalize_successful_payment(invoice, subscription, _amount) do
     now = PaperTiger.now()
+    amount = invoice.amount_due
 
     # Create payment intent
     payment_intent = %{

--- a/lib/paper_tiger/resources/checkout_session.ex
+++ b/lib/paper_tiger/resources/checkout_session.ex
@@ -37,6 +37,7 @@ defmodule PaperTiger.Resources.CheckoutSession do
 
   import PaperTiger.Resource
 
+  alias PaperTiger.AutomaticTax
   alias PaperTiger.Store.CheckoutSessions
   alias PaperTiger.Store.Invoices
   alias PaperTiger.Store.PaymentIntents
@@ -486,7 +487,7 @@ defmodule PaperTiger.Resources.CheckoutSession do
 
   defp create_payment_intent_from_session(session, payment_method) do
     now = PaperTiger.now()
-    amount = calculate_amount_from_line_items(session.line_items)
+    amount = session[:amount_total] || calculate_amount_from_line_items(session.line_items)
 
     payment_intent = %{
       amount: amount,
@@ -702,6 +703,9 @@ defmodule PaperTiger.Resources.CheckoutSession do
     session_id = generate_id("cs")
 
     %{
+      amount_subtotal: nil,
+      amount_total: nil,
+      automatic_tax: AutomaticTax.automatic_tax(params, :checkout_session),
       billing_address_collection: Map.get(params, :billing_address_collection),
       cancel_url: Map.get(params, :cancel_url),
       completed_at: nil,
@@ -734,6 +738,60 @@ defmodule PaperTiger.Resources.CheckoutSession do
       ui_mode: Map.get(params, :ui_mode, "hosted"),
       url: generate_checkout_url(session_id)
     }
+    |> maybe_apply_automatic_tax()
+  end
+
+  defp maybe_apply_automatic_tax(session) do
+    if AutomaticTax.enabled?(session) do
+      {line_items, totals} =
+        session.line_items
+        |> normalize_checkout_line_items_for_tax()
+        |> AutomaticTax.apply_to_line_items(session, :checkout_session)
+
+      session
+      |> Map.put(:amount_subtotal, totals.subtotal)
+      |> Map.put(:amount_total, totals.total)
+      |> Map.put(:automatic_tax, totals.automatic_tax)
+      |> Map.put(:line_items, line_items)
+      |> Map.put(:total_details, totals.total_details)
+    else
+      session
+    end
+  end
+
+  defp normalize_checkout_line_items_for_tax(line_items) when is_list(line_items) do
+    Enum.map(line_items, fn item ->
+      price = normalize_checkout_line_item_price(item)
+
+      unit_amount =
+        Map.get(item, :amount) ||
+          Map.get(item, "amount") ||
+          get_in_flexible(item, [:price_data, :unit_amount]) ||
+          get_in_flexible(price, [:unit_amount])
+
+      item =
+        if price do
+          Map.put(item, :price, price)
+        else
+          item
+        end
+
+      if unit_amount do
+        Map.put(item, :unit_amount_excluding_tax, unit_amount)
+      else
+        item
+      end
+    end)
+  end
+
+  defp normalize_checkout_line_items_for_tax(line_items), do: line_items
+
+  defp normalize_checkout_line_item_price(item) do
+    case Map.get(item, :price) || Map.get(item, "price") do
+      %{} = price -> price
+      price_id when is_binary(price_id) -> fetch_price_object(price_id)
+      _ -> nil
+    end
   end
 
   # Generates a checkout URL pointing to PaperTiger's auto-complete endpoint.

--- a/lib/paper_tiger/resources/subscription.ex
+++ b/lib/paper_tiger/resources/subscription.ex
@@ -39,8 +39,10 @@ defmodule PaperTiger.Resources.Subscription do
 
   import PaperTiger.Resource
 
+  alias PaperTiger.AutomaticTax
   alias PaperTiger.Store.Coupons
   alias PaperTiger.Store.Customers
+  alias PaperTiger.Store.InvoiceItems
   alias PaperTiger.Store.Invoices
   alias PaperTiger.Store.PaymentIntents
   alias PaperTiger.Store.Plans
@@ -146,17 +148,6 @@ defmodule PaperTiger.Resources.Subscription do
          updated = maybe_update_discount(updated, conn.params),
          updated = maybe_activate_subscription_after_trial(updated),
          {:ok, updated} <- Subscriptions.update(updated) do
-      # Handle items update if provided
-      # Create proration invoice when proration_behavior requests it
-      # Get all subscriptions in current namespace
-      # Filter by customer and/or status if provided
-      # Load subscription items and latest invoice for each subscription in the list
-      # Paginate the filtered results
-      ## Private Functions
-      # Convert subscription from "trialing" to "active" when trial_end is set to now or past
-      # If subscription is trialing and trial_end is now or in the past, activate it
-      # Otherwise, leave subscription as is
-      # Helper to get field from item map (supports both atom and string keys)
       if Map.has_key?(conn.params, :items) do
         update_subscription_items(id, conn.params.items)
       end
@@ -166,11 +157,10 @@ defmodule PaperTiger.Resources.Subscription do
       updated = maybe_create_proration_invoice(updated, conn.params, billable_items_changed)
 
       updated_with_items = load_subscription_items(updated)
-      # items will be loaded separately
       previous_attributes = diff_attributes(existing, updated_with_items)
       items_changed = Map.has_key?(conn.params, :items)
       maybe_emit_subscription_updated_telemetry(previous_attributes, items_changed, updated_with_items)
-      # Additional fields
+
       updated_with_items
       |> maybe_expand(conn.params)
       |> then(&json_response(conn, 200, &1))
@@ -353,6 +343,7 @@ defmodule PaperTiger.Resources.Subscription do
     status = determine_subscription_status(params, trial_end)
 
     %{
+      automatic_tax: AutomaticTax.automatic_tax(params, :subscription),
       billing_cycle_anchor: Map.get(params, :billing_cycle_anchor, current_period_start),
       cancel_at: nil,
       cancel_at_period_end: false,
@@ -810,18 +801,26 @@ defmodule PaperTiger.Resources.Subscription do
     # Trialing subs have no immediate charge, so no PI needed
     if payment_behavior == "default_incomplete" and subscription.status != "trialing" do
       now = PaperTiger.now()
-      total = calculate_items_total(items)
+      subtotal = calculate_items_total(items)
       default_pm = Map.get(params, :default_payment_method)
+      automatic_tax = AutomaticTax.automatic_tax(params, :invoice)
 
       # If payment method provided, auto-confirm; otherwise requires_payment_method
       {pi_status, inv_status, sub_status, paid, amt_paid, amt_remaining} =
         if default_pm do
-          {"succeeded", "paid", "active", true, total, 0}
+          {"succeeded", "paid", "active", true, :paid_total, 0}
         else
-          {"requires_payment_method", "draft", "incomplete", false, 0, total}
+          {"requires_payment_method", "draft", "incomplete", false, 0, :remaining_total}
         end
 
-      # Create payment intent
+      # Create invoice with payment_intent reference
+      invoice_id = generate_id("in")
+      line_items = build_initial_invoice_line_items(subscription, invoice_id)
+      {line_items, totals} = AutomaticTax.apply_to_line_items(line_items, params, :invoice)
+      total = if(AutomaticTax.enabled?(params), do: totals.total, else: subtotal)
+      amount_paid = if(amt_paid == :paid_total, do: total, else: amt_paid)
+      amount_remaining = if(amt_remaining == :remaining_total, do: total, else: amt_remaining)
+
       pi_id = generate_id("pi")
       client_secret = pi_id <> "_secret_" <> Base.encode16(:crypto.strong_rand_bytes(12), case: :lower)
 
@@ -846,13 +845,11 @@ defmodule PaperTiger.Resources.Subscription do
 
       {:ok, _} = PaymentIntents.insert(pi)
 
-      # Create invoice with payment_intent reference
-      invoice_id = generate_id("in")
-
       invoice = %{
         amount_due: total,
-        amount_paid: amt_paid,
-        amount_remaining: amt_remaining,
+        amount_paid: amount_paid,
+        amount_remaining: amount_remaining,
+        automatic_tax: automatic_tax,
         created: now,
         currency: "usd",
         customer: subscription.customer,
@@ -868,10 +865,13 @@ defmodule PaperTiger.Resources.Subscription do
         status: inv_status,
         status_transitions: %{finalized_at: nil, marked_uncollectible_at: nil, paid_at: nil, voided_at: nil},
         subscription: subscription.id,
-        subtotal: total,
-        total: total
+        subtotal: subtotal,
+        tax: totals.amount_tax,
+        total: total,
+        total_details: totals.total_details
       }
 
+      Enum.each(line_items, &InvoiceItems.insert/1)
       {:ok, _} = Invoices.insert(invoice)
 
       # Update subscription with latest_invoice and final status
@@ -896,6 +896,40 @@ defmodule PaperTiger.Resources.Subscription do
   end
 
   defp calculate_items_total(_), do: 0
+
+  defp build_initial_invoice_line_items(subscription, invoice_id) do
+    now = PaperTiger.now()
+
+    SubscriptionItems.find_by_subscription(subscription.id)
+    |> Enum.sort_by(& &1.created, :asc)
+    |> Enum.map(fn item ->
+      price = item[:price] || %{}
+      unit_amount = price[:unit_amount] || 0
+      quantity = item[:quantity] || 1
+      amount = unit_amount * quantity
+
+      %{
+        amount: amount,
+        currency: price[:currency] || "usd",
+        customer: subscription.customer,
+        date: now,
+        description: price[:nickname] || "Subscription",
+        id: generate_id("ii"),
+        invoice: invoice_id,
+        livemode: false,
+        metadata: %{},
+        object: "invoiceitem",
+        period: %{end: subscription.current_period_end, start: subscription.current_period_start},
+        price: price,
+        proration: false,
+        quantity: quantity,
+        subscription: subscription.id,
+        subscription_item: item.id,
+        type: "invoiceitem",
+        unit_amount_excluding_tax: unit_amount
+      }
+    end)
+  end
 
   # Loads the latest invoice ID for this subscription from the store
   # Note: By default Stripe returns only the invoice ID, not the full object

--- a/test/paper_tiger/automatic_tax_test.exs
+++ b/test/paper_tiger/automatic_tax_test.exs
@@ -1,0 +1,50 @@
+defmodule PaperTiger.AutomaticTaxTest do
+  use ExUnit.Case, async: true
+
+  alias PaperTiger.AutomaticTax
+
+  describe "automatic_tax/2" do
+    test "returns checkout-style status for checkout sessions" do
+      automatic_tax = AutomaticTax.automatic_tax(%{automatic_tax: %{enabled: true}}, :checkout_session)
+
+      assert automatic_tax == %{enabled: true, liability: nil, status: "complete"}
+    end
+
+    test "returns subscription-style disabled reason without calculation status" do
+      automatic_tax = AutomaticTax.automatic_tax(%{"automatic_tax" => %{"enabled" => "true"}}, :subscription)
+
+      assert automatic_tax == %{disabled_reason: nil, enabled: true, liability: nil}
+    end
+
+    test "returns invoice-style calculation status" do
+      automatic_tax = AutomaticTax.automatic_tax(%{automatic_tax: %{enabled: true}}, :invoice)
+
+      assert automatic_tax == %{disabled_reason: nil, enabled: true, liability: nil, status: "complete"}
+    end
+  end
+
+  describe "apply_to_line_items/3" do
+    test "applies deterministic tax totals and line tax fields" do
+      {lines, totals} =
+        AutomaticTax.apply_to_line_items(
+          [%{quantity: "2", unit_amount: "1000"}],
+          %{automatic_tax: %{enabled: true}, metadata: %{tax_country: "US"}},
+          :invoice
+        )
+
+      assert totals.subtotal == 2000
+      assert totals.amount_tax == 150
+      assert totals.total == 2150
+      assert totals.total_details.amount_tax == 150
+
+      assert [
+               %{
+                 amount_tax: 150,
+                 amount_total: 2150,
+                 tax_amounts: [%{amount: 150, inclusive: false, tax_rate: nil, taxable_amount: 2000}],
+                 taxes: [%{amount: 150, tax_behavior: "exclusive", taxable_amount: 2000}]
+               }
+             ] = lines
+    end
+  end
+end

--- a/test/paper_tiger/billing_engine_test.exs
+++ b/test/paper_tiger/billing_engine_test.exs
@@ -3,7 +3,18 @@ defmodule PaperTiger.BillingEngineTest do
 
   alias PaperTiger.BillingEngine
   alias PaperTiger.ChaosCoordinator
-  alias PaperTiger.Store.{Charges, Customers, Invoices, Plans, Prices, Products, Subscriptions}
+
+  alias PaperTiger.Store.{
+    Charges,
+    Customers,
+    InvoiceItems,
+    Invoices,
+    PaymentIntents,
+    Plans,
+    Prices,
+    Products,
+    Subscriptions
+  }
 
   setup do
     PaperTiger.flush()
@@ -110,6 +121,55 @@ defmodule PaperTiger.BillingEngineTest do
       {:ok, updated_sub} = Subscriptions.get("sub_due")
       assert updated_sub.current_period_start == past
       assert updated_sub.current_period_end > past
+    end
+
+    test "applies automatic tax to renewal invoices", %{customer: customer} do
+      now = PaperTiger.now()
+      past = now - 86_400
+
+      {:ok, _sub} =
+        Subscriptions.insert(%{
+          automatic_tax: %{enabled: true, liability: nil, status: "complete"},
+          created: past - 2_592_000,
+          current_period_end: past,
+          current_period_start: past - 2_592_000,
+          customer: customer.id,
+          id: "sub_tax_due",
+          items: %{
+            data: [%{price: "price_test"}]
+          },
+          metadata: %{tax_country: "US"},
+          object: "subscription",
+          plan: %{interval: "month", interval_count: 1},
+          status: "active"
+        })
+
+      start_supervised!({BillingEngine, []})
+      BillingEngine.set_mode(:happy_path)
+
+      {:ok, stats} = BillingEngine.process_billing()
+
+      assert stats.processed == 1
+      assert stats.succeeded == 1
+
+      %{data: [invoice]} = Invoices.list(%{})
+      assert invoice.subtotal == 2000
+      assert invoice.tax == 150
+      assert invoice.total_details.amount_tax == 150
+      assert invoice.amount_due == 2150
+      assert invoice.amount_paid == 2150
+      assert invoice.amount_remaining == 0
+
+      [line] = InvoiceItems.find_by_invoice(invoice.id)
+      assert line.amount == 2000
+      assert [%{amount: 150, taxable_amount: 2000}] = line.tax_amounts
+      assert [%{amount: 150, tax_behavior: "exclusive", taxable_amount: 2000}] = line.taxes
+
+      %{data: [payment_intent]} = PaymentIntents.list(%{})
+      assert payment_intent.amount == 2150
+
+      %{data: [charge]} = Charges.list(%{})
+      assert charge.amount == 2150
     end
 
     test "does not process subscription that is not due", %{customer: customer} do

--- a/test/paper_tiger/resources/checkout_session_test.exs
+++ b/test/paper_tiger/resources/checkout_session_test.exs
@@ -400,6 +400,59 @@ defmodule PaperTiger.Resources.CheckoutSessionTest do
       pi = json_response(pi_conn)
       assert pi["currency"] == "gbp"
     end
+
+    test "applies automatic tax to checkout totals and payment intent amount" do
+      cust_conn = request(:post, "/v1/customers", %{"email" => "taxed-checkout@example.com"})
+      customer_id = json_response(cust_conn)["id"]
+
+      prod_conn = request(:post, "/v1/products", %{"name" => "Taxed Product"})
+      product_id = json_response(prod_conn)["id"]
+
+      price_conn =
+        request(:post, "/v1/prices", %{
+          "currency" => "usd",
+          "product" => product_id,
+          "unit_amount" => 1000
+        })
+
+      price_id = json_response(price_conn)["id"]
+
+      params = %{
+        "automatic_tax" => %{"enabled" => true},
+        "cancel_url" => "https://example.com/cancel",
+        "currency" => "usd",
+        "customer" => customer_id,
+        "line_items" => [%{"price" => price_id, "quantity" => 2}],
+        "metadata" => %{"tax_country" => "US"},
+        "mode" => "payment",
+        "success_url" => "https://example.com/success"
+      }
+
+      create_conn = request(:post, "/v1/checkout/sessions", params)
+      session = json_response(create_conn)
+
+      assert session["automatic_tax"]["enabled"] == true
+      assert session["automatic_tax"]["status"] == "complete"
+      assert session["amount_subtotal"] == 2000
+      assert session["total_details"]["amount_tax"] == 150
+      assert session["amount_total"] == 2150
+
+      assert [
+               %{
+                 "amount_tax" => 150,
+                 "amount_total" => 2150,
+                 "tax_amounts" => [%{"amount" => 150, "taxable_amount" => 2000}],
+                 "taxes" => [%{"amount" => 150, "tax_behavior" => "exclusive", "taxable_amount" => 2000}]
+               }
+             ] = session["line_items"]
+
+      complete_conn = request(:post, "/_test/checkout/sessions/#{session["id"]}/complete")
+      completed = json_response(complete_conn)
+
+      pi_conn = request(:get, "/v1/payment_intents/#{completed["payment_intent"]}")
+      pi = json_response(pi_conn)
+      assert pi["amount"] == 2150
+    end
   end
 
   describe "GET /v1/checkout/sessions - List" do

--- a/test/paper_tiger/resources/subscription_test.exs
+++ b/test/paper_tiger/resources/subscription_test.exs
@@ -1423,6 +1423,42 @@ defmodule PaperTiger.Resources.SubscriptionTest do
       assert pi["client_secret"] != nil
     end
 
+    test "applies automatic tax to default_incomplete subscription invoice", %{customer: customer, price: price} do
+      sub_conn =
+        request(:post, "/v1/subscriptions", %{
+          "automatic_tax" => %{"enabled" => true},
+          "customer" => customer["id"],
+          "items" => [%{"price" => price["id"], "quantity" => "2"}],
+          "metadata" => %{"tax_country" => "US"},
+          "payment_behavior" => "default_incomplete"
+        })
+
+      assert sub_conn.status == 200
+      sub = json_response(sub_conn)
+      assert sub["automatic_tax"]["enabled"] == true
+      assert is_binary(sub["latest_invoice"])
+
+      inv_conn = request(:get, "/v1/invoices/#{sub["latest_invoice"]}", %{})
+      invoice = json_response(inv_conn)
+
+      assert invoice["automatic_tax"]["enabled"] == true
+      assert invoice["subtotal"] == 19_800
+      assert invoice["tax"] == 1485
+      assert invoice["total_details"]["amount_tax"] == 1485
+      assert invoice["total"] == 21_285
+      assert invoice["amount_due"] == 21_285
+      assert invoice["amount_remaining"] == 21_285
+
+      [line] = invoice["lines"]["data"]
+      assert line["amount"] == 19_800
+      assert [%{"amount" => 1485, "taxable_amount" => 19_800}] = line["tax_amounts"]
+      assert [%{"amount" => 1485, "tax_behavior" => "exclusive", "taxable_amount" => 19_800}] = line["taxes"]
+
+      pi_conn = request(:get, "/v1/payment_intents/#{invoice["payment_intent"]}", %{})
+      pi = json_response(pi_conn)
+      assert pi["amount"] == 21_285
+    end
+
     test "expands latest_invoice.payment_intent", %{customer: customer, price: price} do
       sub_conn =
         request(:post, "/v1/subscriptions", %{


### PR DESCRIPTION
## Summary

- add a scoped `PaperTiger.AutomaticTax` fixture helper for deterministic automatic-tax totals
- apply automatic tax to Checkout Session totals and resulting PaymentIntent amounts
- apply automatic tax to default-incomplete subscription invoices and renewal invoices
- include current Stripe-style line `taxes` fields while preserving existing `tax_amounts` compatibility
- add focused unit and regression coverage

Closes #66

## Validation

- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix test --warnings-as-errors`
- `mix credo --strict --all`
- `mix dialyzer --format short`