### PR TITLE
Add SetupIntent lifecycle endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deterministic automatic-tax fixtures for Checkout Session totals, PaymentIntent amounts, initial subscription invoices, and subscription renewal invoices.
 - PaymentIntent lifecycle endpoints for `POST /v1/payment_intents/:id/cancel` and `POST /v1/payment_intents/:id/capture`, including manual-capture authorization, partial capture, `amount_capturable` / `amount_received`, captured Charge state, and Stripe-shaped invalid-state errors.
 - Checkout Session update and line-item retrieval endpoints, including metadata merge/delete semantics, paginated `GET /v1/checkout/sessions/:id/line_items`, `expand[]=line_items`, and preview-style full-array line item updates for dynamic Checkout tests.
+- SetupIntent lifecycle endpoints for `POST /v1/setup_intents/:id/confirm`, `POST /v1/setup_intents/:id/cancel`, `POST /v1/setup_intents/:id/verify_microdeposits`, and `GET /v1/setup_attempts`, including customer attachment for successful card setup, bank-account microdeposit verification, cancellation reasons, failed/abandoned/succeeded SetupAttempt records, and live Stripe contract coverage for confirm/cancel/list-attempts.
 
 ### Fixed
 

--- a/lib/paper_tiger.ex
+++ b/lib/paper_tiger.ex
@@ -60,6 +60,7 @@ defmodule PaperTiger do
     Products,
     Refunds,
     Reviews,
+    SetupAttempts,
     SetupIntents,
     Sources,
     SubscriptionItems,
@@ -223,6 +224,7 @@ defmodule PaperTiger do
   def flush(:plans), do: Plans.clear()
   def flush(:payment_methods), do: PaymentMethods.clear()
   def flush(:payment_intents), do: PaymentIntents.clear()
+  def flush(:setup_attempts), do: SetupAttempts.clear()
   def flush(:setup_intents), do: SetupIntents.clear()
   def flush(:charges), do: Charges.clear()
   def flush(:refunds), do: Refunds.clear()

--- a/lib/paper_tiger/application.ex
+++ b/lib/paper_tiger/application.ex
@@ -25,6 +25,7 @@ defmodule PaperTiger.Application do
   alias PaperTiger.Store.Products
   alias PaperTiger.Store.Refunds
   alias PaperTiger.Store.Reviews
+  alias PaperTiger.Store.SetupAttempts
   alias PaperTiger.Store.SetupIntents
   alias PaperTiger.Store.Sources
   alias PaperTiger.Store.SubscriptionItems
@@ -73,6 +74,7 @@ defmodule PaperTiger.Application do
         Charges,
         Refunds,
         PaymentIntents,
+        SetupAttempts,
         SetupIntents,
         SubscriptionItems,
         SubscriptionSchedules,

--- a/lib/paper_tiger/hydrator.ex
+++ b/lib/paper_tiger/hydrator.ex
@@ -48,6 +48,7 @@ defmodule PaperTiger.Hydrator do
   alias PaperTiger.Store.Products
   alias PaperTiger.Store.Refunds
   alias PaperTiger.Store.Reviews
+  alias PaperTiger.Store.SetupAttempts
   alias PaperTiger.Store.SetupIntents
   alias PaperTiger.Store.Sources
   alias PaperTiger.Store.SubscriptionItems
@@ -80,6 +81,7 @@ defmodule PaperTiger.Hydrator do
     Products,
     Refunds,
     Reviews,
+    SetupAttempts,
     SetupIntents,
     Sources,
     SubscriptionItems,

--- a/lib/paper_tiger/resources/setup_attempt.ex
+++ b/lib/paper_tiger/resources/setup_attempt.ex
@@ -1,0 +1,41 @@
+defmodule PaperTiger.Resources.SetupAttempt do
+  @moduledoc """
+  Handles SetupAttempt resource endpoints.
+
+  ## Endpoints
+
+  - GET /v1/setup_attempts - List setup attempts
+  """
+
+  import PaperTiger.Resource
+
+  alias PaperTiger.Store.SetupAttempts
+
+  @doc """
+  Lists setup attempts, usually filtered by setup_intent.
+  """
+  @spec list(Plug.Conn.t()) :: Plug.Conn.t()
+  def list(conn) do
+    pagination_opts = parse_pagination_params(conn.params)
+    setup_intent_id = Map.get(conn.params, :setup_intent)
+
+    setup_attempts =
+      if setup_intent_id do
+        SetupAttempts.find_by_setup_intent(setup_intent_id)
+      else
+        SetupAttempts.list(%{limit: 100}).data
+      end
+
+    result =
+      setup_attempts
+      |> PaperTiger.List.paginate(Map.put(pagination_opts, :url, "/v1/setup_attempts"))
+      |> maybe_expand(conn.params)
+
+    json_response(conn, 200, result)
+  end
+
+  defp maybe_expand(result, params) do
+    expand_params = parse_expand_params(params)
+    PaperTiger.Hydrator.hydrate(result, expand_params)
+  end
+end

--- a/lib/paper_tiger/resources/setup_intent.ex
+++ b/lib/paper_tiger/resources/setup_intent.ex
@@ -8,6 +8,9 @@ defmodule PaperTiger.Resources.SetupIntent do
   - GET    /v1/setup_intents/:id  - Retrieve setup intent
   - POST   /v1/setup_intents/:id  - Update setup intent
   - GET    /v1/setup_intents      - List setup intents
+  - POST   /v1/setup_intents/:id/confirm - Confirm setup intent
+  - POST   /v1/setup_intents/:id/cancel - Cancel setup intent
+  - POST   /v1/setup_intents/:id/verify_microdeposits - Verify bank microdeposits
 
   Note: Setup intents cannot be deleted (only canceled).
 
