### PR TITLE
Add Stripe search endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PaymentIntent lifecycle endpoints for `POST /v1/payment_intents/:id/cancel` and `POST /v1/payment_intents/:id/capture`, including manual-capture authorization, partial capture, `amount_capturable` / `amount_received`, captured Charge state, and Stripe-shaped invalid-state errors.
 - Checkout Session update and line-item retrieval endpoints, including metadata merge/delete semantics, paginated `GET /v1/checkout/sessions/:id/line_items`, `expand[]=line_items`, and preview-style full-array line item updates for dynamic Checkout tests.
 - SetupIntent lifecycle endpoints for `POST /v1/setup_intents/:id/confirm`, `POST /v1/setup_intents/:id/cancel`, `POST /v1/setup_intents/:id/verify_microdeposits`, and `GET /v1/setup_attempts`, including customer attachment for successful card setup, bank-account microdeposit verification, cancellation reasons, failed/abandoned/succeeded SetupAttempt records, and live Stripe contract coverage for confirm/cancel/list-attempts.
+- Stripe-style search endpoints for `GET /v1/customers/search`, `GET /v1/subscriptions/search`, `GET /v1/payment_intents/search`, `GET /v1/charges/search`, and `GET /v1/invoices/search`, backed by a shared query parser/evaluator with resource field schemas, metadata predicates, boolean connectors, negation, numeric comparisons, substring matching, search-result pagination, and Stripe-shaped unsupported-query errors.
 
 ### Fixed
 

--- a/lib/paper_tiger/resources/charge.ex
+++ b/lib/paper_tiger/resources/charge.ex
@@ -32,7 +32,21 @@ defmodule PaperTiger.Resources.Charge do
   import PaperTiger.Resource
 
   alias PaperTiger.BalanceTransactionHelper
+  alias PaperTiger.Search
   alias PaperTiger.Store.Charges
+
+  @search_fields %{
+    "amount" => :numeric,
+    "created" => :numeric,
+    "currency" => :token,
+    "customer" => :token,
+    "disputed" => :token,
+    "metadata" => :token,
+    "payment_method_details.card.last4" => :token,
+    "receipt_email" => :string,
+    "refunded" => :token,
+    "status" => :string
+  }
 
   @doc """
   Creates a new charge.
@@ -153,6 +167,23 @@ defmodule PaperTiger.Resources.Charge do
 
     json_response(conn, 200, result)
   end
+
+  @doc """
+  Searches charges with Stripe-style search query syntax.
+  """
+  @spec search(Plug.Conn.t()) :: Plug.Conn.t()
+  def search(conn) do
+    Charges.list_namespace(PaperTiger.Test.current_namespace())
+    |> Search.run(conn.params,
+      fields: @search_fields,
+      url: "/v1/charges/search",
+      decorate: &maybe_expand(&1, conn.params)
+    )
+    |> respond_to_search(conn)
+  end
+
+  defp respond_to_search({:ok, result}, conn), do: json_response(conn, 200, result)
+  defp respond_to_search({:error, error}, conn), do: error_response(conn, error)
 
   defp build_charge(params) do
     amount = get_integer(params, :amount)

--- a/lib/paper_tiger/resources/customer.ex
+++ b/lib/paper_tiger/resources/customer.ex
@@ -28,7 +28,16 @@ defmodule PaperTiger.Resources.Customer do
 
   import PaperTiger.Resource
 
+  alias PaperTiger.Search
   alias PaperTiger.Store.Customers
+
+  @search_fields %{
+    "created" => :numeric,
+    "email" => :string,
+    "metadata" => :token,
+    "name" => :string,
+    "phone" => :string
+  }
 
   @doc """
   Creates a new customer.
@@ -158,7 +167,24 @@ defmodule PaperTiger.Resources.Customer do
     json_response(conn, 200, result)
   end
 
+  @doc """
+  Searches customers with Stripe-style search query syntax.
+  """
+  @spec search(Plug.Conn.t()) :: Plug.Conn.t()
+  def search(conn) do
+    Customers.list_namespace(PaperTiger.Test.current_namespace())
+    |> Search.run(conn.params,
+      fields: @search_fields,
+      url: "/v1/customers/search",
+      decorate: &maybe_expand(&1, conn.params)
+    )
+    |> respond_to_search(conn)
+  end
+
   ## Private Functions
+  defp respond_to_search({:ok, result}, conn), do: json_response(conn, 200, result)
+  defp respond_to_search({:error, error}, conn), do: error_response(conn, error)
+
   # Use provided created timestamp or default to now
   defp build_customer(params) do
     created = get_optional_integer(params, :created) || PaperTiger.now()

--- a/lib/paper_tiger/resources/invoice.ex
+++ b/lib/paper_tiger/resources/invoice.ex
@@ -39,11 +39,26 @@ defmodule PaperTiger.Resources.Invoice do
   import PaperTiger.Resource
 
   alias PaperTiger.ChaosCoordinator
+  alias PaperTiger.Search
   alias PaperTiger.Store.InvoiceItems
   alias PaperTiger.Store.Invoices
   alias PaperTiger.Store.Prices
   alias PaperTiger.Store.SubscriptionItems
   alias PaperTiger.Store.Subscriptions
+
+  @search_fields %{
+    "created" => :numeric,
+    "currency" => :token,
+    "customer" => :token,
+    "last_finalization_error.code" => :token,
+    "last_finalization_error.type" => :token,
+    "metadata" => :token,
+    "number" => :string,
+    "receipt_number" => :string,
+    "status" => :string,
+    "subscription" => :token,
+    "total" => :numeric
+  }
 
   @doc """
   Creates a new invoice.
@@ -195,9 +210,30 @@ defmodule PaperTiger.Resources.Invoice do
     json_response(conn, 200, result)
   end
 
+  @doc """
+  Searches invoices with Stripe-style search query syntax.
+  """
+  @spec search(Plug.Conn.t()) :: Plug.Conn.t()
+  def search(conn) do
+    Invoices.list_namespace(PaperTiger.Test.current_namespace())
+    |> Search.run(conn.params,
+      fields: @search_fields,
+      url: "/v1/invoices/search",
+      decorate: fn invoice ->
+        invoice
+        |> load_invoice_lines()
+        |> maybe_expand(conn.params)
+      end
+    )
+    |> respond_to_search(conn)
+  end
+
   defp to_string_or_nil(nil), do: nil
   defp to_string_or_nil(val) when is_binary(val), do: val
   defp to_string_or_nil(val) when is_atom(val), do: Atom.to_string(val)
+
+  defp respond_to_search({:ok, result}, conn), do: json_response(conn, 200, result)
+  defp respond_to_search({:error, error}, conn), do: error_response(conn, error)
 
   defp get_filtered_invoices(nil, nil, nil) do
     Invoices.all()

--- a/lib/paper_tiger/resources/payment_intent.ex
+++ b/lib/paper_tiger/resources/payment_intent.ex
@@ -32,10 +32,19 @@ defmodule PaperTiger.Resources.PaymentIntent do
 
   import PaperTiger.Resource
 
+  alias PaperTiger.Search
   alias PaperTiger.Store.PaymentIntents
 
   @cancelable_statuses ~w(requires_payment_method requires_capture requires_confirmation requires_action processing)
   @cancellation_reasons ~w(duplicate fraudulent requested_by_customer abandoned)
+  @search_fields %{
+    "amount" => :numeric,
+    "created" => :numeric,
+    "currency" => :token,
+    "customer" => :token,
+    "metadata" => :token,
+    "status" => :string
+  }
 
   @doc """
   Creates a new payment intent.
