### PR TITLE
Add PaymentIntent cancel and capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI quality checks now include Elixir `1.20.0-rc.5`, and the package version requirement accepts the `1.20` release-candidate line.
 - Side-by-side contract drift harness for running a scenario against both PaperTiger and Stripe test mode in the same test, normalizing volatile fields, and reporting the first mismatch with both backend shapes. The first live drift scenario covers customer create/retrieve/update/delete.
 - Deterministic automatic-tax fixtures for Checkout Session totals, PaymentIntent amounts, initial subscription invoices, and subscription renewal invoices.
+- PaymentIntent lifecycle endpoints for `POST /v1/payment_intents/:id/cancel` and `POST /v1/payment_intents/:id/capture`, including manual-capture authorization, partial capture, `amount_capturable` / `amount_received`, captured Charge state, and Stripe-shaped invalid-state errors.
 
 ### Fixed
 

--- a/lib/paper_tiger/billing_engine.ex
+++ b/lib/paper_tiger/billing_engine.ex
@@ -373,6 +373,10 @@ defmodule PaperTiger.BillingEngine do
     # Create payment intent
     payment_intent = %{
       amount: amount,
+      amount_capturable: 0,
+      amount_received: amount,
+      canceled_at: nil,
+      cancellation_reason: nil,
       created: now,
       currency: invoice.currency,
       customer: invoice.customer,
@@ -415,6 +419,10 @@ defmodule PaperTiger.BillingEngine do
     # Create failed payment intent
     payment_intent = %{
       amount: invoice.amount_due,
+      amount_capturable: 0,
+      amount_received: 0,
+      canceled_at: nil,
+      cancellation_reason: nil,
       created: now,
       currency: invoice.currency,
       customer: invoice.customer,
@@ -439,6 +447,7 @@ defmodule PaperTiger.BillingEngine do
     # Create failed charge
     charge = %{
       amount: invoice.amount_due,
+      amount_captured: 0,
       captured: false,
       created: now,
       currency: invoice.currency,

--- a/lib/paper_tiger/charge_helper.ex
+++ b/lib/paper_tiger/charge_helper.ex
@@ -23,15 +23,18 @@ defmodule PaperTiger.ChargeHelper do
   6. Fires telemetry
   7. Returns `{:ok, charge}`
   """
-  @spec create_for_payment_intent(map()) :: {:ok, map()}
-  def create_for_payment_intent(payment_intent) do
-    charge = build_charge(payment_intent)
+  @spec create_for_payment_intent(map(), keyword()) :: {:ok, map()}
+  def create_for_payment_intent(payment_intent, opts \\ []) do
+    captured? = Keyword.get(opts, :captured, true)
+    charge = build_charge(payment_intent, captured?)
     {:ok, charge} = Charges.insert(charge)
 
-    # Create balance transaction and link it to the charge
-    {:ok, txn_id} = BalanceTransactionHelper.create_for_charge(charge)
-    charge = Map.put(charge, :balance_transaction, txn_id)
-    {:ok, charge} = Charges.update(charge)
+    {:ok, charge} =
+      if captured? do
+        create_balance_transaction(charge, Map.get(charge, :amount, 0))
+      else
+        {:ok, charge}
+      end
 
     # Update the PI with latest_charge
     updated_pi = Map.put(payment_intent, :latest_charge, charge.id)
@@ -42,13 +45,52 @@ defmodule PaperTiger.ChargeHelper do
     {:ok, charge}
   end
 
-  defp build_charge(pi) do
+  @doc """
+  Captures an authorized PaymentIntent charge and links the resulting balance transaction.
+  """
+  @spec capture_payment_intent_charge(map(), integer(), boolean()) :: {:ok, map()} | {:error, :not_found}
+  def capture_payment_intent_charge(payment_intent, amount_to_capture, final_capture?) do
+    with {:ok, charge} <- get_or_create_payment_intent_charge(payment_intent) do
+      amount_captured = Map.get(charge, :amount_captured, 0) + amount_to_capture
+
+      charge =
+        charge
+        |> Map.put(:amount_captured, amount_captured)
+        |> Map.put(:captured, final_capture?)
+        |> Map.put(:status, "succeeded")
+
+      create_balance_transaction(charge, amount_to_capture)
+    end
+  end
+
+  defp get_or_create_payment_intent_charge(%{latest_charge: charge_id}) when is_binary(charge_id) do
+    Charges.get(charge_id)
+  end
+
+  defp get_or_create_payment_intent_charge(payment_intent) do
+    create_for_payment_intent(payment_intent, captured: false)
+  end
+
+  defp create_balance_transaction(charge, amount) do
+    # The stored Charge keeps the authorization amount; the balance transaction
+    # records the amount actually captured in this operation.
+    {:ok, txn_id} = charge |> Map.put(:amount, amount) |> BalanceTransactionHelper.create_for_charge()
+
+    charge
+    |> Map.put(:balance_transaction, txn_id)
+    |> Charges.update()
+  end
+
+  defp build_charge(pi, captured?) do
+    amount = Map.get(pi, :amount, 0)
+
     %{
-      amount: Map.get(pi, :amount, 0),
+      amount: amount,
+      amount_captured: if(captured?, do: amount, else: 0),
       amount_refunded: 0,
       balance_transaction: nil,
       billing_details: nil,
-      captured: true,
+      captured: captured?,
       created: PaperTiger.now(),
       currency: Map.get(pi, :currency),
       customer: Map.get(pi, :customer),

--- a/lib/paper_tiger/resources/charge.ex
+++ b/lib/paper_tiger/resources/charge.ex
@@ -155,8 +155,11 @@ defmodule PaperTiger.Resources.Charge do
   end
 
   defp build_charge(params) do
+    amount = get_integer(params, :amount)
+
     %{
-      amount: get_integer(params, :amount),
+      amount: amount,
+      amount_captured: get_integer(params, :amount_captured, amount),
       amount_refunded: get_integer(params, :amount_refunded),
       balance_transaction: nil,
       billing_details: Map.get(params, :billing_details),

--- a/lib/paper_tiger/resources/checkout_session.ex
+++ b/lib/paper_tiger/resources/checkout_session.ex
@@ -491,9 +491,12 @@ defmodule PaperTiger.Resources.CheckoutSession do
 
     payment_intent = %{
       amount: amount,
+      amount_capturable: 0,
       amount_details: nil,
+      amount_received: amount,
       application: nil,
       application_fee_amount: nil,
+      canceled_at: nil,
       cancellation_reason: nil,
       capture_method: "automatic",
       client_secret: generate_client_secret(),

--- a/lib/paper_tiger/resources/payment_intent.ex
+++ b/lib/paper_tiger/resources/payment_intent.ex
@@ -6,8 +6,11 @@ defmodule PaperTiger.Resources.PaymentIntent do
 
   - POST   /v1/payment_intents      - Create payment intent
   - GET    /v1/payment_intents/:id  - Retrieve payment intent
-  - POST   /v1/payment_intents/:id  - Update payment intent
-  - GET    /v1/payment_intents      - List payment intents
+  - POST   /v1/payment_intents/:id          - Update payment intent
+  - GET    /v1/payment_intents              - List payment intents
+  - POST   /v1/payment_intents/:id/confirm  - Confirm payment intent
+  - POST   /v1/payment_intents/:id/cancel   - Cancel payment intent
+  - POST   /v1/payment_intents/:id/capture  - Capture manual payment intent
 
   Note: Payment intents cannot be deleted (only canceled).
 
@@ -30,6 +33,9 @@ defmodule PaperTiger.Resources.PaymentIntent do
   import PaperTiger.Resource
 
   alias PaperTiger.Store.PaymentIntents
+
+  @cancelable_statuses ~w(requires_payment_method requires_capture requires_confirmation requires_action processing)
+  @cancellation_reasons ~w(duplicate fraudulent requested_by_customer abandoned)
 
   @doc """
   Creates a new payment intent.
@@ -139,7 +145,8 @@ defmodule PaperTiger.Resources.PaymentIntent do
 
   @doc """
   Confirms a payment intent, transitioning it to "succeeded" and creating
-  a charge + balance transaction.
+  a charge + balance transaction for automatic capture or an uncaptured charge
+  for manual capture.
   """
   @spec confirm(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
   def confirm(conn, id) do
@@ -157,13 +164,26 @@ defmodule PaperTiger.Resources.PaymentIntent do
           _ -> pi
         end
 
-      updated = %{updated | status: "succeeded"}
-      # Additional fields
+      manual_capture? = updated.capture_method == "manual"
+
+      updated =
+        updated
+        |> Map.put(:status, if(manual_capture?, do: "requires_capture", else: "succeeded"))
+        |> Map.put(:amount_capturable, if(manual_capture?, do: updated.amount, else: 0))
+        |> Map.put(:amount_received, if(manual_capture?, do: 0, else: updated.amount))
+
       {:ok, updated} = PaymentIntents.update(updated)
-      {:ok, _charge} = PaperTiger.ChargeHelper.create_for_payment_intent(updated)
+      {:ok, _charge} = PaperTiger.ChargeHelper.create_for_payment_intent(updated, captured: not manual_capture?)
       {:ok, final} = PaymentIntents.get(id)
 
-      :telemetry.execute([:paper_tiger, :payment_intent, :succeeded], %{}, %{object: final})
+      event =
+        if manual_capture? do
+          [:paper_tiger, :payment_intent, :requires_capture]
+        else
+          [:paper_tiger, :payment_intent, :succeeded]
+        end
+
+      :telemetry.execute(event, %{}, %{object: final})
 
       final
       |> maybe_expand(conn.params)
@@ -183,17 +203,149 @@ defmodule PaperTiger.Resources.PaymentIntent do
     end
   end
 
+  @doc """
+  Cancels a payment intent that has not reached a terminal successful state.
+  """
+  @spec cancel(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def cancel(conn, id) do
+    with {:ok, pi} <- PaymentIntents.get(id),
+         :ok <- validate_cancelable(pi),
+         {:ok, cancellation_reason} <- validate_cancellation_reason(Map.get(conn.params, :cancellation_reason)) do
+      canceled =
+        pi
+        |> Map.put(:status, "canceled")
+        |> Map.put(:canceled_at, PaperTiger.now())
+        |> Map.put(:cancellation_reason, cancellation_reason)
+        |> Map.put(:amount_capturable, 0)
+
+      {:ok, canceled} = PaymentIntents.update(canceled)
+
+      :telemetry.execute([:paper_tiger, :payment_intent, :canceled], %{}, %{object: canceled})
+
+      canceled
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("payment_intent", id))
+
+      {:error, :not_cancelable, status} ->
+        error_response(
+          conn,
+          PaperTiger.Error.invalid_request(
+            "This PaymentIntent's status (#{status}) does not allow cancellation.",
+            "status"
+          )
+        )
+
+      {:error, :invalid_cancellation_reason, reason} ->
+        error_response(
+          conn,
+          PaperTiger.Error.invalid_request(
+            "Invalid cancellation_reason: #{reason}",
+            "cancellation_reason"
+          )
+        )
+    end
+  end
+
+  @doc """
+  Captures a payment intent confirmed with capture_method=manual.
+  """
+  @spec capture(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def capture(conn, id) do
+    with {:ok, pi} <- PaymentIntents.get(id),
+         :ok <- validate_capturable(pi),
+         {:ok, amount_to_capture} <- parse_amount_to_capture(conn.params, pi),
+         final_capture? = final_capture?(conn.params),
+         remaining_capturable = pi.amount_capturable - amount_to_capture,
+         final_capture? = final_capture? or remaining_capturable == 0,
+         {:ok, _charge} <-
+           PaperTiger.ChargeHelper.capture_payment_intent_charge(pi, amount_to_capture, final_capture?) do
+      captured =
+        pi
+        |> Map.put(:amount_capturable, if(final_capture?, do: 0, else: remaining_capturable))
+        |> Map.put(:amount_received, Map.get(pi, :amount_received, 0) + amount_to_capture)
+        |> Map.put(:status, if(final_capture?, do: "succeeded", else: "requires_capture"))
+
+      {:ok, captured} = PaymentIntents.update(captured)
+
+      if captured.status == "succeeded" do
+        :telemetry.execute([:paper_tiger, :payment_intent, :succeeded], %{}, %{object: captured})
+      end
+
+      captured
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("payment_intent", id))
+
+      {:error, :not_capturable, status} ->
+        error_response(
+          conn,
+          PaperTiger.Error.invalid_request(
+            "This PaymentIntent's status (#{status}) does not allow capture.",
+            "status"
+          )
+        )
+
+      {:error, :invalid_capture_amount, message} ->
+        error_response(conn, PaperTiger.Error.invalid_request(message, "amount_to_capture"))
+    end
+  end
+
   defp validate_confirmable(%{status: status}) when status in ["requires_payment_method", "requires_confirmation"],
     do: :ok
 
   defp validate_confirmable(%{status: status}), do: {:error, :not_confirmable, status}
 
+  defp validate_cancelable(%{status: status}) when status in @cancelable_statuses, do: :ok
+  defp validate_cancelable(%{status: status}), do: {:error, :not_cancelable, status}
+
+  defp validate_capturable(%{amount_capturable: amount, status: "requires_capture"}) when amount > 0, do: :ok
+  defp validate_capturable(%{status: status}), do: {:error, :not_capturable, status}
+
+  defp validate_cancellation_reason(nil), do: {:ok, nil}
+  defp validate_cancellation_reason(reason) when reason in @cancellation_reasons, do: {:ok, reason}
+  defp validate_cancellation_reason(reason), do: {:error, :invalid_cancellation_reason, reason}
+
+  defp parse_amount_to_capture(params, pi) do
+    amount_capturable = Map.get(pi, :amount_capturable, 0)
+    amount_to_capture = get_integer(params, :amount_to_capture, amount_capturable)
+
+    cond do
+      amount_to_capture <= 0 ->
+        {:error, :invalid_capture_amount, "Amount to capture must be greater than zero"}
+
+      amount_to_capture > amount_capturable ->
+        {:error, :invalid_capture_amount, "Amount to capture exceeds the capturable amount"}
+
+      true ->
+        {:ok, amount_to_capture}
+    end
+  end
+
+  defp final_capture?(params) do
+    case Map.get(params, :final_capture) do
+      nil -> true
+      true -> true
+      "true" -> true
+      false -> false
+      "false" -> false
+      _ -> false
+    end
+  end
+
   defp build_payment_intent(params) do
     %{
       amount: get_integer(params, :amount),
+      amount_capturable: 0,
       amount_details: Map.get(params, :amount_details),
+      amount_received: 0,
       application: nil,
       application_fee_amount: nil,
+      canceled_at: nil,
       cancellation_reason: nil,
       capture_method: Map.get(params, :capture_method, "automatic"),
       client_secret: generate_client_secret(),

--- a/lib/paper_tiger/resources/subscription.ex
+++ b/lib/paper_tiger/resources/subscription.ex
@@ -826,6 +826,10 @@ defmodule PaperTiger.Resources.Subscription do
 
       pi = %{
         amount: total,
+        amount_capturable: 0,
+        amount_received: amount_paid,
+        canceled_at: nil,
+        cancellation_reason: nil,
         capture_method: "automatic",
         client_secret: client_secret,
         confirmation_method: "automatic",

--- a/lib/paper_tiger/router.ex
+++ b/lib/paper_tiger/router.ex
@@ -207,9 +207,17 @@ defmodule PaperTiger.Router do
 
   stripe_resource("invoices", Invoice, [])
   stripe_resource("payment_methods", PaymentMethod, [])
-  # Custom payment intent endpoint — must come BEFORE stripe_resource
+  # Custom payment intent endpoints — must come BEFORE stripe_resource
   post "/v1/payment_intents/:id/confirm" do
     PaymentIntent.confirm(conn, id)
+  end
+
+  post "/v1/payment_intents/:id/cancel" do
+    PaymentIntent.cancel(conn, id)
+  end
+
+  post "/v1/payment_intents/:id/capture" do
+    PaymentIntent.capture(conn, id)
   end
 
   stripe_resource("payment_intents", PaymentIntent, except: [:delete])

--- a/test/paper_tiger/charge_helper_test.exs
+++ b/test/paper_tiger/charge_helper_test.exs
@@ -12,9 +12,12 @@ defmodule PaperTiger.ChargeHelperTest do
     Map.merge(
       %{
         amount: 2000,
+        amount_capturable: 0,
         amount_details: nil,
+        amount_received: 2000,
         application: nil,
         application_fee_amount: nil,
+        canceled_at: nil,
         cancellation_reason: nil,
         capture_method: "automatic",
         client_secret: "pi_secret_test",
@@ -59,6 +62,7 @@ defmodule PaperTiger.ChargeHelperTest do
       assert String.starts_with?(charge.id, "ch_")
       assert charge.object == "charge"
       assert charge.amount == 2000
+      assert charge.amount_captured == 2000
       assert charge.currency == "usd"
       assert charge.customer == "cus_test123"
       assert charge.payment_method == "pm_test456"
@@ -94,6 +98,54 @@ defmodule PaperTiger.ChargeHelperTest do
 
       {:ok, updated_pi} = PaymentIntents.get(pi.id)
       assert updated_pi.latest_charge == charge.id
+    end
+
+    test "creates uncaptured charge for manual capture payment intent" do
+      pi =
+        build_payment_intent(%{
+          amount_capturable: 2000,
+          amount_received: 0,
+          capture_method: "manual",
+          status: "requires_capture"
+        })
+
+      {:ok, pi} = PaymentIntents.insert(pi)
+
+      {:ok, charge} = ChargeHelper.create_for_payment_intent(pi, captured: false)
+
+      assert charge.amount == 2000
+      assert charge.amount_captured == 0
+      assert charge.captured == false
+      assert charge.balance_transaction == nil
+
+      {:ok, updated_pi} = PaymentIntents.get(pi.id)
+      assert updated_pi.latest_charge == charge.id
+    end
+
+    test "captures an authorized payment intent charge" do
+      pi =
+        build_payment_intent(%{
+          amount_capturable: 2000,
+          amount_received: 0,
+          capture_method: "manual",
+          status: "requires_capture"
+        })
+
+      {:ok, pi} = PaymentIntents.insert(pi)
+      {:ok, charge} = ChargeHelper.create_for_payment_intent(pi, captured: false)
+      {:ok, pi} = PaymentIntents.get(pi.id)
+
+      {:ok, captured_charge} = ChargeHelper.capture_payment_intent_charge(pi, 1500, true)
+
+      assert captured_charge.id == charge.id
+      assert captured_charge.amount == 2000
+      assert captured_charge.amount_captured == 1500
+      assert captured_charge.captured == true
+      assert captured_charge.balance_transaction != nil
+
+      {:ok, txn} = BalanceTransactions.get(captured_charge.balance_transaction)
+      assert txn.amount == 1500
+      assert txn.source == charge.id
     end
 
     test "charge inherits invoice field from PI when present" do

--- a/test/paper_tiger/contract/payment_intent_chain_test.exs
+++ b/test/paper_tiger/contract/payment_intent_chain_test.exs
@@ -10,7 +10,7 @@ defmodule PaperTiger.Contract.PaymentIntentChainTest do
       VALIDATE_AGAINST_STRIPE=true STRIPE_API_KEY=sk_test_xxx mix test test/paper_tiger/contract/payment_intent_chain_test.exs
   """
 
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   import PaperTiger.Test
 
@@ -26,40 +26,14 @@ defmodule PaperTiger.Contract.PaymentIntentChainTest do
 
   describe "PaymentIntent confirm creates full chain" do
     test "confirm produces Charge with BalanceTransaction" do
-      # Create customer
-      {:ok, customer} = TestClient.create_customer(%{"email" => "chain-test@example.com"})
+      pm_id = "pm_card_visa"
 
-      # Create PI with payment method
-      # Real Stripe: use pm_card_visa token (avoids raw card number restrictions)
-      # PaperTiger: create a PM and attach it
-      {pm_id, pi_params} =
-        if TestClient.real_stripe?() do
-          {"pm_card_visa",
-           %{
-             "amount" => 2500,
-             "currency" => "usd",
-             "customer" => customer["id"],
-             "payment_method" => "pm_card_visa",
-             "payment_method_types" => ["card"]
-           }}
-        else
-          {:ok, pm} =
-            TestClient.create_payment_method(%{
-              "card" => TestClient.test_card_simple(),
-              "type" => "card"
-            })
-
-          {:ok, _} =
-            TestClient.attach_payment_method(pm["id"], %{"customer" => customer["id"]})
-
-          {pm["id"],
-           %{
-             "amount" => 2500,
-             "currency" => "usd",
-             "customer" => customer["id"],
-             "payment_method" => pm["id"]
-           }}
-        end
+      pi_params = %{
+        "amount" => 2500,
+        "currency" => "usd",
+        "payment_method" => pm_id,
+        "payment_method_types" => ["card"]
+      }
 
       {:ok, pi} = TestClient.create_payment_intent(pi_params)
 
@@ -85,6 +59,61 @@ defmodule PaperTiger.Contract.PaymentIntentChainTest do
       assert bt["amount"] == 2500
       assert bt["type"] == "charge"
       assert bt["source"] == charge["id"]
+    end
+  end
+
+  describe "PaymentIntent lifecycle endpoints" do
+    test "cancel transitions a pre-confirmation intent to canceled" do
+      {:ok, pi} =
+        TestClient.create_payment_intent(%{
+          "amount" => 1300,
+          "currency" => "usd"
+        })
+
+      {:ok, canceled} =
+        TestClient.cancel_payment_intent(pi["id"], %{
+          "cancellation_reason" => "requested_by_customer"
+        })
+
+      assert canceled["id"] == pi["id"]
+      assert canceled["status"] == "canceled"
+      assert canceled["cancellation_reason"] == "requested_by_customer"
+      assert canceled["amount_capturable"] == 0
+      assert is_integer(canceled["canceled_at"])
+    end
+
+    test "manual capture supports final partial capture and captured charge state" do
+      {:ok, pi} =
+        TestClient.create_payment_intent(%{
+          "amount" => 2500,
+          "capture_method" => "manual",
+          "currency" => "usd",
+          "payment_method" => "pm_card_visa",
+          "payment_method_types" => ["card"]
+        })
+
+      {:ok, authorized} =
+        TestClient.confirm_payment_intent(pi["id"], %{
+          "payment_method" => "pm_card_visa"
+        })
+
+      assert authorized["status"] == "requires_capture"
+      assert authorized["amount_capturable"] == 2500
+      assert authorized["amount_received"] == 0
+      assert authorized["latest_charge"] != nil
+
+      {:ok, captured} =
+        TestClient.capture_payment_intent(pi["id"], %{
+          "amount_to_capture" => 1800
+        })
+
+      assert captured["status"] == "succeeded"
+      assert captured["amount_capturable"] == 0
+      assert captured["amount_received"] == 1800
+
+      {:ok, charge} = TestClient.get_charge(captured["latest_charge"])
+      assert charge["captured"] == true
+      assert charge["amount_captured"] == 1800
     end
   end
 end

--- a/test/paper_tiger/resources/payment_intent_confirm_test.exs
+++ b/test/paper_tiger/resources/payment_intent_confirm_test.exs
@@ -74,6 +74,8 @@ defmodule PaperTiger.Resources.PaymentIntentConfirmTest do
       confirmed = json_response(confirm_conn)
       assert confirmed["id"] == pi_id
       assert confirmed["status"] == "succeeded"
+      assert confirmed["amount_capturable"] == 0
+      assert confirmed["amount_received"] == 5000
       assert confirmed["latest_charge"] != nil
       assert String.starts_with?(confirmed["latest_charge"], "ch_")
 
@@ -85,6 +87,8 @@ defmodule PaperTiger.Resources.PaymentIntentConfirmTest do
       assert ch["currency"] == "usd"
       assert ch["payment_intent"] == pi_id
       assert ch["status"] == "succeeded"
+      assert ch["captured"] == true
+      assert ch["amount_captured"] == 5000
       assert ch["customer"] == customer_id
       assert ch["payment_method"] == pm_id
 

--- a/test/paper_tiger/resources/payment_intent_lifecycle_test.exs
+++ b/test/paper_tiger/resources/payment_intent_lifecycle_test.exs
@@ -1,0 +1,200 @@
+defmodule PaperTiger.Resources.PaymentIntentLifecycleTest do
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
+
+  alias PaperTiger.Router
+
+  setup :checkout_paper_tiger
+
+  defp request(method, path, params \\ %{}) do
+    conn = Plug.Test.conn(method, path, params)
+
+    [{"content-type", "application/json"}, {"authorization", "Bearer sk_test_pi_lifecycle_key"}]
+    |> Kernel.++(sandbox_headers())
+    |> Enum.reduce(conn, fn {key, value}, acc -> Plug.Conn.put_req_header(acc, key, value) end)
+    |> Router.call([])
+  end
+
+  defp json_response(conn), do: Jason.decode!(conn.resp_body)
+
+  describe "POST /v1/payment_intents/:id/cancel" do
+    test "cancels a pre-confirmation payment intent with a cancellation reason" do
+      create_conn =
+        request(:post, "/v1/payment_intents", %{
+          "amount" => 2400,
+          "currency" => "usd"
+        })
+
+      pi = json_response(create_conn)
+
+      cancel_conn =
+        request(:post, "/v1/payment_intents/#{pi["id"]}/cancel", %{
+          "cancellation_reason" => "requested_by_customer"
+        })
+
+      assert cancel_conn.status == 200
+      canceled = json_response(cancel_conn)
+      assert canceled["status"] == "canceled"
+      assert canceled["cancellation_reason"] == "requested_by_customer"
+      assert canceled["amount_capturable"] == 0
+      assert is_integer(canceled["canceled_at"])
+    end
+
+    test "returns a Stripe-shaped error when canceling a succeeded payment intent" do
+      pi =
+        request(:post, "/v1/payment_intents", %{"amount" => 2400, "currency" => "usd"})
+        |> json_response()
+
+      assert request(:post, "/v1/payment_intents/#{pi["id"]}/confirm").status == 200
+
+      cancel_conn = request(:post, "/v1/payment_intents/#{pi["id"]}/cancel")
+
+      assert cancel_conn.status == 400
+      error = json_response(cancel_conn)["error"]
+      assert error["type"] == "invalid_request_error"
+      assert error["param"] == "status"
+      assert error["message"] =~ "does not allow cancellation"
+    end
+  end
+
+  describe "POST /v1/payment_intents/:id/capture" do
+    test "manual confirmation authorizes and full capture succeeds the payment intent" do
+      confirmed = create_and_confirm_manual_payment_intent(5000)
+
+      assert confirmed["status"] == "requires_capture"
+      assert confirmed["amount_capturable"] == 5000
+      assert confirmed["amount_received"] == 0
+      assert confirmed["latest_charge"] != nil
+
+      uncaptured_charge =
+        request(:get, "/v1/charges/#{confirmed["latest_charge"]}")
+        |> json_response()
+
+      assert uncaptured_charge["captured"] == false
+      assert uncaptured_charge["amount_captured"] == 0
+      assert uncaptured_charge["balance_transaction"] == nil
+
+      capture_conn = request(:post, "/v1/payment_intents/#{confirmed["id"]}/capture")
+
+      assert capture_conn.status == 200
+      captured = json_response(capture_conn)
+      assert captured["status"] == "succeeded"
+      assert captured["amount_capturable"] == 0
+      assert captured["amount_received"] == 5000
+
+      captured_charge =
+        request(:get, "/v1/charges/#{captured["latest_charge"]}")
+        |> json_response()
+
+      assert captured_charge["captured"] == true
+      assert captured_charge["amount_captured"] == 5000
+      assert captured_charge["balance_transaction"] != nil
+    end
+
+    test "supports non-final partial capture followed by final capture" do
+      confirmed = create_and_confirm_manual_payment_intent(5000)
+
+      partial_conn =
+        request(:post, "/v1/payment_intents/#{confirmed["id"]}/capture", %{
+          "amount_to_capture" => 1800,
+          "final_capture" => false
+        })
+
+      assert partial_conn.status == 200
+      partial = json_response(partial_conn)
+      assert partial["status"] == "requires_capture"
+      assert partial["amount_capturable"] == 3200
+      assert partial["amount_received"] == 1800
+
+      partially_captured_charge =
+        request(:get, "/v1/charges/#{partial["latest_charge"]}")
+        |> json_response()
+
+      assert partially_captured_charge["captured"] == false
+      assert partially_captured_charge["amount_captured"] == 1800
+
+      final_conn = request(:post, "/v1/payment_intents/#{confirmed["id"]}/capture")
+
+      assert final_conn.status == 200
+      final = json_response(final_conn)
+      assert final["status"] == "succeeded"
+      assert final["amount_capturable"] == 0
+      assert final["amount_received"] == 5000
+
+      captured_charge =
+        request(:get, "/v1/charges/#{final["latest_charge"]}")
+        |> json_response()
+
+      assert captured_charge["captured"] == true
+      assert captured_charge["amount_captured"] == 5000
+    end
+
+    test "supports final partial capture and releases the remaining amount" do
+      confirmed = create_and_confirm_manual_payment_intent(5000)
+
+      capture_conn =
+        request(:post, "/v1/payment_intents/#{confirmed["id"]}/capture", %{
+          "amount_to_capture" => 1800
+        })
+
+      assert capture_conn.status == 200
+      captured = json_response(capture_conn)
+      assert captured["status"] == "succeeded"
+      assert captured["amount_capturable"] == 0
+      assert captured["amount_received"] == 1800
+
+      captured_charge =
+        request(:get, "/v1/charges/#{captured["latest_charge"]}")
+        |> json_response()
+
+      assert captured_charge["captured"] == true
+      assert captured_charge["amount_captured"] == 1800
+    end
+
+    test "returns a Stripe-shaped error when capture amount exceeds capturable amount" do
+      confirmed = create_and_confirm_manual_payment_intent(5000)
+
+      capture_conn =
+        request(:post, "/v1/payment_intents/#{confirmed["id"]}/capture", %{
+          "amount_to_capture" => 5001
+        })
+
+      assert capture_conn.status == 400
+      error = json_response(capture_conn)["error"]
+      assert error["type"] == "invalid_request_error"
+      assert error["param"] == "amount_to_capture"
+      assert error["message"] =~ "exceeds the capturable amount"
+    end
+
+    test "returns a Stripe-shaped error when capturing an automatic payment intent" do
+      pi =
+        request(:post, "/v1/payment_intents", %{"amount" => 5000, "currency" => "usd"})
+        |> json_response()
+
+      request(:post, "/v1/payment_intents/#{pi["id"]}/confirm")
+
+      capture_conn = request(:post, "/v1/payment_intents/#{pi["id"]}/capture")
+
+      assert capture_conn.status == 400
+      error = json_response(capture_conn)["error"]
+      assert error["type"] == "invalid_request_error"
+      assert error["param"] == "status"
+      assert error["message"] =~ "does not allow capture"
+    end
+  end
+
+  defp create_and_confirm_manual_payment_intent(amount) do
+    pi =
+      request(:post, "/v1/payment_intents", %{
+        "amount" => amount,
+        "capture_method" => "manual",
+        "currency" => "usd",
+        "payment_method" => "pm_card_visa"
+      })
+      |> json_response()
+
+    request(:post, "/v1/payment_intents/#{pi["id"]}/confirm")
+    |> json_response()
+  end
+end

--- a/test/support/test_client.ex
+++ b/test/support/test_client.ex
@@ -607,6 +607,32 @@ defmodule PaperTiger.TestClient do
     end
   end
 
+  @doc """
+  Cancels a payment intent.
+  """
+  def cancel_payment_intent(payment_intent_id, params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        cancel_payment_intent_real(payment_intent_id, params)
+
+      :paper_tiger ->
+        cancel_payment_intent_mock(payment_intent_id, params)
+    end
+  end
+
+  @doc """
+  Captures a manual-capture payment intent.
+  """
+  def capture_payment_intent(payment_intent_id, params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        capture_payment_intent_real(payment_intent_id, params)
+
+      :paper_tiger ->
+        capture_payment_intent_mock(payment_intent_id, params)
+    end
+  end
+
   ## Refund Operations
 
   @doc """
@@ -792,6 +818,47 @@ defmodule PaperTiger.TestClient do
 
   defp stripe_opts do
     [api_key: System.get_env("STRIPE_API_KEY")]
+  end
+
+  defp stripe_request(method, path, params \\ %{}) do
+    url = "https://api.stripe.com#{path}"
+
+    headers = [
+      {"authorization", "Bearer #{System.get_env("STRIPE_API_KEY")}"},
+      {"content-type", "application/x-www-form-urlencoded"}
+    ]
+
+    req_opts =
+      case method do
+        :get ->
+          [
+            headers: headers,
+            params: params
+          ]
+
+        :post ->
+          [
+            body: params_to_form_data(params),
+            headers: headers
+          ]
+      end
+
+    case apply(Req, method, [url, req_opts]) do
+      {:ok, %{body: body, status: status}} when status in 200..299 ->
+        {:ok, body}
+
+      {:ok, %{body: body}} ->
+        {:error, body}
+
+      {:error, reason} ->
+        {:error,
+         %{
+           "error" => %{
+             "message" => "An error occurred while making the network request. Reason: #{inspect(reason)}",
+             "type" => "network_error"
+           }
+         }}
+    end
   end
 
   defp create_customer_real(params) do
@@ -1002,38 +1069,31 @@ defmodule PaperTiger.TestClient do
   end
 
   defp get_charge_real(charge_id) do
-    case Stripe.Charge.retrieve(charge_id, %{}, stripe_opts()) do
-      {:ok, charge} -> {:ok, stripe_to_map(charge)}
-      {:error, error} -> {:error, stripe_error_to_map(error)}
-    end
+    stripe_request(:get, "/v1/charges/#{charge_id}")
   end
 
   defp create_payment_intent_real(params) do
-    case Stripe.PaymentIntent.create(normalize_params(params), stripe_opts()) do
-      {:ok, payment_intent} -> {:ok, stripe_to_map(payment_intent)}
-      {:error, error} -> {:error, stripe_error_to_map(error)}
-    end
+    stripe_request(:post, "/v1/payment_intents", params)
   end
 
   defp get_payment_intent_real(payment_intent_id) do
-    case Stripe.PaymentIntent.retrieve(payment_intent_id, %{}, stripe_opts()) do
-      {:ok, payment_intent} -> {:ok, stripe_to_map(payment_intent)}
-      {:error, error} -> {:error, stripe_error_to_map(error)}
-    end
+    stripe_request(:get, "/v1/payment_intents/#{payment_intent_id}")
   end
 
   defp confirm_payment_intent_real(payment_intent_id, params) do
-    case Stripe.PaymentIntent.confirm(payment_intent_id, normalize_params(params), stripe_opts()) do
-      {:ok, pi} -> {:ok, stripe_to_map(pi)}
-      {:error, error} -> {:error, stripe_error_to_map(error)}
-    end
+    stripe_request(:post, "/v1/payment_intents/#{payment_intent_id}/confirm", params)
+  end
+
+  defp cancel_payment_intent_real(payment_intent_id, params) do
+    stripe_request(:post, "/v1/payment_intents/#{payment_intent_id}/cancel", params)
+  end
+
+  defp capture_payment_intent_real(payment_intent_id, params) do
+    stripe_request(:post, "/v1/payment_intents/#{payment_intent_id}/capture", params)
   end
 
   defp get_balance_transaction_real(txn_id) do
-    case Stripe.BalanceTransaction.retrieve(txn_id, %{}, stripe_opts()) do
-      {:ok, txn} -> {:ok, stripe_to_map(txn)}
-      {:error, error} -> {:error, stripe_error_to_map(error)}
-    end
+    stripe_request(:get, "/v1/balance_transactions/#{txn_id}")
   end
 
   defp create_refund_real(params) do
@@ -1225,6 +1285,16 @@ defmodule PaperTiger.TestClient do
 
   defp confirm_payment_intent_mock(payment_intent_id, params) do
     conn = request(:post, "/v1/payment_intents/#{payment_intent_id}/confirm", params)
+    handle_response(conn)
+  end
+
+  defp cancel_payment_intent_mock(payment_intent_id, params) do
+    conn = request(:post, "/v1/payment_intents/#{payment_intent_id}/cancel", params)
+    handle_response(conn)
+  end
+
+  defp capture_payment_intent_mock(payment_intent_id, params) do
+    conn = request(:post, "/v1/payment_intents/#{payment_intent_id}/capture", params)
     handle_response(conn)
   end
 


### PR DESCRIPTION
## Summary
- add `POST /v1/payment_intents/:id/cancel` and `POST /v1/payment_intents/:id/capture`
- model manual-capture authorization, full capture, final partial capture, non-final partial capture, `amount_capturable`, `amount_received`, and captured Charge state
- add focused lifecycle tests plus dual-mode PaymentIntent contract coverage

## Validation
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict --all`
- `mix dialyzer`
- `mix test --warnings-as-errors`
- `STRIPE_API_KEY=<test key> VALIDATE_AGAINST_STRIPE=true mix test test/paper_tiger/contract/payment_intent_chain_test.exs`

Closes #60