@@ -28,7 +31,15 @@ defmodule PaperTiger.Resources.SetupIntent do
 
   import PaperTiger.Resource
 
+  alias PaperTiger.Store.PaymentMethods
+  alias PaperTiger.Store.SetupAttempts
   alias PaperTiger.Store.SetupIntents
+
+  @cancelable_statuses ~w(requires_payment_method requires_confirmation requires_action)
+  @confirmable_statuses ~w(requires_payment_method requires_confirmation)
+  @cancellation_reasons ~w(abandoned duplicate requested_by_customer)
+  @microdeposit_amounts [32, 45]
+  @microdeposit_descriptor_code "SM11AA"
 
   @doc """
   Creates a new setup intent.
@@ -121,20 +132,505 @@ defmodule PaperTiger.Resources.SetupIntent do
     json_response(conn, 200, result)
   end
 
+  @doc """
+  Confirms a setup intent.
+
+  Compatible card payment methods transition to succeeded immediately. Bank
+  account methods transition to requires_action until microdeposits are verified.
+  """
+  @spec confirm(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def confirm(conn, id) do
+    with {:ok, setup_intent} <- SetupIntents.get(id),
+         :ok <- validate_confirmable(setup_intent),
+         {:ok, payment_method} <- resolve_payment_method(setup_intent, conn.params),
+         {:ok, confirmed} <- confirm_with_payment_method(setup_intent, payment_method, conn.params) do
+      confirmed
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("setup_intent", id))
+
+      {:error, :not_confirmable, status} ->
+        error_response(
+          conn,
+          PaperTiger.Error.invalid_request(
+            "This SetupIntent's status (#{status}) does not allow confirmation.",
+            "status"
+          )
+        )
+
+      {:error, :missing_payment_method} ->
+        error_response(
+          conn,
+          PaperTiger.Error.invalid_request(
+            "You cannot confirm this SetupIntent because it's missing a payment method.",
+            "payment_method"
+          )
+        )
+
+      {:error, :payment_method_not_found, payment_method_id} ->
+        error_response(conn, PaperTiger.Error.not_found("payment_method", payment_method_id))
+
+      {:error, :payment_method_attached_elsewhere} ->
+        error_response(
+          conn,
+          PaperTiger.Error.invalid_request(
+            "This PaymentMethod is already attached to a different customer.",
+            "payment_method"
+          )
+        )
+
+      {:error, :setup_failed, error} ->
+        error_response(conn, error)
+    end
+  end
+
+  @doc """
+  Cancels a setup intent that has not reached a terminal state.
+  """
+  @spec cancel(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def cancel(conn, id) do
+    with {:ok, setup_intent} <- SetupIntents.get(id),
+         :ok <- validate_cancelable(setup_intent),
+         {:ok, cancellation_reason} <- validate_cancellation_reason(Map.get(conn.params, :cancellation_reason)) do
+      canceled =
+        setup_intent
+        |> Map.put(:status, "canceled")
+        |> Map.put(:cancellation_reason, cancellation_reason)
+        |> Map.put(:next_action, nil)
+        |> abandon_latest_attempt()
+
+      {:ok, canceled} = SetupIntents.update(canceled)
+
+      :telemetry.execute([:paper_tiger, :setup_intent, :canceled], %{}, %{object: canceled})
+
+      canceled
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("setup_intent", id))
+
+      {:error, :not_cancelable, status} ->
+        error_response(
+          conn,
+          PaperTiger.Error.invalid_request(
+            "This SetupIntent's status (#{status}) does not allow cancellation.",
+            "status"
+          )
+        )
+
+      {:error, :invalid_cancellation_reason, reason} ->
+        error_response(
+          conn,
+          PaperTiger.Error.invalid_request(
+            "Invalid cancellation_reason: #{reason}",
+            "cancellation_reason"
+          )
+        )
+    end
+  end
+
+  @doc """
+  Verifies microdeposits for a bank-account setup intent.
+  """
+  @spec verify_microdeposits(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def verify_microdeposits(conn, id) do
+    with {:ok, setup_intent} <- SetupIntents.get(id),
+         :ok <- validate_microdeposit_verifiable(setup_intent),
+         :ok <- validate_microdeposit_params(conn.params),
+         {:ok, verified} <- verify_microdeposit_setup(setup_intent) do
+      verified
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("setup_intent", id))
+
+      {:error, :not_microdeposit_verifiable, status} ->
+        error_response(
+          conn,
+          PaperTiger.Error.invalid_request(
+            "This SetupIntent's status (#{status}) does not allow microdeposit verification.",
+            "status"
+          )
+        )
+
+      {:error, :missing_microdeposit_verification} ->
+        error_response(
+          conn,
+          PaperTiger.Error.invalid_request(
+            "You must provide either amounts or descriptor_code.",
+            nil
+          )
+        )
+
+      {:error, :invalid_microdeposit_verification, param} ->
+        error_response(
+          conn,
+          PaperTiger.Error.invalid_request(
+            "The provided microdeposit verification values do not match.",
+            param
+          )
+        )
+
+      {:error, :payment_method_not_found, payment_method_id} ->
+        error_response(conn, PaperTiger.Error.not_found("payment_method", payment_method_id))
+
+      {:error, :payment_method_attached_elsewhere} ->
+        error_response(
+          conn,
+          PaperTiger.Error.invalid_request(
+            "This PaymentMethod is already attached to a different customer.",
+            "payment_method"
+          )
+        )
+    end
+  end
+
   ## Private Functions
+  defp validate_confirmable(%{status: status}) when status in @confirmable_statuses, do: :ok
+  defp validate_confirmable(%{status: status}), do: {:error, :not_confirmable, status}
+
+  defp validate_cancelable(%{status: status}) when status in @cancelable_statuses, do: :ok
+  defp validate_cancelable(%{status: status}), do: {:error, :not_cancelable, status}
+
+  defp validate_cancellation_reason(nil), do: {:ok, nil}
+  defp validate_cancellation_reason(reason) when reason in @cancellation_reasons, do: {:ok, reason}
+  defp validate_cancellation_reason(reason), do: {:error, :invalid_cancellation_reason, reason}
+
+  defp validate_microdeposit_verifiable(%{status: status}) when status in ["requires_action", "processing"], do: :ok
+
+  defp validate_microdeposit_verifiable(%{status: status}), do: {:error, :not_microdeposit_verifiable, status}
+
+  defp validate_microdeposit_params(params) do
+    amounts = Map.get(params, :amounts)
+    descriptor_code = Map.get(params, :descriptor_code)
+
+    cond do
+      valid_microdeposit_amounts?(amounts) ->
+        :ok
+
+      valid_microdeposit_descriptor_code?(descriptor_code) ->
+        :ok
+
+      present?(amounts) ->
+        {:error, :invalid_microdeposit_verification, "amounts"}
+
+      present?(descriptor_code) ->
+        {:error, :invalid_microdeposit_verification, "descriptor_code"}
+
+      true ->
+        {:error, :missing_microdeposit_verification}
+    end
+  end
+
+  defp valid_microdeposit_amounts?(amounts) when is_list(amounts) do
+    amounts
+    |> Enum.map(&to_integer/1)
+    |> Enum.sort()
+    |> Kernel.==(@microdeposit_amounts)
+  end
+
+  defp valid_microdeposit_amounts?(_amounts), do: false
+
+  defp valid_microdeposit_descriptor_code?(descriptor_code) do
+    descriptor_code == @microdeposit_descriptor_code
+  end
+
+  defp present?(nil), do: false
+  defp present?(""), do: false
+  defp present?([]), do: false
+  defp present?(_value), do: true
+
+  defp resolve_payment_method(setup_intent, params) do
+    cond do
+      is_map(Map.get(params, :payment_method_data)) ->
+        create_payment_method_from_data(Map.get(params, :payment_method_data))
+
+      payment_method_id = Map.get(params, :payment_method) || setup_intent.payment_method ->
+        fetch_payment_method(payment_method_id)
+
+      true ->
+        {:error, :missing_payment_method}
+    end
+  end
+
+  defp fetch_payment_method(payment_method_id) when is_binary(payment_method_id) do
+    case PaymentMethods.get(payment_method_id) do
+      {:ok, payment_method} -> {:ok, payment_method}
+      {:error, :not_found} -> load_test_payment_method(payment_method_id)
+    end
+  end
+
+  defp fetch_payment_method(_payment_method), do: {:error, :missing_payment_method}
+
+  defp load_test_payment_method(payment_method_id) do
+    if payment_method_id in PaperTiger.TestTokens.payment_method_ids() do
+      {:ok, _stats} = PaperTiger.TestTokens.load()
+
+      case PaymentMethods.get(payment_method_id) do
+        {:ok, payment_method} -> {:ok, payment_method}
+        {:error, :not_found} -> {:error, :payment_method_not_found, payment_method_id}
+      end
+    else
+      {:error, :payment_method_not_found, payment_method_id}
+    end
+  end
+
+  defp create_payment_method_from_data(payment_method_data) do
+    type = Map.get(payment_method_data, :type)
+
+    if is_binary(type) do
+      payment_method = %{
+        billing_details: Map.get(payment_method_data, :billing_details),
+        card: Map.get(payment_method_data, :card),
+        created: PaperTiger.now(),
+        customer: nil,
+        id: generate_id("pm"),
+        livemode: false,
+        metadata: Map.get(payment_method_data, :metadata, %{}),
+        object: "payment_method",
+        type: type,
+        us_bank_account: Map.get(payment_method_data, :us_bank_account)
+      }
+
+      PaymentMethods.insert(payment_method)
+    else
+      {:error, :missing_payment_method}
+    end
+  end
+
+  defp confirm_with_payment_method(setup_intent, payment_method, params) do
+    setup_intent =
+      setup_intent
+      |> Map.put(:payment_method, payment_method.id)
+      |> maybe_replace(:payment_method_options, params)
+
+    cond do
+      decline_code = decline_code(payment_method) ->
+        fail_setup_intent(setup_intent, payment_method, decline_code)
+
+      requires_microdeposits?(payment_method, setup_intent) ->
+        require_microdeposit_verification(setup_intent, payment_method)
+
+      true ->
+        succeed_setup_intent(setup_intent, payment_method)
+    end
+  end
+
+  defp fail_setup_intent(setup_intent, payment_method, decline_code) do
+    error = PaperTiger.Error.card_declined(code: decline_code)
+    {:ok, attempt} = create_setup_attempt(setup_intent, payment_method, "failed", error)
+
+    failed =
+      setup_intent
+      |> Map.put(:last_setup_error, PaperTiger.Error.to_json(error).error)
+      |> Map.put(:latest_attempt, attempt.id)
+      |> Map.put(:next_action, nil)
+      |> Map.put(:status, "requires_payment_method")
+
+    {:ok, _failed} = SetupIntents.update(failed)
+
+    :telemetry.execute([:paper_tiger, :setup_intent, :setup_failed], %{}, %{object: failed})
+
+    {:error, :setup_failed, error}
+  end
+
+  defp require_microdeposit_verification(setup_intent, payment_method) do
+    {:ok, attempt} = create_setup_attempt(setup_intent, payment_method, "requires_action")
+
+    requires_action =
+      setup_intent
+      |> Map.put(:last_setup_error, nil)
+      |> Map.put(:latest_attempt, attempt.id)
+      |> Map.put(:next_action, microdeposit_next_action())
+      |> Map.put(:status, "requires_action")
+
+    {:ok, requires_action} = SetupIntents.update(requires_action)
+
+    :telemetry.execute([:paper_tiger, :setup_intent, :requires_action], %{}, %{object: requires_action})
+
+    {:ok, requires_action}
+  end
+
+  defp succeed_setup_intent(setup_intent, payment_method) do
+    with {:ok, payment_method} <- maybe_attach_payment_method(payment_method, setup_intent.customer),
+         {:ok, attempt} <- create_setup_attempt(setup_intent, payment_method, "succeeded") do
+      succeeded =
+        setup_intent
+        |> Map.put(:last_setup_error, nil)
+        |> Map.put(:latest_attempt, attempt.id)
+        |> Map.put(:mandate, maybe_mandate_id(setup_intent, payment_method))
+        |> Map.put(:next_action, nil)
+        |> Map.put(:status, "succeeded")
+
+      {:ok, succeeded} = SetupIntents.update(succeeded)
+
+      :telemetry.execute([:paper_tiger, :setup_intent, :succeeded], %{}, %{object: succeeded})
+
+      {:ok, succeeded}
+    end
+  end
+
+  defp verify_microdeposit_setup(setup_intent) do
+    with {:ok, payment_method} <- fetch_payment_method(setup_intent.payment_method),
+         {:ok, payment_method} <- maybe_attach_payment_method(payment_method, setup_intent.customer),
+         {:ok, latest_attempt_id} <- succeed_latest_or_new_attempt(setup_intent, payment_method) do
+      verified =
+        setup_intent
+        |> Map.put(:last_setup_error, nil)
+        |> Map.put(:latest_attempt, latest_attempt_id)
+        |> Map.put(:mandate, Map.get(setup_intent, :mandate) || generate_id("mandate"))
+        |> Map.put(:next_action, nil)
+        |> Map.put(:status, "succeeded")
+
+      {:ok, verified} = SetupIntents.update(verified)
+
+      :telemetry.execute([:paper_tiger, :setup_intent, :succeeded], %{}, %{object: verified})
+
+      {:ok, verified}
+    end
+  end
+
+  defp succeed_latest_or_new_attempt(%{latest_attempt: attempt_id} = setup_intent, payment_method)
+       when is_binary(attempt_id) do
+    case SetupAttempts.get(attempt_id) do
+      {:ok, attempt} ->
+        succeeded = %{attempt | setup_error: nil, status: "succeeded"}
+        {:ok, succeeded} = SetupAttempts.update(succeeded)
+        {:ok, succeeded.id}
+
+      {:error, :not_found} ->
+        succeed_latest_or_new_attempt(Map.delete(setup_intent, :latest_attempt), payment_method)
+    end
+  end
+
+  defp succeed_latest_or_new_attempt(setup_intent, payment_method) do
+    {:ok, attempt} = create_setup_attempt(setup_intent, payment_method, "succeeded")
+    {:ok, attempt.id}
+  end
+
+  defp maybe_attach_payment_method(payment_method, nil), do: {:ok, payment_method}
+
+  defp maybe_attach_payment_method(%{customer: nil} = payment_method, customer_id) do
+    attached = %{payment_method | customer: customer_id}
+    PaymentMethods.update(attached)
+  end
+
+  defp maybe_attach_payment_method(%{customer: existing_customer_id} = payment_method, customer_id)
+       when existing_customer_id == customer_id do
+    {:ok, payment_method}
+  end
+
+  defp maybe_attach_payment_method(_payment_method, _customer_id), do: {:error, :payment_method_attached_elsewhere}
+
+  defp create_setup_attempt(setup_intent, payment_method, status, error \\ nil) do
+    setup_attempt = %{
+      application: Map.get(setup_intent, :application),
+      attach_to_self: Map.get(setup_intent, :attach_to_self, false),
+      created: PaperTiger.now(),
+      customer: Map.get(setup_intent, :customer),
+      flow_directions: Map.get(setup_intent, :flow_directions),
+      id: generate_id("setatt"),
+      livemode: false,
+      object: "setup_attempt",
+      on_behalf_of: Map.get(setup_intent, :on_behalf_of),
+      payment_method: payment_method.id,
+      payment_method_details: payment_method_details(payment_method),
+      setup_error: setup_error(error),
+      setup_intent: setup_intent.id,
+      status: status,
+      usage: Map.get(setup_intent, :usage, "off_session")
+    }
+
+    SetupAttempts.insert(setup_attempt)
+  end
+
+  defp setup_error(nil), do: nil
+  defp setup_error(%PaperTiger.Error{} = error), do: PaperTiger.Error.to_json(error).error
+
+  defp payment_method_details(%{type: "card"} = payment_method) do
+    %{
+      card: Map.get(payment_method, :card),
+      type: "card"
+    }
+  end
+
+  defp payment_method_details(%{type: type} = payment_method) when is_binary(type) do
+    details = Map.get(payment_method, String.to_existing_atom(type), %{})
+    Map.put(%{type: type}, type, details)
+  rescue
+    ArgumentError -> %{type: type}
+  end
+
+  defp payment_method_details(_payment_method), do: %{}
+
+  defp requires_microdeposits?(%{type: type}, _setup_intent) when type in ["us_bank_account", "acss_debit"], do: true
+
+  defp requires_microdeposits?(_payment_method, _setup_intent), do: false
+
+  defp decline_code(payment_method) do
+    payment_method
+    |> Map.get(:metadata, %{})
+    |> Map.get(:_paper_tiger_decline_code)
+  end
+
+  defp microdeposit_next_action do
+    %{
+      type: "verify_with_microdeposits",
+      verify_with_microdeposits: %{
+        arrival_date: PaperTiger.now() + 172_800,
+        hosted_verification_url: nil,
+        microdeposit_type: "amounts"
+      }
+    }
+  end
+
+  defp abandon_latest_attempt(%{latest_attempt: attempt_id} = setup_intent) when is_binary(attempt_id) do
+    case SetupAttempts.get(attempt_id) do
+      {:ok, attempt} ->
+        {:ok, _attempt} = SetupAttempts.update(%{attempt | status: "abandoned"})
+        setup_intent
+
+      {:error, :not_found} ->
+        setup_intent
+    end
+  end
+
+  defp abandon_latest_attempt(setup_intent), do: setup_intent
+
+  defp maybe_mandate_id(%{mandate: mandate_id}, _payment_method) when is_binary(mandate_id), do: mandate_id
+
+  defp maybe_mandate_id(_setup_intent, %{type: type}) when type in ["us_bank_account", "acss_debit"],
+    do: generate_id("mandate")
+
+  defp maybe_mandate_id(_setup_intent, _payment_method), do: nil
+
+  defp maybe_replace(resource, key, params) do
+    if Map.has_key?(params, key) do
+      Map.put(resource, key, Map.get(params, key))
+    else
+      resource
+    end
+  end
 
   defp build_setup_intent(params) do
-    # Additional fields
     %{
       application: Map.get(params, :application),
+      attach_to_self: Map.get(params, :attach_to_self, false),
+      automatic_payment_methods: Map.get(params, :automatic_payment_methods),
       cancellation_reason: nil,
       client_secret: generate_client_secret(),
       created: PaperTiger.now(),
       customer: Map.get(params, :customer),
       description: Map.get(params, :description),
+      excluded_payment_method_types: Map.get(params, :excluded_payment_method_types),
       flow_directions: Map.get(params, :flow_directions, []),
       id: generate_id("seti"),
       last_setup_error: nil,
+      latest_attempt: nil,
       livemode: false,
       mandate: Map.get(params, :mandate),
       metadata: Map.get(params, :metadata, %{}),
@@ -142,13 +638,17 @@ defmodule PaperTiger.Resources.SetupIntent do
       object: "setup_intent",
       on_behalf_of: Map.get(params, :on_behalf_of),
       payment_method: Map.get(params, :payment_method),
+      payment_method_configuration_details: nil,
       payment_method_options: Map.get(params, :payment_method_options),
       payment_method_types: Map.get(params, :payment_method_types, ["card"]),
       single_use_mandate: nil,
-      status: "requires_payment_method",
+      status: initial_status(params),
       usage: Map.get(params, :usage, "off_session")
     }
   end
+
+  defp initial_status(%{payment_method: payment_method}) when is_binary(payment_method), do: "requires_confirmation"
+  defp initial_status(_params), do: "requires_payment_method"
 
   defp maybe_expand(setup_intent, params) do
     expand_params = parse_expand_params(params)

--- a/lib/paper_tiger/router.ex
+++ b/lib/paper_tiger/router.ex
@@ -74,6 +74,7 @@ defmodule PaperTiger.Router do
   alias PaperTiger.Resources.Product
   alias PaperTiger.Resources.Refund
   alias PaperTiger.Resources.Review
+  alias PaperTiger.Resources.SetupAttempt
   alias PaperTiger.Resources.SetupIntent
   alias PaperTiger.Resources.Source
   alias PaperTiger.Resources.Subscription
@@ -221,7 +222,21 @@ defmodule PaperTiger.Router do
   end
 
   stripe_resource("payment_intents", PaymentIntent, except: [:delete])
+  # Custom setup intent endpoints — must come BEFORE stripe_resource
+  post "/v1/setup_intents/:id/confirm" do
+    SetupIntent.confirm(conn, id)
+  end
+
+  post "/v1/setup_intents/:id/cancel" do
+    SetupIntent.cancel(conn, id)
+  end
+
+  post "/v1/setup_intents/:id/verify_microdeposits" do
+    SetupIntent.verify_microdeposits(conn, id)
+  end
+
   stripe_resource("setup_intents", SetupIntent, except: [:delete])
+  stripe_resource("setup_attempts", SetupAttempt, only: [:list])
   stripe_resource("charges", Charge, except: [:delete])
   stripe_resource("refunds", Refund, except: [:delete])
   stripe_resource("coupons", Coupon, [])

--- a/lib/paper_tiger/store/setup_attempts.ex
+++ b/lib/paper_tiger/store/setup_attempts.ex
@@ -1,0 +1,29 @@
+defmodule PaperTiger.Store.SetupAttempts do
+  @moduledoc """
+  ETS-backed storage for SetupAttempt resources.
+
+  SetupAttempts record each SetupIntent confirmation attempt and are scoped by
+  the same PaperTiger test namespace as the SetupIntent they belong to.
+  """
+
+  use PaperTiger.Store,
+    table: :paper_tiger_setup_attempts,
+    resource: "setup_attempt",
+    plural: "setup_attempts",
+    prefix: "setatt"
+
+  @doc """
+  Finds setup attempts associated with a SetupIntent ID.
+
+  **Direct ETS access** - does not go through GenServer.
+  """
+  @spec find_by_setup_intent(String.t() | nil) :: [map()]
+  def find_by_setup_intent(nil), do: []
+
+  def find_by_setup_intent(setup_intent_id) when is_binary(setup_intent_id) do
+    namespace = PaperTiger.Test.current_namespace()
+
+    :ets.match_object(@table, {{namespace, :_}, %{setup_intent: setup_intent_id}})
+    |> Enum.map(fn {_key, setup_attempt} -> setup_attempt end)
+  end
+end

--- a/lib/paper_tiger/test.ex
+++ b/lib/paper_tiger/test.ex
@@ -50,6 +50,7 @@ defmodule PaperTiger.Test do
   alias PaperTiger.Store.Products
   alias PaperTiger.Store.Refunds
   alias PaperTiger.Store.Reviews
+  alias PaperTiger.Store.SetupAttempts
   alias PaperTiger.Store.SetupIntents
   alias PaperTiger.Store.Sources
   alias PaperTiger.Store.SubscriptionItems
@@ -214,6 +215,7 @@ defmodule PaperTiger.Test do
       Products,
       Refunds,
       Reviews,
+      SetupAttempts,
       SetupIntents,
       Sources,
       SubscriptionItems,

--- a/test/paper_tiger/contract_test.exs
+++ b/test/paper_tiger/contract_test.exs
@@ -603,6 +603,50 @@ defmodule PaperTiger.ContractTest do
     end
   end
 
+  describe "SetupIntent Lifecycle Validation" do
+    @tag :contract
+    test "confirms a card setup intent and records a setup attempt" do
+      {:ok, setup_intent} =
+        TestClient.create_setup_intent(%{
+          "payment_method" => "pm_card_visa"
+        })
+
+      {:ok, confirmed} = TestClient.confirm_setup_intent(setup_intent["id"])
+
+      assert confirmed["object"] == "setup_intent"
+      assert confirmed["status"] == "succeeded"
+      assert is_binary(confirmed["payment_method"])
+      assert String.starts_with?(confirmed["payment_method"], "pm_")
+      assert is_binary(confirmed["latest_attempt"])
+      assert String.starts_with?(confirmed["latest_attempt"], "setatt_")
+
+      {:ok, attempts} = TestClient.list_setup_attempts(%{"setup_intent" => confirmed["id"]})
+
+      assert attempts["object"] == "list"
+      assert length(attempts["data"]) == 1
+
+      [attempt] = attempts["data"]
+      assert attempt["object"] == "setup_attempt"
+      assert attempt["setup_intent"] == confirmed["id"]
+      assert attempt["status"] == "succeeded"
+      assert is_binary(attempt["payment_method"])
+    end
+
+    @tag :contract
+    test "cancels a setup intent with a cancellation reason" do
+      {:ok, setup_intent} = TestClient.create_setup_intent()
+
+      {:ok, canceled} =
+        TestClient.cancel_setup_intent(setup_intent["id"], %{
+          "cancellation_reason" => "duplicate"
+        })
+
+      assert canceled["object"] == "setup_intent"
+      assert canceled["status"] == "canceled"
+      assert canceled["cancellation_reason"] == "duplicate"
+    end
+  end
+
   describe "Refund Structure Validation" do
     @tag :contract
     test "refund has balance_transaction" do

--- a/test/paper_tiger/resources/setup_intent_lifecycle_test.exs
+++ b/test/paper_tiger/resources/setup_intent_lifecycle_test.exs
@@ -1,0 +1,255 @@
+defmodule PaperTiger.Resources.SetupIntentLifecycleTest do
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
+
+  alias PaperTiger.Router
+
+  setup :checkout_paper_tiger
+
+  defp request(method, path, params \\ %{}) do
+    conn = Plug.Test.conn(method, path, params)
+
+    [{"content-type", "application/json"}, {"authorization", "Bearer sk_test_setup_intent_key"}]
+    |> Kernel.++(sandbox_headers())
+    |> Enum.reduce(conn, fn {key, value}, acc -> Plug.Conn.put_req_header(acc, key, value) end)
+    |> Router.call([])
+  end
+
+  defp json_response(conn), do: Jason.decode!(conn.resp_body)
+
+  describe "POST /v1/setup_intents/:id/confirm" do
+    test "succeeds a card setup intent, attaches the payment method, and records an attempt" do
+      customer_id = create_customer_id()
+
+      setup_intent =
+        request(:post, "/v1/setup_intents", %{
+          "customer" => customer_id,
+          "payment_method" => "pm_card_visa"
+        })
+        |> json_response()
+
+      conn = request(:post, "/v1/setup_intents/#{setup_intent["id"]}/confirm")
+
+      assert conn.status == 200
+      confirmed = json_response(conn)
+      assert confirmed["status"] == "succeeded"
+      assert confirmed["customer"] == customer_id
+      assert confirmed["payment_method"] == "pm_card_visa"
+      assert String.starts_with?(confirmed["latest_attempt"], "setatt_")
+      assert is_nil(confirmed["last_setup_error"])
+      assert is_nil(confirmed["next_action"])
+
+      payment_method =
+        request(:get, "/v1/payment_methods/pm_card_visa")
+        |> json_response()
+
+      assert payment_method["customer"] == customer_id
+
+      attempts = list_attempts(confirmed["id"])
+      assert attempts["object"] == "list"
+      assert attempts["has_more"] == false
+
+      assert [
+               %{
+                 "object" => "setup_attempt",
+                 "payment_method" => "pm_card_visa",
+                 "status" => "succeeded"
+               }
+             ] = attempts["data"]
+
+      assert hd(attempts["data"])["payment_method_details"]["type"] == "card"
+    end
+
+    test "declined cards leave the setup intent retryable and record a failed attempt" do
+      setup_intent =
+        request(:post, "/v1/setup_intents", %{
+          "payment_method" => "pm_card_chargeDeclinedInsufficientFunds"
+        })
+        |> json_response()
+
+      conn = request(:post, "/v1/setup_intents/#{setup_intent["id"]}/confirm")
+
+      assert conn.status == 402
+      error = json_response(conn)["error"]
+      assert error["type"] == "card_error"
+      assert error["decline_code"] == "insufficient_funds"
+
+      retrieved =
+        request(:get, "/v1/setup_intents/#{setup_intent["id"]}")
+        |> json_response()
+
+      assert retrieved["status"] == "requires_payment_method"
+      assert retrieved["last_setup_error"]["type"] == "card_error"
+      assert String.starts_with?(retrieved["latest_attempt"], "setatt_")
+
+      attempts = list_attempts(setup_intent["id"])
+      assert [%{"setup_error" => %{"type" => "card_error"}, "status" => "failed"}] = attempts["data"]
+    end
+
+    test "bank-account setup requires microdeposit verification before succeeding" do
+      customer_id = create_customer_id()
+      payment_method = create_bank_payment_method()
+
+      setup_intent =
+        request(:post, "/v1/setup_intents", %{
+          "customer" => customer_id,
+          "payment_method" => payment_method["id"],
+          "payment_method_types" => ["us_bank_account"]
+        })
+        |> json_response()
+
+      conn = request(:post, "/v1/setup_intents/#{setup_intent["id"]}/confirm")
+
+      assert conn.status == 200
+      confirmed = json_response(conn)
+      assert confirmed["status"] == "requires_action"
+      assert confirmed["next_action"]["type"] == "verify_with_microdeposits"
+
+      attempts = list_attempts(setup_intent["id"])
+      assert [%{"status" => "requires_action"}] = attempts["data"]
+    end
+  end
+
+  describe "POST /v1/setup_intents/:id/verify_microdeposits" do
+    test "verifies bank-account microdeposits and attaches the payment method" do
+      customer_id = create_customer_id()
+      payment_method = create_bank_payment_method()
+      setup_intent = create_confirmed_bank_setup_intent(customer_id, payment_method["id"])
+
+      conn =
+        request(:post, "/v1/setup_intents/#{setup_intent["id"]}/verify_microdeposits", %{
+          "amounts" => [32, 45]
+        })
+
+      assert conn.status == 200
+      verified = json_response(conn)
+      assert verified["status"] == "succeeded"
+      assert String.starts_with?(verified["mandate"], "mandate_")
+      assert is_nil(verified["next_action"])
+
+      payment_method =
+        request(:get, "/v1/payment_methods/#{payment_method["id"]}")
+        |> json_response()
+
+      assert payment_method["customer"] == customer_id
+
+      attempts = list_attempts(setup_intent["id"])
+      assert [%{"status" => "succeeded"}] = attempts["data"]
+    end
+
+    test "also accepts the Stripe test descriptor code" do
+      customer_id = create_customer_id()
+      payment_method = create_bank_payment_method()
+      setup_intent = create_confirmed_bank_setup_intent(customer_id, payment_method["id"])
+
+      conn =
+        request(:post, "/v1/setup_intents/#{setup_intent["id"]}/verify_microdeposits", %{
+          "descriptor_code" => "SM11AA"
+        })
+
+      assert conn.status == 200
+      assert json_response(conn)["status"] == "succeeded"
+    end
+
+    test "returns a Stripe-shaped error for incorrect verification values" do
+      payment_method = create_bank_payment_method()
+      setup_intent = create_confirmed_bank_setup_intent(nil, payment_method["id"])
+
+      conn =
+        request(:post, "/v1/setup_intents/#{setup_intent["id"]}/verify_microdeposits", %{
+          "amounts" => [1, 2]
+        })
+
+      assert conn.status == 400
+      error = json_response(conn)["error"]
+      assert error["type"] == "invalid_request_error"
+      assert error["param"] == "amounts"
+    end
+  end
+
+  describe "POST /v1/setup_intents/:id/cancel" do
+    test "cancels a pre-confirmation setup intent with a cancellation reason" do
+      setup_intent =
+        request(:post, "/v1/setup_intents")
+        |> json_response()
+
+      conn =
+        request(:post, "/v1/setup_intents/#{setup_intent["id"]}/cancel", %{
+          "cancellation_reason" => "requested_by_customer"
+        })
+
+      assert conn.status == 200
+      canceled = json_response(conn)
+      assert canceled["status"] == "canceled"
+      assert canceled["cancellation_reason"] == "requested_by_customer"
+    end
+
+    test "abandons the latest attempt when canceling a setup intent that requires action" do
+      payment_method = create_bank_payment_method()
+      setup_intent = create_confirmed_bank_setup_intent(nil, payment_method["id"])
+
+      conn =
+        request(:post, "/v1/setup_intents/#{setup_intent["id"]}/cancel", %{
+          "cancellation_reason" => "duplicate"
+        })
+
+      assert conn.status == 200
+      assert json_response(conn)["status"] == "canceled"
+
+      attempts = list_attempts(setup_intent["id"])
+      assert [%{"status" => "abandoned"}] = attempts["data"]
+    end
+
+    test "returns a Stripe-shaped error when canceling a succeeded setup intent" do
+      setup_intent =
+        request(:post, "/v1/setup_intents", %{"payment_method" => "pm_card_visa"})
+        |> json_response()
+
+      request(:post, "/v1/setup_intents/#{setup_intent["id"]}/confirm")
+
+      conn = request(:post, "/v1/setup_intents/#{setup_intent["id"]}/cancel")
+
+      assert conn.status == 400
+      error = json_response(conn)["error"]
+      assert error["type"] == "invalid_request_error"
+      assert error["param"] == "status"
+      assert error["message"] =~ "does not allow cancellation"
+    end
+  end
+
+  defp create_customer_id do
+    request(:post, "/v1/customers", %{"email" => "setup-intent@example.com"})
+    |> json_response()
+    |> Map.fetch!("id")
+  end
+
+  defp create_bank_payment_method do
+    request(:post, "/v1/payment_methods", %{
+      "billing_details" => %{"name" => "Bank Customer"},
+      "type" => "us_bank_account"
+    })
+    |> json_response()
+  end
+
+  defp create_confirmed_bank_setup_intent(customer_id, payment_method_id) do
+    params = %{
+      "payment_method" => payment_method_id,
+      "payment_method_types" => ["us_bank_account"]
+    }
+
+    params = if customer_id, do: Map.put(params, "customer", customer_id), else: params
+
+    setup_intent =
+      request(:post, "/v1/setup_intents", params)
+      |> json_response()
+
+    request(:post, "/v1/setup_intents/#{setup_intent["id"]}/confirm")
+    |> json_response()
+  end
+
+  defp list_attempts(setup_intent_id) do
+    request(:get, "/v1/setup_attempts?setup_intent=#{setup_intent_id}")
+    |> json_response()
+  end
+end

--- a/test/support/test_client.ex
+++ b/test/support/test_client.ex
@@ -522,6 +522,86 @@ defmodule PaperTiger.TestClient do
     end
   end
 
+  ## SetupIntent Operations
+
+  @doc """
+  Creates a setup intent.
+  """
+  def create_setup_intent(params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        create_setup_intent_real(params)
+
+      :paper_tiger ->
+        create_setup_intent_mock(params)
+    end
+  end
+
+  @doc """
+  Retrieves a setup intent by ID.
+  """
+  def get_setup_intent(setup_intent_id) do
+    case mode() do
+      :real_stripe ->
+        get_setup_intent_real(setup_intent_id)
+
+      :paper_tiger ->
+        get_setup_intent_mock(setup_intent_id)
+    end
+  end
+
+  @doc """
+  Confirms a setup intent.
+  """
+  def confirm_setup_intent(setup_intent_id, params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        confirm_setup_intent_real(setup_intent_id, params)
+
+      :paper_tiger ->
+        confirm_setup_intent_mock(setup_intent_id, params)
+    end
+  end
+
+  @doc """
+  Cancels a setup intent.
+  """
+  def cancel_setup_intent(setup_intent_id, params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        cancel_setup_intent_real(setup_intent_id, params)
+
+      :paper_tiger ->
+        cancel_setup_intent_mock(setup_intent_id, params)
+    end
+  end
+
+  @doc """
+  Verifies setup intent microdeposits.
+  """
+  def verify_setup_intent_microdeposits(setup_intent_id, params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        verify_setup_intent_microdeposits_real(setup_intent_id, params)
+
+      :paper_tiger ->
+        verify_setup_intent_microdeposits_mock(setup_intent_id, params)
+    end
+  end
+
+  @doc """
+  Lists setup attempts.
+  """
+  def list_setup_attempts(params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        list_setup_attempts_real(params)
+
+      :paper_tiger ->
+        list_setup_attempts_mock(params)
+    end
+  end
+
   ## Charge Operations
 
   @doc """