@@ -141,6 +150,20 @@ defmodule PaperTiger.Resources.PaymentIntent do
     result = PaymentIntents.list(pagination_opts)
 
     json_response(conn, 200, result)
+  end
+
+  @doc """
+  Searches payment intents with Stripe-style search query syntax.
+  """
+  @spec search(Plug.Conn.t()) :: Plug.Conn.t()
+  def search(conn) do
+    PaymentIntents.list_namespace(PaperTiger.Test.current_namespace())
+    |> Search.run(conn.params,
+      fields: @search_fields,
+      url: "/v1/payment_intents/search",
+      decorate: &maybe_expand(&1, conn.params)
+    )
+    |> respond_to_search(conn)
   end
 
   @doc """
@@ -305,6 +328,9 @@ defmodule PaperTiger.Resources.PaymentIntent do
 
   defp validate_capturable(%{amount_capturable: amount, status: "requires_capture"}) when amount > 0, do: :ok
   defp validate_capturable(%{status: status}), do: {:error, :not_capturable, status}
+
+  defp respond_to_search({:ok, result}, conn), do: json_response(conn, 200, result)
+  defp respond_to_search({:error, error}, conn), do: error_response(conn, error)
 
   defp validate_cancellation_reason(nil), do: {:ok, nil}
   defp validate_cancellation_reason(reason) when reason in @cancellation_reasons, do: {:ok, reason}

--- a/lib/paper_tiger/resources/subscription.ex
+++ b/lib/paper_tiger/resources/subscription.ex
@@ -40,6 +40,7 @@ defmodule PaperTiger.Resources.Subscription do
   import PaperTiger.Resource
 
   alias PaperTiger.AutomaticTax
+  alias PaperTiger.Search
   alias PaperTiger.Store.Coupons
   alias PaperTiger.Store.Customers
   alias PaperTiger.Store.InvoiceItems
@@ -49,6 +50,13 @@ defmodule PaperTiger.Resources.Subscription do
   alias PaperTiger.Store.Prices
   alias PaperTiger.Store.SubscriptionItems
   alias PaperTiger.Store.Subscriptions
+
+  @search_fields %{
+    "canceled_at" => :numeric,
+    "created" => :numeric,
+    "metadata" => :token,
+    "status" => :string
+  }
 
   @doc """
   Creates a new subscription.
@@ -244,6 +252,25 @@ defmodule PaperTiger.Resources.Subscription do
   end
 
   @doc """
+  Searches subscriptions with Stripe-style search query syntax.
+  """
+  @spec search(Plug.Conn.t()) :: Plug.Conn.t()
+  def search(conn) do
+    Subscriptions.list_namespace(PaperTiger.Test.current_namespace())
+    |> Search.run(conn.params,
+      fields: @search_fields,
+      url: "/v1/subscriptions/search",
+      decorate: fn subscription ->
+        subscription
+        |> load_subscription_items()
+        |> load_latest_invoice()
+        |> maybe_expand(conn.params)
+      end
+    )
+    |> respond_to_search(conn)
+  end
+
+  @doc """
   Cancels a subscription immediately.
 
   POST /v1/subscriptions/:id/cancel
@@ -334,6 +361,9 @@ defmodule PaperTiger.Resources.Subscription do
       true -> "active"
     end
   end
+
+  defp respond_to_search({:ok, result}, conn), do: json_response(conn, 200, result)
+  defp respond_to_search({:error, error}, conn), do: error_response(conn, error)
 
   defp build_subscription(params) do
     now = PaperTiger.now()

--- a/lib/paper_tiger/router.ex
+++ b/lib/paper_tiger/router.ex
@@ -192,7 +192,16 @@ defmodule PaperTiger.Router do
   ## Resource Routes
 
   # Core resources (Phase 1)
+  get "/v1/customers/search" do
+    Customer.search(conn)
+  end
+
   stripe_resource("customers", Customer, [])
+
+  get "/v1/subscriptions/search" do
+    Subscription.search(conn)
+  end
+
   stripe_resource("subscriptions", Subscription, [])
   stripe_resource("products", Product, [])
   stripe_resource("prices", Price, except: [:delete])
@@ -206,9 +215,17 @@ defmodule PaperTiger.Router do
     Invoice.create_preview(conn)
   end
 
+  get "/v1/invoices/search" do
+    Invoice.search(conn)
+  end
+
   stripe_resource("invoices", Invoice, [])
   stripe_resource("payment_methods", PaymentMethod, [])
   # Custom payment intent endpoints — must come BEFORE stripe_resource
+  get "/v1/payment_intents/search" do
+    PaymentIntent.search(conn)
+  end
+
   post "/v1/payment_intents/:id/confirm" do
     PaymentIntent.confirm(conn, id)
   end
@@ -237,6 +254,11 @@ defmodule PaperTiger.Router do
 
   stripe_resource("setup_intents", SetupIntent, except: [:delete])
   stripe_resource("setup_attempts", SetupAttempt, only: [:list])
+
+  get "/v1/charges/search" do
+    Charge.search(conn)
+  end
+
   stripe_resource("charges", Charge, except: [:delete])
   stripe_resource("refunds", Refund, except: [:delete])
   stripe_resource("coupons", Coupon, [])

--- a/lib/paper_tiger/search.ex
+++ b/lib/paper_tiger/search.ex
@@ -1,0 +1,647 @@
+defmodule PaperTiger.Search do
+  @moduledoc """
+  Shared Stripe-style search support.
+
+  This implements the same structural pieces for every search endpoint:
+  parsing to a small AST, validating fields against each resource's schema,
+  evaluating clauses over resource maps, and returning Stripe's
+  `search_result` pagination shape.
+  """
+
+  @type field_type :: :numeric | :string | :token
+  @type field_schema :: %{required(String.t()) => field_type()}
+
+  @default_limit 10
+  @max_limit 100
+  @max_clauses 10
+
+  @doc false
+  @spec run([map()], map(), keyword()) :: {:ok, map()} | {:error, PaperTiger.Error.t()}
+  def run(items, params, opts) when is_list(items) and is_map(params) do
+    fields = Keyword.fetch!(opts, :fields)
+    url = Keyword.fetch!(opts, :url)
+    decorate = Keyword.get(opts, :decorate, & &1)
+
+    with {:ok, query} <- fetch_query(params),
+         {:ok, ast} <- compile(query, fields),
+         {:ok, limit} <- parse_limit(get_param(params, :limit)),
+         {:ok, offset} <- parse_page(get_param(params, :page)) do
+      result =
+        items
+        |> Enum.filter(&matches?(&1, ast))
+        |> Enum.sort_by(&sortable_created/1, :desc)
+        |> paginate_search(limit, offset, url, decorate, expand_total_count?(params))
+
+      {:ok, result}
+    end
+  end
+
+  @doc false
+  @spec compile(String.t(), field_schema()) :: {:ok, map()} | {:error, PaperTiger.Error.t()}
+  def compile(query, fields) when is_binary(query) and is_map(fields) do
+    with {:ok, tokens} <- split_query(query),
+         {:ok, ast} <- parse_tokens(tokens) do
+      validate_ast(ast, fields)
+    end
+  end
+
+  defp fetch_query(params) do
+    case get_param(params, :query) do
+      query when is_binary(query) and query != "" ->
+        {:ok, query}
+
+      _ ->
+        invalid("Missing required parameter", "query")
+    end
+  end
+
+  defp split_query(query) do
+    query
+    |> String.graphemes()
+    |> do_split_query([], [], nil, false)
+  end
+
+  defp do_split_query([], current, tokens, nil, _escaped) do
+    tokens =
+      current
+      |> flush_token(tokens)
+      |> Enum.reverse()
+
+    if tokens == [] do
+      invalid("Missing required parameter", "query")
+    else
+      {:ok, tokens}
+    end
+  end
+
+  defp do_split_query([], _current, _tokens, _quote, _escaped) do
+    invalid("Unterminated quoted string")
+  end
+
+  defp do_split_query(["\\" | rest], current, tokens, quote, false) when not is_nil(quote) do
+    do_split_query(rest, ["\\" | current], tokens, quote, true)
+  end
+
+  defp do_split_query([char | rest], current, tokens, quote, true) do
+    do_split_query(rest, [char | current], tokens, quote, false)
+  end
+
+  defp do_split_query([char | rest], current, tokens, char, false) when char in ["\"", "'"] do
+    do_split_query(rest, [char | current], tokens, nil, false)
+  end
+
+  defp do_split_query([char | rest], current, tokens, nil, false) when char in ["\"", "'"] do
+    do_split_query(rest, [char | current], tokens, char, false)
+  end
+
+  defp do_split_query([char | rest], current, tokens, nil, false) when char in [" ", "\t", "\n", "\r"] do
+    do_split_query(rest, [], flush_token(current, tokens), nil, false)
+  end
+
+  defp do_split_query([char | rest], current, tokens, quote, false) do
+    do_split_query(rest, [char | current], tokens, quote, false)
+  end
+
+  defp flush_token([], tokens), do: tokens
+
+  defp flush_token(current, tokens) do
+    token =
+      current
+      |> Enum.reverse()
+      |> Enum.join()
+
+    if token == "" do
+      tokens
+    else
+      [token | tokens]
+    end
+  end
+
+  defp parse_tokens(tokens), do: parse_tokens(tokens, [], [], true)
+
+  defp parse_tokens([], [], _connectors, _expect_clause), do: invalid("Missing required parameter", "query")
+  defp parse_tokens([], _clauses, _connectors, true), do: invalid("Search query cannot end with a connector")
+
+  defp parse_tokens([], clauses, connectors, false) do
+    connector =
+      cond do
+        Enum.member?(connectors, :and) and Enum.member?(connectors, :or) ->
+          :mixed
+
+        Enum.member?(connectors, :or) ->
+          :or
+
+        true ->
+          :and
+      end
+
+    case connector do
+      :mixed ->
+        invalid("Search queries cannot mix AND and OR")
+
+      _ when length(clauses) > @max_clauses ->
+        invalid("Search queries cannot contain more than #{@max_clauses} clauses")
+
+      _ ->
+        {:ok, %{clauses: Enum.reverse(clauses), connector: connector}}
+    end
+  end
+
+  defp parse_tokens([token | rest], clauses, connectors, true) do
+    if connector_token?(token) do
+      invalid("Search query cannot start with a connector")
+    else
+      with {:ok, clause} <- parse_clause(token) do
+        parse_tokens(rest, [clause | clauses], connectors, false)
+      end
+    end
+  end
+
+  defp parse_tokens([token | rest], clauses, connectors, false) do
+    if connector_token?(token) do
+      parse_tokens(rest, clauses, [connector_token(token) | connectors], true)
+    else
+      with {:ok, clause} <- parse_clause(token) do
+        parse_tokens(rest, [clause | clauses], [:and | connectors], false)
+      end
+    end
+  end
+
+  defp connector_token?(token), do: connector_token(token) in [:and, :or]
+
+  defp connector_token(token) do
+    case String.upcase(token) do
+      "AND" -> :and
+      "OR" -> :or
+      _ -> nil
+    end
+  end
+
+  defp parse_clause(token) do
+    {negated, clause} =
+      case token do
+        "-" <> rest -> {true, rest}
+        _ -> {false, token}
+      end
+
+    with {:ok, field, operator, value} <- split_clause(clause),
+         {:ok, field} <- parse_field(field),
+         {:ok, value} <- parse_value(value) do
+      {:ok,
+       %{
+         field: field.name,
+         negated: negated,
+         operator: operator,
+         path: field.path,
+         quoted?: value.quoted?,
+         value: value.value
+       }}
+    end
+  end
+
+  defp split_clause(clause) do
+    clause
+    |> String.graphemes()
+    |> find_clause_operator([])
+  end
+
+  defp find_clause_operator([], _field) do
+    invalid("Search clause is missing an operator")
+  end
+
+  defp find_clause_operator([">", "=" | rest], field), do: clause_parts(field, :gte, rest)
+  defp find_clause_operator(["<", "=" | rest], field), do: clause_parts(field, :lte, rest)
+  defp find_clause_operator([":" | rest], field), do: clause_parts(field, :exact, rest)
+  defp find_clause_operator(["~" | rest], field), do: clause_parts(field, :substring, rest)
+  defp find_clause_operator([">" | rest], field), do: clause_parts(field, :gt, rest)
+  defp find_clause_operator(["<" | rest], field), do: clause_parts(field, :lt, rest)
+  defp find_clause_operator(["=" | rest], field), do: clause_parts(field, :equals, rest)
+
+  defp find_clause_operator([quote | rest], field) when quote in ["\"", "'"] do
+    find_clause_operator_in_quote(rest, [quote | field], quote, false)
+  end
+
+  defp find_clause_operator([char | rest], field) do
+    find_clause_operator(rest, [char | field])
+  end
+
+  defp find_clause_operator_in_quote([], _field, _quote, _escaped) do
+    invalid("Unterminated quoted string")
+  end
+
+  defp find_clause_operator_in_quote(["\\" | rest], field, quote, false) do
+    find_clause_operator_in_quote(rest, ["\\" | field], quote, true)
+  end
+
+  defp find_clause_operator_in_quote([char | rest], field, quote, true) do
+    find_clause_operator_in_quote(rest, [char | field], quote, false)
+  end
+
+  defp find_clause_operator_in_quote([quote | rest], field, quote, false) do
+    find_clause_operator(rest, [quote | field])
+  end
+
+  defp find_clause_operator_in_quote([char | rest], field, quote, false) do
+    find_clause_operator_in_quote(rest, [char | field], quote, false)
+  end
+
+  defp clause_parts(field, operator, value) do
+    field =
+      field
+      |> Enum.reverse()
+      |> Enum.join()
+      |> String.trim()
+
+    value =
+      value
+      |> Enum.join()
+      |> String.trim()
+
+    cond do
+      field == "" -> invalid("Search clause is missing a field")
+      value == "" -> invalid("Search clause is missing a value")
+      true -> {:ok, field, operator, value}
+    end
+  end
+
+  defp parse_field("metadata[" <> rest) do
+    case parse_metadata_field(rest) do
+      {:ok, key} ->
+        {:ok, %{name: "metadata", path: ["metadata", key]}}
+
+      :error ->
+        invalid("Invalid metadata search field")
+    end
+  end
+
+  defp parse_field(field) do
+    if Regex.match?(~r/\A[a-zA-Z0-9_.]+\z/, field) do
+      {:ok, %{name: field, path: String.split(field, ".")}}
+    else
+      invalid("Invalid search field")
+    end
+  end
+
+  defp parse_metadata_field("\"" <> rest), do: parse_metadata_field(rest, "\"")
+  defp parse_metadata_field("'" <> rest), do: parse_metadata_field(rest, "'")
+  defp parse_metadata_field(_rest), do: :error
+
+  defp parse_metadata_field(rest, quote) do
+    suffix = "#{quote}]"
+
+    if String.ends_with?(rest, suffix) do
+      key = String.slice(rest, 0, byte_size(rest) - byte_size(suffix))
+      if key == "", do: :error, else: {:ok, key}
+    else
+      :error
+    end
+  end
+
+  defp parse_value(value) do
+    value = String.trim(value)
+
+    cond do
+      String.starts_with?(value, "\"") ->
+        parse_quoted_value(String.slice(value, 1..-1//1), "\"")
+
+      String.starts_with?(value, "'") ->
+        parse_quoted_value(String.slice(value, 1..-1//1), "'")
+
+      String.downcase(value) == "null" ->
+        {:ok, %{quoted?: false, value: :null}}
+
+      true ->
+        {:ok, %{quoted?: false, value: value}}
+    end
+  end
+
+  defp parse_quoted_value(value, quote) do
+    value
+    |> String.graphemes()
+    |> parse_quoted_value([], quote, false)
+  end
+
+  defp parse_quoted_value([], _acc, _quote, _escaped), do: invalid("Unterminated quoted string")
+
+  defp parse_quoted_value(["\\" | rest], acc, quote, false) do
+    parse_quoted_value(rest, acc, quote, true)
+  end
+
+  defp parse_quoted_value([char | rest], acc, quote, true) do
+    parse_quoted_value(rest, [char | acc], quote, false)
+  end
+
+  defp parse_quoted_value([quote | rest], acc, quote, false) do
+    rest
+    |> Enum.join()
+    |> String.trim()
+    |> case do
+      "" ->
+        {:ok, %{quoted?: true, value: acc |> Enum.reverse() |> Enum.join()}}
+
+      _ ->
+        invalid("Unexpected characters after quoted value")
+    end
+  end
+
+  defp parse_quoted_value([char | rest], acc, quote, false) do
+    parse_quoted_value(rest, [char | acc], quote, false)
+  end
+
+  defp validate_ast(%{clauses: clauses} = ast, fields) do
+    with {:ok, clauses} <- validate_clauses(clauses, fields) do
+      {:ok, %{ast | clauses: clauses}}
+    end
+  end
+
+  defp validate_clauses(clauses, fields) do
+    clauses
+    |> Enum.reduce_while({:ok, []}, fn clause, {:ok, acc} ->
+      case validate_clause(clause, fields) do
+        {:ok, clause} -> {:cont, {:ok, [clause | acc]}}
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
+    |> case do
+      {:ok, clauses} -> {:ok, Enum.reverse(clauses)}
+      error -> error
+    end
+  end
+
+  defp validate_clause(%{field: field} = clause, fields) do
+    with {:ok, type} <- field_type(fields, field),
+         :ok <- validate_operator(clause.operator, type, clause.value),
+         {:ok, value} <- normalize_clause_value(clause.value, clause.operator, type) do
+      {:ok, clause |> Map.put(:type, type) |> Map.put(:value, value)}
+    end
+  end
+
+  defp field_type(fields, field) do
+    case Map.fetch(fields, field) do
+      {:ok, type} ->
+        {:ok, type}
+
+      :error ->
+        invalid("Unsupported search field '#{field}'")
+    end
+  end
+
+  defp validate_operator(:exact, _type, _value), do: :ok
+  defp validate_operator(:substring, :string, value) when value != :null, do: validate_substring_value(value)
+
+  defp validate_operator(operator, :numeric, value) when operator in [:gt, :gte, :lt, :lte, :equals] and value != :null,
+    do: :ok
+
+  defp validate_operator(:substring, _type, _value) do
+    invalid("Substring search is only supported for string fields")
+  end
+
+  defp validate_operator(operator, _type, _value) when operator in [:gt, :gte, :lt, :lte, :equals] do
+    invalid("Numeric comparison is only supported for numeric fields")
+  end
+
+  defp validate_operator(_operator, _type, :null) do
+    invalid("Null search only supports exact-match syntax")
+  end
+
+  defp validate_substring_value(value) when is_binary(value) and byte_size(value) >= 3, do: :ok
+  defp validate_substring_value(_value), do: invalid("Substring search terms must contain at least 3 characters")
+
+  defp normalize_clause_value(:null, _operator, _type), do: {:ok, :null}
+
+  defp normalize_clause_value(value, operator, :numeric) when operator in [:exact, :equals, :gt, :gte, :lt, :lte] do
+    case parse_number(value) do
+      {:ok, number} -> {:ok, number}
+      :error -> invalid("Numeric search values must be valid numbers")
+    end
+  end
+
+  defp normalize_clause_value(value, _operator, _type), do: {:ok, value}
+
+  defp matches?(item, %{clauses: clauses, connector: :and}) do
+    Enum.all?(clauses, &matches_clause?(item, &1))
+  end
+
+  defp matches?(item, %{clauses: clauses, connector: :or}) do
+    Enum.any?(clauses, &matches_clause?(item, &1))
+  end
+
+  defp matches_clause?(item, clause) do
+    matched =
+      item
+      |> value_at(clause.path)
+      |> value_matches?(clause)
+
+    if clause.negated, do: not matched, else: matched
+  end
+
+  defp value_matches?(actual, %{operator: :exact, value: :null}) do
+    is_nil(actual) or actual == ""
+  end
+
+  defp value_matches?(actual, %{operator: operator, type: :numeric, value: expected}) do
+    case parse_number(actual) do
+      {:ok, actual} -> compare_numbers(actual, operator, expected)
+      :error -> false
+    end
+  end
+
+  defp value_matches?(actual, %{operator: :exact, type: :string, value: expected}) do
+    actual
+    |> string_value()
+    |> case do
+      nil -> false
+      actual -> String.contains?(normalize_search_string(actual), normalize_search_string(expected))
+    end
+  end
+
+  defp value_matches?(actual, %{operator: :substring, type: :string, value: expected}) do
+    actual
+    |> string_value()
+    |> case do
+      nil -> false
+      actual -> String.contains?(normalize_search_string(actual), normalize_search_string(expected))
+    end
+  end
+
+  defp value_matches?(actual, %{operator: :exact, type: :token, value: expected}) do
+    case token_value(actual) do
+      nil -> false
+      actual -> actual == normalize_token(expected)
+    end
+  end
+
+  defp value_matches?(_actual, _clause), do: false
+
+  defp compare_numbers(actual, :exact, expected), do: actual == expected
+  defp compare_numbers(actual, :equals, expected), do: actual == expected
+  defp compare_numbers(actual, :gt, expected), do: actual > expected
+  defp compare_numbers(actual, :gte, expected), do: actual >= expected
+  defp compare_numbers(actual, :lt, expected), do: actual < expected
+  defp compare_numbers(actual, :lte, expected), do: actual <= expected
+
+  defp value_at(item, ["metadata", key]) do
+    case value_at(item, ["metadata"]) do
+      metadata when is_map(metadata) ->
+        fetch_map_value(metadata, key)
+        |> case do
+          {:ok, value} -> value
+          :error -> nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp value_at(item, path) do
+    Enum.reduce_while(path, item, fn key, acc ->
+      case fetch_map_value(acc, key) do
+        {:ok, value} -> {:cont, value}
+        :error -> {:halt, nil}
+      end
+    end)
+  end
+
+  defp fetch_map_value(map, key) when is_map(map) do
+    cond do
+      Map.has_key?(map, key) ->
+        {:ok, Map.fetch!(map, key)}
+
+      atom = existing_atom(key) ->
+        if Map.has_key?(map, atom) do
+          {:ok, Map.fetch!(map, atom)}
+        else
+          :error
+        end
+
+      true ->
+        :error
+    end
+  end
+
+  defp fetch_map_value(_value, _key), do: :error
+
+  defp existing_atom(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp parse_number(value) when is_integer(value), do: {:ok, value}
+  defp parse_number(value) when is_float(value), do: {:ok, value}
+
+  defp parse_number(value) when is_binary(value) do
+    cond do
+      Regex.match?(~r/\A-?\d+\z/, value) ->
+        {number, ""} = Integer.parse(value)
+        {:ok, number}
+
+      Regex.match?(~r/\A-?\d+\.\d+\z/, value) ->
+        {number, ""} = Float.parse(value)
+        {:ok, number}
+
+      true ->
+        :error
+    end
+  end
+
+  defp parse_number(_value), do: :error
+
+  defp string_value(value) when is_binary(value), do: value
+  defp string_value(value) when is_integer(value), do: Integer.to_string(value)
+  defp string_value(value) when is_float(value), do: Float.to_string(value)
+  defp string_value(_value), do: nil
+
+  defp token_value(nil), do: nil
+  defp token_value(value), do: value |> to_string() |> normalize_token()
+
+  defp normalize_token(value), do: value |> to_string() |> String.downcase()
+
+  defp normalize_search_string(value) do
+    value
+    |> to_string()
+    |> String.downcase()
+  end
+
+  defp paginate_search(items, limit, offset, url, decorate, include_total_count?) do
+    page = items |> Enum.drop(offset) |> Enum.take(limit + 1)
+    has_more = length(page) > limit
+
+    data =
+      page
+      |> Enum.take(limit)
+      |> Enum.map(decorate)
+
+    %{
+      data: data,
+      has_more: has_more,
+      next_page: if(has_more, do: encode_page(offset + limit)),
+      object: "search_result",
+      url: url
+    }
+    |> maybe_put_total_count(include_total_count?, length(items))
+  end
+
+  defp maybe_put_total_count(result, true, total_count), do: Map.put(result, :total_count, total_count)
+  defp maybe_put_total_count(result, false, _total_count), do: result
+
+  defp parse_limit(nil), do: {:ok, @default_limit}
+
+  defp parse_limit(limit) when is_integer(limit) do
+    if limit > 0 do
+      {:ok, min(limit, @max_limit)}
+    else
+      invalid("Invalid positive integer", "limit")
+    end
+  end
+
+  defp parse_limit(limit) when is_binary(limit) do
+    case Integer.parse(limit) do
+      {limit, ""} -> parse_limit(limit)
+      _ -> invalid("Invalid positive integer", "limit")
+    end
+  end
+
+  defp parse_limit(_limit), do: invalid("Invalid positive integer", "limit")
+
+  defp parse_page(nil), do: {:ok, 0}
+
+  defp parse_page("pt_search_" <> offset) do
+    case Integer.parse(offset) do
+      {offset, ""} when offset >= 0 -> {:ok, offset}
+      _ -> invalid("Invalid page cursor", "page")
+    end
+  end
+
+  defp parse_page(_page), do: invalid("Invalid page cursor", "page")
+
+  defp encode_page(offset), do: "pt_search_#{offset}"
+
+  defp sortable_created(item) do
+    case value_at(item, ["created"]) do
+      value when is_integer(value) -> value
+      value when is_binary(value) -> value |> parse_number() |> elem_or_zero()
+      _ -> 0
+    end
+  end
+
+  defp elem_or_zero({:ok, value}), do: value
+  defp elem_or_zero(:error), do: 0
+
+  defp expand_total_count?(params) do
+    case get_param(params, :expand) do
+      values when is_list(values) -> Enum.member?(values, "total_count")
+      "total_count" -> true
+      _ -> false
+    end
+  end
+
+  defp get_param(params, key) when is_map(params) do
+    Map.get(params, key) || Map.get(params, to_string(key))
+  end
+
+  defp invalid(message, param \\ "query") do
+    {:error, PaperTiger.Error.invalid_request(message, param)}
+  end
+end

--- a/test/paper_tiger/contract_test.exs
+++ b/test/paper_tiger/contract_test.exs
@@ -194,6 +194,41 @@ defmodule PaperTiger.ContractTest do
     end
   end
 
+  describe "Search Operations" do
+    @tag :contract
+    test "searches customers by email and metadata" do
+      marker = "pt_search_#{System.unique_integer([:positive])}"
+      email = "#{marker}@example.com"
+
+      {:ok, customer} =
+        TestClient.create_customer(%{
+          "email" => email,
+          "metadata" => %{"paper_tiger_search" => marker},
+          "name" => "PaperTiger Search Contract"
+        })
+
+      query = "email:'#{email}' AND metadata['paper_tiger_search']:'#{marker}'"
+      result = eventually_search_customer(query, customer["id"])
+
+      assert result["object"] == "search_result"
+      assert is_list(result["data"])
+      assert is_boolean(result["has_more"])
+      assert Enum.any?(result["data"], fn item -> item["id"] == customer["id"] end)
+
+      cleanup_customer(customer["id"])
+    end
+
+    @tag :contract
+    test "search returns an invalid request error for mixed connectors" do
+      {:error, error} =
+        TestClient.search_customers(%{
+          "query" => "email:'one@example.com' AND email:'two@example.com' OR email:'three@example.com'"
+        })
+
+      assert error["error"]["type"] == "invalid_request_error"
+    end
+  end
+
   describe "Subscription CRUD Operations" do
     # Helper to create a product and price for subscription tests
     defp create_test_price(name, amount \\ 2000) do
@@ -1362,4 +1397,51 @@ defmodule PaperTiger.ContractTest do
     # Just leave them - they're in test mode anyway
     :ok
   end
+
+  defp eventually_search_customer(query, customer_id) do
+    attempts = if TestClient.real_stripe?(), do: 20, else: 1
+
+    1..attempts
+    |> Enum.find_value(fn attempt ->
+      query
+      |> search_customer_once(customer_id)
+      |> handle_search_attempt(attempt, attempts)
+    end)
+    |> case do
+      nil -> flunk("Customer #{customer_id} did not appear in search results for #{inspect(query)}")
+      result -> result
+    end
+  end
+
+  defp search_customer_once(query, customer_id) do
+    case TestClient.search_customers(%{"limit" => 10, "query" => query}) do
+      {:ok, result} -> maybe_found_customer(result, customer_id)
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  defp maybe_found_customer(result, customer_id) do
+    if Enum.any?(result["data"], fn item -> item["id"] == customer_id end) do
+      {:found, result}
+    else
+      :missing
+    end
+  end
+
+  defp handle_search_attempt({:found, result}, _attempt, _attempts), do: result
+
+  defp handle_search_attempt(:missing, attempt, attempts) do
+    maybe_wait_for_search_index(attempt, attempts)
+    nil
+  end
+
+  defp handle_search_attempt({:error, error}, _attempt, _attempts) do
+    flunk("Customer search failed: #{inspect(error)}")
+  end
+
+  defp maybe_wait_for_search_index(attempt, attempts) when attempt < attempts and attempts > 1 do
+    Process.sleep(3_000)
+  end
+
+  defp maybe_wait_for_search_index(_attempt, _attempts), do: :ok
 end

--- a/test/paper_tiger/resources/search_test.exs
+++ b/test/paper_tiger/resources/search_test.exs
@@ -1,0 +1,225 @@
+defmodule PaperTiger.Resources.SearchTest do
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
+
+  alias PaperTiger.Router
+
+  setup :checkout_paper_tiger
+
+  defp request(method, path, params) do
+    path = maybe_put_query_string(method, path, params)
+    body = if method in [:get, :delete], do: "", else: params
+    conn = Plug.Test.conn(method, path, body)
+
+    [{"content-type", "application/json"}, {"authorization", "Bearer sk_test_search_key"}]
+    |> Kernel.++(sandbox_headers())
+    |> Enum.reduce(conn, fn {key, value}, acc -> Plug.Conn.put_req_header(acc, key, value) end)
+    |> Router.call([])
+  end
+
+  defp maybe_put_query_string(method, path, params) when method in [:get, :delete] and map_size(params) > 0 do
+    "#{path}?#{URI.encode_query(params)}"
+  end
+
+  defp maybe_put_query_string(_method, path, _params), do: path
+
+  defp json_response(conn), do: Jason.decode!(conn.resp_body)
+
+  describe "GET /v1/customers/search" do
+    test "filters by string, metadata, numeric clauses, and negation" do
+      target =
+        create_customer(%{
+          "created" => 2_000,
+          "email" => "search-target@example.com",
+          "metadata" => %{"batch" => "search-suite", "tier" => "gold"},
+          "name" => "Search Target"
+        })
+
+      _other =
+        create_customer(%{
+          "created" => 1_500,
+          "email" => "other@example.com",
+          "metadata" => %{"batch" => "search-suite", "tier" => "gold"},
+          "name" => "Other Person"
+        })
+
+      conn =
+        request(:get, "/v1/customers/search", %{
+          "query" => "email:'search-target@example.com' AND metadata['tier']:'gold' AND created>=2000"
+        })
+
+      assert conn.status == 200
+      result = json_response(conn)
+      assert result["object"] == "search_result"
+      assert result["url"] == "/v1/customers/search"
+      assert result["has_more"] == false
+      assert result["next_page"] == nil
+      assert Enum.map(result["data"], & &1["id"]) == [target["id"]]
+
+      conn =
+        request(:get, "/v1/customers/search", %{
+          "query" => "metadata['batch']:'search-suite' AND -email:'other@example.com'"
+        })
+
+      assert conn.status == 200
+      assert json_response(conn)["data"] |> Enum.map(& &1["id"]) == [target["id"]]
+    end
+
+    test "supports substring matching and search pagination" do
+      customers =
+        for created <- [10, 20, 30] do
+          create_customer(%{
+            "created" => created,
+            "email" => "page-#{created}@example.com",
+            "metadata" => %{"batch" => "page"},
+            "name" => "Page Target #{created}"
+          })
+        end
+
+      expected_ids =
+        customers
+        |> Enum.sort_by(& &1["created"], :desc)
+        |> Enum.map(& &1["id"])
+
+      first =
+        request(:get, "/v1/customers/search", %{
+          "limit" => "2",
+          "query" => "name~'target' AND metadata['batch']:'page'"
+        })
+        |> json_response()
+
+      assert first["has_more"] == true
+      assert is_binary(first["next_page"])
+      assert Enum.map(first["data"], & &1["id"]) == Enum.take(expected_ids, 2)
+
+      second =
+        request(:get, "/v1/customers/search", %{
+          "limit" => "2",
+          "page" => first["next_page"],
+          "query" => "name~'target' AND metadata['batch']:'page'"
+        })
+        |> json_response()
+
+      assert second["has_more"] == false
+      assert second["next_page"] == nil
+      assert Enum.map(second["data"], & &1["id"]) == Enum.drop(expected_ids, 2)
+    end
+
+    test "supports OR queries without mixing boolean connectors" do
+      first = create_customer(%{"email" => "or-one@example.com", "metadata" => %{"group" => "or-test"}})
+      second = create_customer(%{"email" => "or-two@example.com", "metadata" => %{"group" => "or-test"}})
+
+      conn =
+        request(:get, "/v1/customers/search", %{
+          "query" => "email:'or-one@example.com' OR email:'or-two@example.com'"
+        })
+
+      assert conn.status == 200
+      ids = conn |> json_response() |> Map.fetch!("data") |> Enum.map(& &1["id"])
+      assert Enum.sort(ids) == Enum.sort([first["id"], second["id"]])
+    end
+  end
+
+  describe "search endpoints across resources" do
+    test "searches payment intents, charges, invoices, and subscriptions with resource schemas" do
+      customer = create_customer(%{"email" => "resource-search@example.com"})
+      product = create_product(%{"name" => "Resource Search"})
+
+      price =
+        create_price(%{
+          "currency" => "usd",
+          "product" => product["id"],
+          "recurring" => %{"interval" => "month"},
+          "unit_amount" => 1200
+        })
+
+      payment_intent =
+        create_payment_intent(%{
+          "amount" => 2_500,
+          "currency" => "usd",
+          "customer" => customer["id"],
+          "metadata" => %{"case" => "pi"}
+        })
+
+      charge =
+        create_charge(%{
+          "amount" => 800,
+          "currency" => "usd",
+          "customer" => customer["id"],
+          "metadata" => %{"case" => "charge"}
+        })
+
+      invoice =
+        create_invoice(%{
+          "customer" => customer["id"],
+          "metadata" => %{"case" => "invoice"},
+          "total" => 1_200
+        })
+
+      subscription =
+        create_subscription(%{
+          "customer" => customer["id"],
+          "items" => [%{"price" => price["id"]}],
+          "metadata" => %{"case" => "subscription"}
+        })
+
+      assert one_result_id("/v1/payment_intents/search", "customer:'#{customer["id"]}' AND amount>=2500") ==
+               payment_intent["id"]
+
+      assert one_result_id("/v1/charges/search", "customer:'#{customer["id"]}' AND amount=800") == charge["id"]
+
+      assert one_result_id("/v1/invoices/search", "customer:'#{customer["id"]}' AND total>=1200") == invoice["id"]
+
+      assert one_result_id("/v1/subscriptions/search", "metadata['case']:'subscription' AND status:'active'") ==
+               subscription["id"]
+    end
+  end
+
+  describe "search errors" do
+    test "returns Stripe-shaped errors for unsupported fields and operators" do
+      conn = request(:get, "/v1/customers/search", %{"query" => "customer:'cus_123'"})
+
+      assert conn.status == 400
+      error = json_response(conn)["error"]
+      assert error["type"] == "invalid_request_error"
+      assert error["param"] == "query"
+      assert error["message"] =~ "Unsupported search field"
+
+      conn = request(:get, "/v1/customers/search", %{"query" => "email:'a' AND email:'b' OR email:'c'"})
+
+      assert conn.status == 400
+      assert json_response(conn)["error"]["message"] =~ "cannot mix AND and OR"
+
+      conn = request(:get, "/v1/customers/search", %{"query" => "metadata['tier']~'gold'"})
+
+      assert conn.status == 400
+      assert json_response(conn)["error"]["message"] =~ "Substring search is only supported"
+    end
+  end
+
+  defp create_customer(params), do: create(:post, "/v1/customers", params)
+  defp create_payment_intent(params), do: create(:post, "/v1/payment_intents", params)
+  defp create_charge(params), do: create(:post, "/v1/charges", params)
+  defp create_invoice(params), do: create(:post, "/v1/invoices", params)
+  defp create_product(params), do: create(:post, "/v1/products", params)
+  defp create_price(params), do: create(:post, "/v1/prices", params)
+  defp create_subscription(params), do: create(:post, "/v1/subscriptions", params)
+
+  defp create(method, path, params) do
+    conn = request(method, path, params)
+    assert conn.status == 200
+    json_response(conn)
+  end
+
+  defp one_result_id(path, query) do
+    conn = request(:get, path, %{"query" => query})
+    assert conn.status == 200
+
+    result = json_response(conn)
+    assert result["object"] == "search_result"
+    assert length(result["data"]) == 1
+
+    result["data"] |> List.first() |> Map.fetch!("id")
+  end
+end

--- a/test/support/test_client.ex
+++ b/test/support/test_client.ex
@@ -343,6 +343,19 @@ defmodule PaperTiger.TestClient do
     end
   end
 
+  @doc """
+  Searches customers.
+  """
+  def search_customers(params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        search_customers_real(params)
+
+      :paper_tiger ->
+        search_customers_mock(params)
+    end
+  end
+
   ## Product Operations
 
   @doc """