@@ -1117,6 +1197,30 @@ defmodule PaperTiger.TestClient do
     stripe_request(:post, "/v1/payment_intents/#{payment_intent_id}/capture", params)
   end
 
+  defp create_setup_intent_real(params) do
+    stripe_request(:post, "/v1/setup_intents", params)
+  end
+
+  defp get_setup_intent_real(setup_intent_id) do
+    stripe_request(:get, "/v1/setup_intents/#{setup_intent_id}")
+  end
+
+  defp confirm_setup_intent_real(setup_intent_id, params) do
+    stripe_request(:post, "/v1/setup_intents/#{setup_intent_id}/confirm", params)
+  end
+
+  defp cancel_setup_intent_real(setup_intent_id, params) do
+    stripe_request(:post, "/v1/setup_intents/#{setup_intent_id}/cancel", params)
+  end
+
+  defp verify_setup_intent_microdeposits_real(setup_intent_id, params) do
+    stripe_request(:post, "/v1/setup_intents/#{setup_intent_id}/verify_microdeposits", params)
+  end
+
+  defp list_setup_attempts_real(params) do
+    stripe_request(:get, "/v1/setup_attempts", params)
+  end
+
   defp get_balance_transaction_real(txn_id) do
     stripe_request(:get, "/v1/balance_transactions/#{txn_id}")
   end