@@ -463,6 +476,19 @@ defmodule PaperTiger.TestClient do
 
       :paper_tiger ->
         list_subscriptions_mock(params)
+    end
+  end
+
+  @doc """
+  Searches subscriptions.
+  """
+  def search_subscriptions(params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        search_subscriptions_real(params)
+
+      :paper_tiger ->
+        search_subscriptions_mock(params)
     end
   end
 
@@ -630,6 +656,19 @@ defmodule PaperTiger.TestClient do
     end
   end
 
+  @doc """
+  Searches charges.
+  """
+  def search_charges(params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        search_charges_real(params)
+
+      :paper_tiger ->
+        search_charges_mock(params)
+    end
+  end
+
   ## BalanceTransaction Operations
 
   @doc """
@@ -709,6 +748,19 @@ defmodule PaperTiger.TestClient do
 
       :paper_tiger ->
         capture_payment_intent_mock(payment_intent_id, params)
+    end
+  end
+
+  @doc """
+  Searches payment intents.
+  """
+  def search_payment_intents(params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        search_payment_intents_real(params)
+
+      :paper_tiger ->
+        search_payment_intents_mock(params)
     end
   end
 
@@ -891,6 +943,19 @@ defmodule PaperTiger.TestClient do
     end
   end
 
+  @doc """
+  Searches invoices.
+  """
+  def search_invoices(params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        search_invoices_real(params)
+
+      :paper_tiger ->
+        search_invoices_mock(params)
+    end
+  end
+
   ## InvoiceItem Operations
 
   @doc """
@@ -941,6 +1006,12 @@ defmodule PaperTiger.TestClient do
             params: params
           ]
 
+        :delete ->
+          [
+            headers: headers,
+            params: params
+          ]
+
         :post ->
           [
             body: params_to_form_data(params),
@@ -967,47 +1038,27 @@ defmodule PaperTiger.TestClient do
   end
 
   defp create_customer_real(params) do
-    case Stripe.Customer.create(normalize_params(params), stripe_opts()) do
-      {:ok, customer} -> {:ok, stripe_to_map(customer)}
-      {:error, error} -> {:error, stripe_error_to_map(error)}
-    end
+    stripe_request(:post, "/v1/customers", params)
   end
 
   defp get_customer_real(customer_id) do
-    case Stripe.Customer.retrieve(customer_id, %{}, stripe_opts()) do
-      {:ok, customer} -> {:ok, stripe_to_map(customer)}
-      {:error, error} -> {:error, stripe_error_to_map(error)}
-    end
+    stripe_request(:get, "/v1/customers/#{customer_id}")
   end
 
   defp update_customer_real(customer_id, params) do
-    case Stripe.Customer.update(customer_id, normalize_params(params), stripe_opts()) do
-      {:ok, customer} -> {:ok, stripe_to_map(customer)}
-      {:error, error} -> {:error, stripe_error_to_map(error)}
-    end
+    stripe_request(:post, "/v1/customers/#{customer_id}", params)
   end
 
   defp delete_customer_real(customer_id) do
-    case Stripe.Customer.delete(customer_id, stripe_opts()) do
-      {:ok, result} ->
-        # stripity_stripe loses the "deleted" field when converting to struct
-        # Add it back since a successful delete means deleted=true
-        map = stripe_to_map(result)
-        {:ok, Map.put(map, "deleted", true)}
-
-      {:error, error} ->
-        {:error, stripe_error_to_map(error)}
-    end
+    stripe_request(:delete, "/v1/customers/#{customer_id}")
   end
 
   defp list_customers_real(params) do
-    case Stripe.Customer.list(normalize_params(params), stripe_opts()) do
-      {:ok, %{data: customers, has_more: has_more}} ->
-        {:ok, %{"data" => Enum.map(customers, &stripe_to_map/1), "has_more" => has_more}}
+    stripe_request(:get, "/v1/customers", params)
+  end
 
-      {:error, error} ->
-        {:error, stripe_error_to_map(error)}
-    end
+  defp search_customers_real(params) do
+    stripe_request(:get, "/v1/customers/search", params)
   end
 
   defp create_subscription_real(params) do
@@ -1046,6 +1097,10 @@ defmodule PaperTiger.TestClient do
       {:error, error} ->
         {:error, stripe_error_to_map(error)}
     end
+  end
+
+  defp search_subscriptions_real(params) do
+    stripe_request(:get, "/v1/subscriptions/search", params)
   end
 
   defp create_payment_method_real(params) do
@@ -1124,6 +1179,10 @@ defmodule PaperTiger.TestClient do
     end
   end
 
+  defp search_invoices_real(params) do
+    stripe_request(:get, "/v1/invoices/search", params)
+  end
+
   defp create_invoice_item_real(params) do
     case Stripe.Invoiceitem.create(normalize_params(params), stripe_opts()) do
       {:ok, item} -> {:ok, stripe_to_map(item)}
@@ -1177,6 +1236,10 @@ defmodule PaperTiger.TestClient do
     stripe_request(:get, "/v1/charges/#{charge_id}")
   end
 
+  defp search_charges_real(params) do
+    stripe_request(:get, "/v1/charges/search", params)
+  end
+
   defp create_payment_intent_real(params) do
     stripe_request(:post, "/v1/payment_intents", params)
   end
@@ -1195,6 +1258,10 @@ defmodule PaperTiger.TestClient do
 
   defp capture_payment_intent_real(payment_intent_id, params) do
     stripe_request(:post, "/v1/payment_intents/#{payment_intent_id}/capture", params)
+  end
+
+  defp search_payment_intents_real(params) do
+    stripe_request(:get, "/v1/payment_intents/search", params)
   end
 
   defp create_setup_intent_real(params) do
@@ -1286,6 +1353,11 @@ defmodule PaperTiger.TestClient do
     handle_response(conn)
   end
 
+  defp search_customers_mock(params) do
+    conn = request(:get, "/v1/customers/search", params)
+    handle_response(conn)
+  end
+
   defp create_subscription_mock(params) do
     conn = request(:post, "/v1/subscriptions", params)
     handle_response(conn)
@@ -1308,6 +1380,11 @@ defmodule PaperTiger.TestClient do
 
   defp list_subscriptions_mock(params) do
     conn = request(:get, "/v1/subscriptions", params)
+    handle_response(conn)
+  end
+
+  defp search_subscriptions_mock(params) do
+    conn = request(:get, "/v1/subscriptions/search", params)
     handle_response(conn)
   end
 
@@ -1361,6 +1438,11 @@ defmodule PaperTiger.TestClient do
     handle_response(conn)
   end
 
+  defp search_invoices_mock(params) do
+    conn = request(:get, "/v1/invoices/search", params)
+    handle_response(conn)
+  end
+
   defp create_invoice_item_mock(params) do
     conn = request(:post, "/v1/invoiceitems", params)
     handle_response(conn)
@@ -1401,6 +1483,11 @@ defmodule PaperTiger.TestClient do
     handle_response(conn)
   end
 
+  defp search_charges_mock(params) do
+    conn = request(:get, "/v1/charges/search", params)
+    handle_response(conn)
+  end
+
   defp create_payment_intent_mock(params) do
     conn = request(:post, "/v1/payment_intents", params)
     handle_response(conn)
@@ -1423,6 +1510,11 @@ defmodule PaperTiger.TestClient do
 
   defp capture_payment_intent_mock(payment_intent_id, params) do
     conn = request(:post, "/v1/payment_intents/#{payment_intent_id}/capture", params)
+    handle_response(conn)
+  end
+
+  defp search_payment_intents_mock(params) do
+    conn = request(:get, "/v1/payment_intents/search", params)
     handle_response(conn)
   end
 


### PR DESCRIPTION
## Summary
- add a shared Stripe-style search parser/evaluator with resource field schemas, metadata predicates, boolean connectors, negation, numeric comparisons, substring matching, and search-result pagination
- wire `GET /v1/customers/search`, `/v1/subscriptions/search`, `/v1/payment_intents/search`, `/v1/charges/search`, and `/v1/invoices/search` before generic `/:id` routes
- add mock coverage across all five search resources plus live Stripe contract coverage for customer search
- move real-mode customer contract helpers to direct Req calls to avoid transport failures below the search behavior under test

Closes #64.

## Validation
- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix test --warnings-as-errors`
- `mix credo --strict --all`
- `mix dialyzer`
- `VALIDATE_AGAINST_STRIPE=true mix test test/paper_tiger/contract_test.exs:199 test/paper_tiger/contract_test.exs:222 --warnings-as-errors`