@@ -1319,6 +1423,36 @@ defmodule PaperTiger.TestClient do
 
   defp capture_payment_intent_mock(payment_intent_id, params) do
     conn = request(:post, "/v1/payment_intents/#{payment_intent_id}/capture", params)
+    handle_response(conn)
+  end
+
+  defp create_setup_intent_mock(params) do
+    conn = request(:post, "/v1/setup_intents", params)
+    handle_response(conn)
+  end
+
+  defp get_setup_intent_mock(setup_intent_id) do
+    conn = request(:get, "/v1/setup_intents/#{setup_intent_id}", %{})
+    handle_response(conn)
+  end
+
+  defp confirm_setup_intent_mock(setup_intent_id, params) do
+    conn = request(:post, "/v1/setup_intents/#{setup_intent_id}/confirm", params)
+    handle_response(conn)
+  end
+
+  defp cancel_setup_intent_mock(setup_intent_id, params) do
+    conn = request(:post, "/v1/setup_intents/#{setup_intent_id}/cancel", params)
+    handle_response(conn)
+  end
+
+  defp verify_setup_intent_microdeposits_mock(setup_intent_id, params) do
+    conn = request(:post, "/v1/setup_intents/#{setup_intent_id}/verify_microdeposits", params)
+    handle_response(conn)
+  end
+
+  defp list_setup_attempts_mock(params) do
+    conn = request(:get, "/v1/setup_attempts", params)
     handle_response(conn)
   end
 


### PR DESCRIPTION
## Summary
- add SetupIntent confirm, cancel, and verify_microdeposits endpoints
- add list-only SetupAttempt support with namespaced storage and expansion support
- attach successful card setup payment methods to the SetupIntent customer, record failed/requires_action/succeeded/abandoned attempts, and model bank-account microdeposit verification
- add dual-mode TestClient coverage plus focused resource and contract tests

## Validation
- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix test --warnings-as-errors`
- `mix credo --strict --all`
- `mix dialyzer`
- live SetupIntent contract slice with provided Stripe test key: confirm/list attempts and cancel

Closes #59