### PR TITLE
Add hosted product APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stripe-style search endpoints for `GET /v1/customers/search`, `GET /v1/subscriptions/search`, `GET /v1/payment_intents/search`, `GET /v1/charges/search`, and `GET /v1/invoices/search`, backed by a shared query parser/evaluator with resource field schemas, metadata predicates, boolean connectors, negation, numeric comparisons, substring matching, search-result pagination, and Stripe-shaped unsupported-query errors.
 - Modern payment-method adjunct APIs: test-helper ConfirmationToken creation plus retrieval, PaymentMethodDomain create/retrieve/update/list, PaymentMethodConfiguration create/retrieve/update/list, CustomerSession creation with client secrets, and stored Mandate retrieval for successful mandate-bearing SetupIntent/PaymentIntent flows.
 - Invoice lifecycle endpoints for `POST /v1/invoices/:id/send`, `POST /v1/invoices/:id/mark_uncollectible`, and PaymentIntent-backed `POST /v1/invoices/:id/attach_payment`, including `invoice.sent`, `invoice.marked_uncollectible`, and `invoice.voided` webhook emission plus status-transition timestamps.
+- Hosted product APIs for Payment Links and Billing Portal: `POST/GET/POST/GET-list /v1/payment_links`, paginated `GET /v1/payment_links/:id/line_items`, browser-visible Payment Link URLs backed by deterministic Checkout Session completion, `POST /v1/billing_portal/sessions`, and Billing Portal Configuration create/retrieve/update/list endpoints.
 
 ### Fixed
 

--- a/lib/paper_tiger.ex
+++ b/lib/paper_tiger.ex
@@ -43,6 +43,8 @@ defmodule PaperTiger do
     ApplicationFees,
     BalanceTransactions,
     BankAccounts,
+    BillingPortalConfigurations,
+    BillingPortalSessions,
     Cards,
     Charges,
     CheckoutSessions,
@@ -55,6 +57,7 @@ defmodule PaperTiger do
     Invoices,
     Mandates,
     PaymentIntents,
+    PaymentLinks,
     PaymentMethodConfigurations,
     PaymentMethodDomains,
     PaymentMethods,
@@ -225,6 +228,7 @@ defmodule PaperTiger do
   def flush(:invoice_items), do: InvoiceItems.clear()
   def flush(:products), do: Products.clear()
   def flush(:prices), do: Prices.clear()
+  def flush(:payment_links), do: PaymentLinks.clear()
   def flush(:plans), do: Plans.clear()
   def flush(:payment_methods), do: PaymentMethods.clear()
   def flush(:payment_method_domains), do: PaymentMethodDomains.clear()
@@ -244,6 +248,8 @@ defmodule PaperTiger do
   def flush(:sources), do: Sources.clear()
   def flush(:tokens), do: Tokens.clear()
   def flush(:checkout_sessions), do: CheckoutSessions.clear()
+  def flush(:billing_portal_configurations), do: BillingPortalConfigurations.clear()
+  def flush(:billing_portal_sessions), do: BillingPortalSessions.clear()
   def flush(:webhooks), do: Webhooks.clear()
   def flush(:events), do: Events.clear()
   def flush(:payouts), do: Payouts.clear()

--- a/lib/paper_tiger/application.ex
+++ b/lib/paper_tiger/application.ex
@@ -8,6 +8,8 @@ defmodule PaperTiger.Application do
   alias PaperTiger.Store.ApplicationFees
   alias PaperTiger.Store.BalanceTransactions
   alias PaperTiger.Store.BankAccounts
+  alias PaperTiger.Store.BillingPortalConfigurations
+  alias PaperTiger.Store.BillingPortalSessions
   alias PaperTiger.Store.Cards
   alias PaperTiger.Store.Charges
   alias PaperTiger.Store.CheckoutSessions
@@ -20,6 +22,7 @@ defmodule PaperTiger.Application do
   alias PaperTiger.Store.Invoices
   alias PaperTiger.Store.Mandates
   alias PaperTiger.Store.PaymentIntents
+  alias PaperTiger.Store.PaymentLinks
   alias PaperTiger.Store.PaymentMethodConfigurations
   alias PaperTiger.Store.PaymentMethodDomains
   alias PaperTiger.Store.PaymentMethods
@@ -73,6 +76,7 @@ defmodule PaperTiger.Application do
         Subscriptions,
         Products,
         Prices,
+        PaymentLinks,
         Invoices,
         PaymentMethods,
         PaymentMethodDomains,
@@ -97,6 +101,8 @@ defmodule PaperTiger.Application do
         BalanceTransactions,
         Payouts,
         CheckoutSessions,
+        BillingPortalConfigurations,
+        BillingPortalSessions,
         Events,
         WebhookDeliveries,
         Webhooks,

--- a/lib/paper_tiger/hydrator.ex
+++ b/lib/paper_tiger/hydrator.ex
@@ -31,6 +31,8 @@ defmodule PaperTiger.Hydrator do
   alias PaperTiger.Store.ApplicationFees
   alias PaperTiger.Store.BalanceTransactions
   alias PaperTiger.Store.BankAccounts
+  alias PaperTiger.Store.BillingPortalConfigurations
+  alias PaperTiger.Store.BillingPortalSessions
   alias PaperTiger.Store.Cards
   alias PaperTiger.Store.Charges
   alias PaperTiger.Store.CheckoutSessions
@@ -43,6 +45,7 @@ defmodule PaperTiger.Hydrator do
   alias PaperTiger.Store.Invoices
   alias PaperTiger.Store.Mandates
   alias PaperTiger.Store.PaymentIntents
+  alias PaperTiger.Store.PaymentLinks
   alias PaperTiger.Store.PaymentMethodConfigurations
   alias PaperTiger.Store.PaymentMethodDomains
   alias PaperTiger.Store.PaymentMethods
@@ -68,6 +71,8 @@ defmodule PaperTiger.Hydrator do
     ApplicationFees,
     BalanceTransactions,
     BankAccounts,
+    BillingPortalConfigurations,
+    BillingPortalSessions,
     Cards,
     Charges,
     CheckoutSessions,
@@ -80,6 +85,7 @@ defmodule PaperTiger.Hydrator do
     Invoices,
     Mandates,
     PaymentIntents,
+    PaymentLinks,
     PaymentMethodConfigurations,
     PaymentMethodDomains,
     PaymentMethods,

--- a/lib/paper_tiger/line_items.ex
+++ b/lib/paper_tiger/line_items.ex
@@ -1,0 +1,278 @@
+defmodule PaperTiger.LineItems do
+  @moduledoc false
+
+  import PaperTiger.Resource, only: [generate_id: 1, get_integer: 3, to_integer: 1]
+
+  alias PaperTiger.Store.Prices
+
+  @known_keys [
+    :amount,
+    :amount_discount,
+    :amount_subtotal,
+    :amount_tax,
+    :amount_total,
+    :currency,
+    :description,
+    :id,
+    :price,
+    :price_data,
+    :quantity,
+    :session,
+    :payment_link,
+    :unit_amount,
+    :unit_amount_excluding_tax
+  ]
+
+  @doc """
+  Normalizes Stripe line item params into a stored list item shape.
+  """
+  @spec normalize([map()] | term(), atom(), String.t()) :: [map()]
+  def normalize(line_items, owner_key, owner_id) when is_list(line_items) and is_atom(owner_key) do
+    Enum.map(line_items, &normalize_item(&1, owner_key, owner_id))
+  end
+
+  def normalize(_line_items, _owner_key, _owner_id), do: []
+
+  @doc """
+  Moves already-normalized line items to another owning object.
+  """
+  @spec reassign([map()] | term(), atom(), String.t()) :: [map()]
+  def reassign(line_items, owner_key, owner_id) when is_list(line_items) and is_atom(owner_key) do
+    Enum.map(line_items, fn item ->
+      item
+      |> normalize_keys()
+      |> Map.drop([:payment_link, :session])
+      |> Map.put(owner_key, owner_id)
+    end)
+  end
+
+  def reassign(_line_items, _owner_key, _owner_id), do: []
+
+  @doc """
+  Returns a Stripe list object for line item collections.
+  """
+  @spec paginate([map()], map(), String.t()) :: map()
+  def paginate(line_items, params, url) do
+    limit = params |> get_integer(:limit, 10) |> min(100)
+    starting_after = Map.get(params, :starting_after)
+    ending_before = Map.get(params, :ending_before)
+
+    line_items
+    |> apply_cursor(starting_after, ending_before)
+    |> Enum.take(limit + 1)
+    |> then(fn page ->
+      %{
+        data: Enum.take(page, limit),
+        has_more: length(page) > limit,
+        object: "list",
+        url: url
+      }
+    end)
+  end
+
+  @doc """
+  Calculates subtotal/total fields from normalized line items.
+  """
+  @spec totals([map()]) :: map()
+  def totals(line_items) when is_list(line_items) do
+    Enum.reduce(
+      line_items,
+      %{amount_discount: 0, amount_subtotal: 0, amount_tax: 0, amount_total: 0},
+      fn item, acc ->
+        %{
+          amount_discount: acc.amount_discount + (value(item, :amount_discount) || 0),
+          amount_subtotal: acc.amount_subtotal + (value(item, :amount_subtotal) || 0),
+          amount_tax: acc.amount_tax + (value(item, :amount_tax) || 0),
+          amount_total: acc.amount_total + (value(item, :amount_total) || 0)
+        }
+      end
+    )
+  end
+
+  def totals(_line_items), do: %{amount_discount: 0, amount_subtotal: 0, amount_tax: 0, amount_total: 0}
+
+  @doc """
+  Derives a currency from line item params or normalized line items.
+  """
+  @spec derive_currency([map()] | term()) :: String.t() | nil
+  def derive_currency(line_items) when is_list(line_items) do
+    Enum.find_value(line_items, fn item ->
+      value(item, :currency) ||
+        item |> value(:price) |> value(:currency) ||
+        item |> value(:price_data) |> value(:currency)
+    end)
+  end
+
+  def derive_currency(_line_items), do: nil
+
+  @doc false
+  @spec value(term(), atom()) :: term()
+  def value(nil, _key), do: nil
+
+  def value(map, key) when is_map(map) and is_atom(key) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  def value(_other, _key), do: nil
+
+  defp normalize_item(item, owner_key, owner_id) do
+    price = normalize_price(item)
+    quantity = item |> value(:quantity) |> to_integer_default(1)
+    unit_amount = unit_amount(item, price)
+    currency = currency(item, price)
+    amount_subtotal = value(item, :amount_subtotal) || unit_amount * quantity
+    amount_tax = value(item, :amount_tax) || 0
+    amount_discount = value(item, :amount_discount) || 0
+    amount_total = value(item, :amount_total) || amount_subtotal + amount_tax - amount_discount
+
+    item
+    |> normalize_keys()
+    |> Map.merge(%{
+      amount_discount: amount_discount,
+      amount_subtotal: amount_subtotal,
+      amount_tax: amount_tax,
+      amount_total: amount_total,
+      currency: currency,
+      description: description(item, price),
+      id: value(item, :id) || generate_id("li"),
+      object: "item",
+      price: price,
+      quantity: quantity,
+      unit_amount_excluding_tax: unit_amount
+    })
+    |> Map.drop([:amount, :price_data, :payment_link, :session])
+    |> Map.put(owner_key, owner_id)
+  end
+
+  defp normalize_keys(map) when is_map(map) do
+    Map.new(map, fn
+      {key, value} when is_binary(key) ->
+        known_key = Enum.find(@known_keys, &(Atom.to_string(&1) == key))
+        {known_key || key, value}
+
+      {key, value} ->
+        {key, value}
+    end)
+  end
+
+  defp normalize_keys(_), do: %{}
+
+  defp normalize_price(item) do
+    case value(item, :price) do
+      %{} = price -> price
+      price_id when is_binary(price_id) -> fetch_price(price_id)
+      _ -> build_price_from_price_data(item)
+    end
+  end
+
+  defp fetch_price(price_id) do
+    case Prices.get(price_id) do
+      {:ok, price} -> price
+      {:error, :not_found} -> minimal_price(price_id)
+    end
+  end
+
+  defp minimal_price(price_id) do
+    %{
+      active: true,
+      currency: "usd",
+      id: price_id,
+      livemode: false,
+      object: "price",
+      type: "one_time",
+      unit_amount: 0
+    }
+  end
+
+  defp build_price_from_price_data(item) do
+    case value(item, :price_data) do
+      %{} = price_data -> embedded_price(price_data)
+      _ -> nil
+    end
+  end
+
+  defp embedded_price(price_data) do
+    unit_amount = value(price_data, :unit_amount) || 0
+    recurring = value(price_data, :recurring)
+
+    %{
+      active: true,
+      currency: value(price_data, :currency) || "usd",
+      id: generate_id("price"),
+      livemode: false,
+      lookup_key: nil,
+      metadata: value(price_data, :metadata) || %{},
+      nickname: nil,
+      object: "price",
+      product: value(price_data, :product) || value(price_data, :product_data),
+      recurring: recurring,
+      tax_behavior: value(price_data, :tax_behavior) || "unspecified",
+      type: price_type(recurring),
+      unit_amount: to_integer(unit_amount),
+      unit_amount_decimal: to_string(unit_amount)
+    }
+  end
+
+  defp price_type(nil), do: "one_time"
+  defp price_type(false), do: "one_time"
+  defp price_type(_recurring), do: "recurring"
+
+  defp unit_amount(item, price) do
+    item
+    |> value(:unit_amount_excluding_tax)
+    |> case do
+      nil ->
+        value(item, :unit_amount) ||
+          value(item, :amount) ||
+          (price || value(item, :price)) |> value(:unit_amount) ||
+          item |> value(:price_data) |> value(:unit_amount) ||
+          0
+
+      amount ->
+        amount
+    end
+    |> to_integer_default()
+  end
+
+  defp currency(item, price) do
+    value(item, :currency) ||
+      value(price, :currency) ||
+      item |> value(:price_data) |> value(:currency) ||
+      "usd"
+  end
+
+  defp description(item, price) do
+    value(item, :description) ||
+      value(price, :nickname) ||
+      item |> value(:price_data) |> value(:product_data) |> value(:name)
+  end
+
+  defp apply_cursor(line_items, nil, nil), do: line_items
+
+  defp apply_cursor(line_items, starting_after, nil) when is_binary(starting_after) do
+    line_items
+    |> Enum.drop_while(fn item -> Map.get(item, :id) != starting_after end)
+    |> Enum.drop(1)
+  end
+
+  defp apply_cursor(line_items, nil, ending_before) when is_binary(ending_before) do
+    Enum.take_while(line_items, fn item -> Map.get(item, :id) != ending_before end)
+  end
+
+  defp apply_cursor(line_items, _starting_after, ending_before) do
+    apply_cursor(line_items, nil, ending_before)
+  end
+
+  defp to_integer_default(value, default \\ 0)
+  defp to_integer_default(value, _default) when is_integer(value), do: value
+
+  defp to_integer_default(value, default) when is_binary(value) do
+    case Integer.parse(value) do
+      {integer, _} -> integer
+      :error -> default
+    end
+  end
+
+  defp to_integer_default(nil, default), do: default
+  defp to_integer_default(_value, default), do: default
+end

--- a/lib/paper_tiger/plugs/auth.ex
+++ b/lib/paper_tiger/plugs/auth.ex
@@ -42,16 +42,25 @@ defmodule PaperTiger.Plugs.Auth do
 
   @impl true
   def call(conn, mode) do
-    case get_req_header(conn, "authorization") do
-      [] ->
-        send_auth_error(conn, "You did not provide an API key.")
+    if public_browser_path?(conn.request_path) do
+      conn
+    else
+      case get_req_header(conn, "authorization") do
+        [] ->
+          send_auth_error(conn, "You did not provide an API key.")
 
-      [auth_header | _] ->
-        validate_auth_header(conn, auth_header, mode)
+        [auth_header | _] ->
+          validate_auth_header(conn, auth_header, mode)
+      end
     end
   end
 
   ## Private Functions
+
+  defp public_browser_path?("/checkout/" <> _rest), do: true
+  defp public_browser_path?("/payment_links/" <> _rest), do: true
+  defp public_browser_path?("/billing_portal/sessions/" <> _rest), do: true
+  defp public_browser_path?(_path), do: false
 
   defp validate_auth_header(conn, "Bearer " <> key, mode) do
     validate_key(conn, key, mode)

--- a/lib/paper_tiger/resources/billing_portal_configuration.ex
+++ b/lib/paper_tiger/resources/billing_portal_configuration.ex
@@ -1,0 +1,160 @@
+defmodule PaperTiger.Resources.BillingPortalConfiguration do
+  @moduledoc """
+  Handles Billing Portal Configuration resource endpoints.
+  """
+
+  import PaperTiger.Resource
+
+  alias PaperTiger.Store.BillingPortalConfigurations
+
+  @doc """
+  Creates a Billing Portal Configuration.
+  """
+  @spec create(Plug.Conn.t()) :: Plug.Conn.t()
+  def create(conn) do
+    with {:ok, _params} <- validate_params(conn.params, [:features]),
+         configuration = build_configuration(conn.params),
+         {:ok, configuration} <- BillingPortalConfigurations.insert(configuration) do
+      maybe_store_idempotency(conn, configuration)
+
+      configuration
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :invalid_params, field} ->
+        error_response(conn, PaperTiger.Error.invalid_request("Missing required parameter", field))
+    end
+  end
+
+  @doc """
+  Retrieves a Billing Portal Configuration.
+  """
+  @spec retrieve(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def retrieve(conn, id) do
+    case BillingPortalConfigurations.get(id) do
+      {:ok, configuration} ->
+        configuration
+        |> maybe_expand(conn.params)
+        |> then(&json_response(conn, 200, &1))
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("billing_portal.configuration", id))
+    end
+  end
+
+  @doc """
+  Updates a Billing Portal Configuration.
+  """
+  @spec update(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def update(conn, id) do
+    case BillingPortalConfigurations.get(id) do
+      {:ok, existing} ->
+        updated =
+          existing
+          |> merge_updates(normalize_update_params(conn.params))
+          |> Map.put(:updated, PaperTiger.now())
+
+        {:ok, updated} = BillingPortalConfigurations.update(updated)
+
+        updated
+        |> maybe_expand(conn.params)
+        |> then(&json_response(conn, 200, &1))
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("billing_portal.configuration", id))
+    end
+  end
+
+  @doc """
+  Lists Billing Portal Configurations.
+  """
+  @spec list(Plug.Conn.t()) :: Plug.Conn.t()
+  def list(conn) do
+    conn.params
+    |> parse_pagination_params()
+    |> BillingPortalConfigurations.list()
+    |> then(&json_response(conn, 200, &1))
+  end
+
+  @doc false
+  @spec build_default() :: map()
+  def build_default do
+    build_configuration(%{is_default: true})
+  end
+
+  defp build_configuration(params) do
+    now = PaperTiger.now()
+
+    %{
+      active: boolean_param(params, :active, true),
+      application: nil,
+      business_profile: Map.get(params, :business_profile, default_business_profile()),
+      created: now,
+      default_return_url: Map.get(params, :default_return_url),
+      features: Map.get(params, :features, default_features()),
+      id: generate_id("bpc", Map.get(params, :id)),
+      is_default: boolean_param(params, :is_default, false),
+      livemode: false,
+      login_page: Map.get(params, :login_page, %{enabled: false, url: nil}),
+      metadata: Map.get(params, :metadata, %{}),
+      object: "billing_portal.configuration",
+      updated: now
+    }
+  end
+
+  defp default_business_profile do
+    %{
+      headline: nil,
+      privacy_policy_url: nil,
+      terms_of_service_url: nil
+    }
+  end
+
+  defp default_features do
+    %{
+      customer_update: %{allowed_updates: [], enabled: false},
+      invoice_history: %{enabled: true},
+      payment_method_update: %{enabled: false},
+      subscription_cancel: %{
+        cancellation_reason: %{enabled: false, options: []},
+        enabled: false,
+        mode: "at_period_end",
+        proration_behavior: "none"
+      },
+      subscription_update: %{
+        default_allowed_updates: [],
+        enabled: false,
+        products: [],
+        proration_behavior: "none"
+      }
+    }
+  end
+
+  defp maybe_expand(configuration, params) do
+    params
+    |> parse_expand_params()
+    |> then(&PaperTiger.Hydrator.hydrate(configuration, &1))
+  end
+
+  defp normalize_update_params(params) do
+    params
+    |> normalize_boolean_field(:active)
+    |> normalize_boolean_field(:is_default)
+  end
+
+  defp normalize_boolean_field(params, key) do
+    if Map.has_key?(params, key) do
+      Map.put(params, key, to_boolean(Map.get(params, key)))
+    else
+      params
+    end
+  end
+
+  defp boolean_param(params, key, default) do
+    if Map.has_key?(params, key) do
+      to_boolean(Map.get(params, key))
+    else
+      default
+    end
+  end
+end

--- a/lib/paper_tiger/resources/billing_portal_session.ex
+++ b/lib/paper_tiger/resources/billing_portal_session.ex
@@ -1,0 +1,117 @@
+defmodule PaperTiger.Resources.BillingPortalSession do
+  @moduledoc """
+  Handles Billing Portal Session creation and deterministic browser redirect.
+  """
+
+  import PaperTiger.Resource
+
+  alias PaperTiger.Resources.BillingPortalConfiguration
+  alias PaperTiger.Store.BillingPortalConfigurations
+  alias PaperTiger.Store.BillingPortalSessions
+  alias PaperTiger.Store.Customers
+
+  @doc """
+  Creates a Billing Portal Session.
+  """
+  @spec create(Plug.Conn.t()) :: Plug.Conn.t()
+  def create(conn) do
+    with {:ok, _params} <- validate_params(conn.params, [:customer]),
+         :ok <- validate_customer(conn.params.customer),
+         {:ok, configuration} <- resolve_configuration(Map.get(conn.params, :configuration)),
+         session = build_session(conn.params, configuration),
+         {:ok, session} <- BillingPortalSessions.insert(session) do
+      maybe_store_idempotency(conn, session)
+      json_response(conn, 200, session)
+    else
+      {:error, :invalid_params, field} ->
+        error_response(conn, PaperTiger.Error.invalid_request("Missing required parameter", field))
+
+      {:error, :customer_not_found, customer_id} ->
+        error_response(conn, PaperTiger.Error.not_found("customer", customer_id))
+
+      {:error, :configuration_not_found, configuration_id} ->
+        error_response(
+          conn,
+          PaperTiger.Error.not_found("billing_portal.configuration", configuration_id)
+        )
+    end
+  end
+
+  @doc """
+  Browser-accessible Billing Portal Session URL.
+
+  PaperTiger does not host an interactive subscription-management page. Visiting
+  the portal URL redirects to the session's return URL when present, or returns
+  a deterministic completion response otherwise.
+  """
+  @spec browser_enter(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def browser_enter(conn, id) do
+    case BillingPortalSessions.get(id) do
+      {:ok, %{return_url: return_url}} when is_binary(return_url) and return_url != "" ->
+        conn
+        |> Plug.Conn.put_resp_header("location", return_url)
+        |> Plug.Conn.send_resp(302, "")
+
+      {:ok, _session} ->
+        Plug.Conn.send_resp(conn, 200, "Billing portal session completed")
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("billing_portal.session", id))
+    end
+  end
+
+  defp validate_customer(customer_id) do
+    case Customers.get(customer_id) do
+      {:ok, _customer} -> :ok
+      {:error, :not_found} -> {:error, :customer_not_found, customer_id}
+    end
+  end
+
+  defp resolve_configuration(nil) do
+    existing_default =
+      BillingPortalConfigurations.list(%{limit: 100}).data
+      |> Enum.find(fn configuration -> Map.get(configuration, :is_default) end)
+
+    case existing_default do
+      nil ->
+        configuration = BillingPortalConfiguration.build_default()
+        BillingPortalConfigurations.insert(configuration)
+
+      configuration ->
+        {:ok, configuration}
+    end
+  end
+
+  defp resolve_configuration(configuration_id) when is_binary(configuration_id) do
+    case BillingPortalConfigurations.get(configuration_id) do
+      {:ok, configuration} -> {:ok, configuration}
+      {:error, :not_found} -> {:error, :configuration_not_found, configuration_id}
+    end
+  end
+
+  defp build_session(params, configuration) do
+    id = generate_id("bps", Map.get(params, :id))
+
+    %{
+      configuration: configuration.id,
+      created: PaperTiger.now(),
+      customer: Map.get(params, :customer),
+      flow: flow(Map.get(params, :flow_data)),
+      id: id,
+      livemode: false,
+      locale: Map.get(params, :locale),
+      object: "billing_portal.session",
+      on_behalf_of: Map.get(params, :on_behalf_of),
+      return_url: Map.get(params, :return_url) || Map.get(configuration, :default_return_url),
+      url: portal_url(id)
+    }
+  end
+
+  defp flow(nil), do: nil
+  defp flow(flow_data) when is_map(flow_data), do: flow_data
+
+  defp portal_url(id) do
+    port = Application.get_env(:paper_tiger, :actual_port) || Application.get_env(:paper_tiger, :port, 4001)
+    "http://localhost:#{port}/billing_portal/sessions/#{id}"
+  end
+end

--- a/lib/paper_tiger/resources/payment_link.ex
+++ b/lib/paper_tiger/resources/payment_link.ex
@@ -1,0 +1,404 @@
+defmodule PaperTiger.Resources.PaymentLink do
+  @moduledoc """
+  Handles Payment Link resource endpoints and deterministic hosted browser flow.
+  """
+
+  import PaperTiger.Resource
+
+  alias PaperTiger.AutomaticTax
+  alias PaperTiger.LineItems
+  alias PaperTiger.Store.CheckoutSessions
+  alias PaperTiger.Store.PaymentLinks
+
+  @doc """
+  Creates a Payment Link.
+  """
+  @spec create(Plug.Conn.t()) :: Plug.Conn.t()
+  def create(conn) do
+    with {:ok, _params} <- validate_params(conn.params, [:line_items]),
+         :ok <- validate_line_items(conn.params.line_items),
+         payment_link = build_payment_link(conn.params),
+         {:ok, payment_link} <- PaymentLinks.insert(payment_link) do
+      maybe_store_idempotency(conn, payment_link)
+
+      payment_link
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :invalid_params, field} ->
+        error_response(conn, PaperTiger.Error.invalid_request("Missing required parameter", field))
+
+      {:error, :invalid_line_items, message} ->
+        error_response(conn, PaperTiger.Error.invalid_request(message, "line_items"))
+    end
+  end
+
+  @doc """
+  Retrieves a Payment Link.
+  """
+  @spec retrieve(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def retrieve(conn, id) do
+    case PaymentLinks.get(id) do
+      {:ok, payment_link} ->
+        payment_link
+        |> maybe_expand(conn.params)
+        |> then(&json_response(conn, 200, &1))
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("payment_link", id))
+    end
+  end
+
+  @doc """
+  Updates a Payment Link.
+  """
+  @spec update(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def update(conn, id) do
+    with {:ok, existing} <- PaymentLinks.get(id),
+         {:ok, updated} <- update_payment_link(existing, conn.params),
+         {:ok, updated} <- PaymentLinks.update(updated) do
+      updated
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("payment_link", id))
+
+      {:error, :invalid_line_items, message} ->
+        error_response(conn, PaperTiger.Error.invalid_request(message, "line_items"))
+    end
+  end
+
+  @doc """
+  Lists Payment Links.
+  """
+  @spec list(Plug.Conn.t()) :: Plug.Conn.t()
+  def list(conn) do
+    conn.params
+    |> parse_pagination_params()
+    |> PaymentLinks.list()
+    |> then(&json_response(conn, 200, &1))
+  end
+
+  @doc """
+  Lists a Payment Link's line items with Stripe-style cursor pagination.
+  """
+  @spec line_items(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def line_items(conn, id) do
+    case PaymentLinks.get(id) do
+      {:ok, payment_link} ->
+        payment_link
+        |> Map.get(:line_items, [])
+        |> LineItems.paginate(conn.params, "/v1/payment_links/#{id}/line_items")
+        |> then(&json_response(conn, 200, &1))
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("payment_link", id))
+    end
+  end
+
+  @doc """
+  Browser-accessible Payment Link endpoint.
+
+  PaperTiger creates a Checkout Session from the Payment Link and redirects to
+  the existing checkout auto-completion URL. Visiting that URL completes the
+  payment/subscription side effects and redirects to the configured success URL.
+  """
+  @spec browser_checkout(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def browser_checkout(conn, id) do
+    case PaymentLinks.get(id) do
+      {:ok, %{active: false}} ->
+        error_response(
+          conn,
+          PaperTiger.Error.invalid_request("This Payment Link is inactive.", "active")
+        )
+
+      {:ok, payment_link} ->
+        session = build_checkout_session(payment_link)
+        {:ok, session} = CheckoutSessions.insert(session)
+
+        conn
+        |> Plug.Conn.put_resp_header("location", session.url)
+        |> Plug.Conn.send_resp(302, "")
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("payment_link", id))
+    end
+  end
+
+  @doc """
+  Deterministic success page used by Payment Links without redirect completion.
+  """
+  @spec browser_complete(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def browser_complete(conn, _id) do
+    Plug.Conn.send_resp(conn, 200, "Payment link completed")
+  end
+
+  defp validate_line_items(line_items) when is_list(line_items) and line_items != [] do
+    cond do
+      length(line_items) > 20 ->
+        {:error, :invalid_line_items, "You may provide up to 20 line items"}
+
+      invalid_item = Enum.find(line_items, &(not valid_line_item?(&1))) ->
+        {:error, :invalid_line_items, invalid_line_item_message(invalid_item)}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_line_items(_line_items), do: {:error, :invalid_line_items, "Invalid array"}
+
+  defp valid_line_item?(item) when is_map(item) do
+    has_quantity?(item) and (has_price?(item) or valid_price_data?(LineItems.value(item, :price_data)))
+  end
+
+  defp valid_line_item?(_item), do: false
+
+  defp has_quantity?(item), do: LineItems.value(item, :quantity) not in [nil, ""]
+  defp has_price?(item), do: LineItems.value(item, :price) not in [nil, ""]
+
+  defp valid_price_data?(price_data) when is_map(price_data) do
+    product = LineItems.value(price_data, :product) || LineItems.value(price_data, :product_data)
+    amount = LineItems.value(price_data, :unit_amount) || LineItems.value(price_data, :unit_amount_decimal)
+
+    LineItems.value(price_data, :currency) not in [nil, ""] and
+      product not in [nil, ""] and
+      amount not in [nil, ""]
+  end
+
+  defp valid_price_data?(_price_data), do: false
+
+  defp invalid_line_item_message(item) when is_map(item) do
+    cond do
+      not has_quantity?(item) ->
+        "Missing required parameter: line_items.quantity"
+
+      not (has_price?(item) or LineItems.value(item, :price_data)) ->
+        "Missing required parameter: line_items.price"
+
+      true ->
+        "Invalid line_items.price_data"
+    end
+  end
+
+  defp invalid_line_item_message(_item), do: "Invalid array"
+
+  defp build_payment_link(params) do
+    id = generate_id("plink", Map.get(params, :id))
+    line_items = LineItems.normalize(Map.get(params, :line_items, []), :payment_link, id)
+    totals = LineItems.totals(line_items)
+
+    %{
+      active: boolean_param(params, :active, true),
+      after_completion: Map.get(params, :after_completion, %{type: "hosted_confirmation"}),
+      allow_promotion_codes: boolean_param(params, :allow_promotion_codes, false),
+      application_fee_amount: Map.get(params, :application_fee_amount),
+      application_fee_percent: Map.get(params, :application_fee_percent),
+      automatic_tax: AutomaticTax.automatic_tax(params, :checkout_session),
+      billing_address_collection: Map.get(params, :billing_address_collection, "auto"),
+      consent_collection: Map.get(params, :consent_collection),
+      currency: Map.get(params, :currency) || LineItems.derive_currency(line_items),
+      custom_fields: Map.get(params, :custom_fields, []),
+      custom_text: Map.get(params, :custom_text),
+      customer_creation: Map.get(params, :customer_creation),
+      id: id,
+      inactive_message: Map.get(params, :inactive_message),
+      invoice_creation: Map.get(params, :invoice_creation),
+      line_items: line_items,
+      livemode: false,
+      metadata: Map.get(params, :metadata, %{}),
+      object: "payment_link",
+      on_behalf_of: Map.get(params, :on_behalf_of),
+      payment_intent_data: Map.get(params, :payment_intent_data),
+      payment_method_collection: Map.get(params, :payment_method_collection, "always"),
+      payment_method_types: Map.get(params, :payment_method_types, ["card"]),
+      phone_number_collection: Map.get(params, :phone_number_collection, %{enabled: false}),
+      restrictions: Map.get(params, :restrictions),
+      shipping_address_collection: Map.get(params, :shipping_address_collection),
+      shipping_options: Map.get(params, :shipping_options, []),
+      submit_type: Map.get(params, :submit_type),
+      subscription_data: Map.get(params, :subscription_data),
+      tax_id_collection: Map.get(params, :tax_id_collection, %{enabled: false}),
+      total_details: %{
+        amount_discount: totals.amount_discount,
+        amount_shipping: 0,
+        amount_tax: totals.amount_tax
+      },
+      transfer_data: Map.get(params, :transfer_data),
+      updated: PaperTiger.now(),
+      url: payment_link_url(id)
+    }
+    |> Map.merge(%{
+      amount_subtotal: totals.amount_subtotal,
+      amount_total: totals.amount_total,
+      created: PaperTiger.now()
+    })
+  end
+
+  defp update_payment_link(payment_link, params) do
+    with :ok <- validate_line_item_update(params) do
+      params = normalize_update_params(params)
+
+      updated =
+        payment_link
+        |> merge_updates(params, immutable_fields())
+        |> maybe_update_line_items(params)
+        |> put_updated_timestamp()
+
+      {:ok, updated}
+    end
+  end
+
+  defp validate_line_item_update(%{line_items: line_items}), do: validate_line_items(line_items)
+  defp validate_line_item_update(_params), do: :ok
+
+  defp maybe_update_line_items(payment_link, %{line_items: line_items}) do
+    line_items = LineItems.normalize(line_items, :payment_link, payment_link.id)
+    totals = LineItems.totals(line_items)
+
+    payment_link
+    |> Map.put(:line_items, line_items)
+    |> Map.put(:amount_subtotal, totals.amount_subtotal)
+    |> Map.put(:amount_total, totals.amount_total)
+    |> Map.put(:total_details, %{
+      amount_discount: totals.amount_discount,
+      amount_shipping: 0,
+      amount_tax: totals.amount_tax
+    })
+  end
+
+  defp maybe_update_line_items(payment_link, _params), do: payment_link
+
+  defp put_updated_timestamp(payment_link), do: Map.put(payment_link, :updated, PaperTiger.now())
+
+  defp normalize_update_params(params) do
+    params
+    |> normalize_boolean_field(:active)
+    |> normalize_boolean_field(:allow_promotion_codes)
+  end
+
+  defp normalize_boolean_field(params, key) do
+    if Map.has_key?(params, key) do
+      Map.put(params, key, to_boolean(Map.get(params, key)))
+    else
+      params
+    end
+  end
+
+  defp boolean_param(params, key, default) do
+    if Map.has_key?(params, key) do
+      to_boolean(Map.get(params, key))
+    else
+      default
+    end
+  end
+
+  defp immutable_fields do
+    [
+      :amount_subtotal,
+      :amount_total,
+      :created,
+      :id,
+      :line_items,
+      :livemode,
+      :object,
+      :total_details,
+      :url
+    ]
+  end
+
+  defp build_checkout_session(payment_link) do
+    session_id = generate_id("cs")
+    line_items = LineItems.reassign(payment_link.line_items, :session, session_id)
+    totals = LineItems.totals(line_items)
+    now = PaperTiger.now()
+
+    %{
+      amount_subtotal: totals.amount_subtotal,
+      amount_total: totals.amount_total,
+      automatic_tax: payment_link.automatic_tax,
+      billing_address_collection: payment_link.billing_address_collection,
+      cancel_url: nil,
+      completed_at: nil,
+      consent_collection: payment_link.consent_collection,
+      created: now,
+      currency: payment_link.currency,
+      customer: nil,
+      customer_creation: payment_link.customer_creation,
+      expires_at: now + 86_400,
+      id: session_id,
+      line_items: line_items,
+      livemode: false,
+      metadata: payment_link.metadata || %{},
+      mode: checkout_mode(payment_link, line_items),
+      object: "checkout.session",
+      payment_intent: nil,
+      payment_link: payment_link.id,
+      payment_method_collection: payment_link.payment_method_collection,
+      payment_method_types: payment_link.payment_method_types || ["card"],
+      payment_status: "unpaid",
+      phone_number_collection: payment_link.phone_number_collection,
+      setup_intent: nil,
+      shipping_address_collection: payment_link.shipping_address_collection,
+      shipping_options: payment_link.shipping_options || [],
+      status: "open",
+      submit_type: payment_link.submit_type,
+      subscription: nil,
+      success_url: success_url(payment_link),
+      total_details: payment_link.total_details,
+      ui_mode: "hosted",
+      url: checkout_url(session_id)
+    }
+  end
+
+  defp checkout_mode(%{subscription_data: subscription_data}, _line_items) when is_map(subscription_data) do
+    "subscription"
+  end
+
+  defp checkout_mode(_payment_link, line_items) do
+    if Enum.any?(line_items, &recurring_line_item?/1), do: "subscription", else: "payment"
+  end
+
+  defp recurring_line_item?(line_item) do
+    line_item
+    |> LineItems.value(:price)
+    |> LineItems.value(:recurring)
+    |> is_map()
+  end
+
+  defp success_url(%{after_completion: %{redirect: %{url: url}, type: "redirect"}}) when is_binary(url) do
+    url
+  end
+
+  defp success_url(%{after_completion: %{"redirect" => %{"url" => url}, "type" => "redirect"}}) when is_binary(url) do
+    url
+  end
+
+  defp success_url(payment_link), do: "#{base_url()}/payment_links/#{payment_link.id}/complete"
+
+  defp maybe_expand(payment_link, params) do
+    expand_params = parse_expand_params(params)
+
+    payment_link =
+      if "line_items" in expand_params do
+        Map.put(
+          payment_link,
+          :line_items,
+          LineItems.paginate(payment_link.line_items, %{}, "/v1/payment_links/#{payment_link.id}/line_items")
+        )
+      else
+        payment_link
+      end
+
+    PaperTiger.Hydrator.hydrate(payment_link, expand_params -- ["line_items"])
+  end
+
+  defp payment_link_url(id), do: "#{base_url()}/payment_links/#{id}"
+  defp checkout_url(id), do: "#{base_url()}/checkout/#{id}/complete"
+
+  defp base_url do
+    port = Application.get_env(:paper_tiger, :actual_port) || Application.get_env(:paper_tiger, :port, 4001)
+    "http://localhost:#{port}"
+  end
+end

--- a/lib/paper_tiger/router.ex
+++ b/lib/paper_tiger/router.ex
@@ -57,6 +57,8 @@ defmodule PaperTiger.Router do
   alias PaperTiger.Resources.ApplicationFee
   alias PaperTiger.Resources.BalanceTransaction
   alias PaperTiger.Resources.BankAccount
+  alias PaperTiger.Resources.BillingPortalConfiguration
+  alias PaperTiger.Resources.BillingPortalSession
   alias PaperTiger.Resources.Card
   alias PaperTiger.Resources.Charge
   alias PaperTiger.Resources.CheckoutSession
@@ -70,6 +72,7 @@ defmodule PaperTiger.Router do
   alias PaperTiger.Resources.InvoiceItem
   alias PaperTiger.Resources.Mandate
   alias PaperTiger.Resources.PaymentIntent
+  alias PaperTiger.Resources.PaymentLink
   alias PaperTiger.Resources.PaymentMethod
   alias PaperTiger.Resources.PaymentMethodConfiguration
   alias PaperTiger.Resources.PaymentMethodDomain
@@ -194,6 +197,18 @@ defmodule PaperTiger.Router do
     CheckoutSession.browser_complete(conn, id)
   end
 
+  get "/payment_links/:id" do
+    PaymentLink.browser_checkout(conn, id)
+  end
+
+  get "/payment_links/:id/complete" do
+    PaymentLink.browser_complete(conn, id)
+  end
+
+  get "/billing_portal/sessions/:id" do
+    BillingPortalSession.browser_enter(conn, id)
+  end
+
   ## Resource Routes
 
   # Core resources (Phase 1)
@@ -214,6 +229,19 @@ defmodule PaperTiger.Router do
   stripe_resource("subscriptions", Subscription, [])
   stripe_resource("products", Product, [])
   stripe_resource("prices", Price, except: [:delete])
+
+  post "/v1/billing_portal/sessions" do
+    BillingPortalSession.create(conn)
+  end
+
+  stripe_resource("billing_portal/configurations", BillingPortalConfiguration, except: [:delete])
+
+  get "/v1/payment_links/:id/line_items" do
+    PaymentLink.line_items(conn, id)
+  end
+
+  stripe_resource("payment_links", PaymentLink, except: [:delete])
+
   # Custom invoice endpoints — must come BEFORE stripe_resource so they
   # match before the generic GET /v1/invoices/:id route.
   get "/v1/invoices/upcoming" do

--- a/lib/paper_tiger/store/billing_portal_configurations.ex
+++ b/lib/paper_tiger/store/billing_portal_configurations.ex
@@ -1,0 +1,10 @@
+defmodule PaperTiger.Store.BillingPortalConfigurations do
+  @moduledoc false
+
+  use PaperTiger.Store,
+    table: :paper_tiger_billing_portal_configurations,
+    resource: "billing_portal.configuration",
+    prefix: "bpc",
+    plural: "billing_portal_configurations",
+    url_path: "/v1/billing_portal/configurations"
+end

--- a/lib/paper_tiger/store/billing_portal_sessions.ex
+++ b/lib/paper_tiger/store/billing_portal_sessions.ex
@@ -1,0 +1,10 @@
+defmodule PaperTiger.Store.BillingPortalSessions do
+  @moduledoc false
+
+  use PaperTiger.Store,
+    table: :paper_tiger_billing_portal_sessions,
+    resource: "billing_portal.session",
+    prefix: "bps",
+    plural: "billing_portal_sessions",
+    url_path: "/v1/billing_portal/sessions"
+end

--- a/lib/paper_tiger/store/payment_links.ex
+++ b/lib/paper_tiger/store/payment_links.ex
@@ -1,0 +1,10 @@
+defmodule PaperTiger.Store.PaymentLinks do
+  @moduledoc false
+
+  use PaperTiger.Store,
+    table: :paper_tiger_payment_links,
+    resource: "payment_link",
+    prefix: "plink",
+    plural: "payment_links",
+    url_path: "/v1/payment_links"
+end

--- a/lib/paper_tiger/test.ex
+++ b/lib/paper_tiger/test.ex
@@ -33,6 +33,8 @@ defmodule PaperTiger.Test do
   alias PaperTiger.Store.ApplicationFees
   alias PaperTiger.Store.BalanceTransactions
   alias PaperTiger.Store.BankAccounts
+  alias PaperTiger.Store.BillingPortalConfigurations
+  alias PaperTiger.Store.BillingPortalSessions
   alias PaperTiger.Store.Cards
   alias PaperTiger.Store.Charges
   alias PaperTiger.Store.CheckoutSessions
@@ -45,6 +47,7 @@ defmodule PaperTiger.Test do
   alias PaperTiger.Store.Invoices
   alias PaperTiger.Store.Mandates
   alias PaperTiger.Store.PaymentIntents
+  alias PaperTiger.Store.PaymentLinks
   alias PaperTiger.Store.PaymentMethodConfigurations
   alias PaperTiger.Store.PaymentMethodDomains
   alias PaperTiger.Store.PaymentMethods
@@ -202,6 +205,8 @@ defmodule PaperTiger.Test do
       ApplicationFees,
       BalanceTransactions,
       BankAccounts,
+      BillingPortalConfigurations,
+      BillingPortalSessions,
       Cards,
       Charges,
       CheckoutSessions,
@@ -214,6 +219,7 @@ defmodule PaperTiger.Test do
       Invoices,
       Mandates,
       PaymentIntents,
+      PaymentLinks,
       PaymentMethodConfigurations,
       PaymentMethodDomains,
       PaymentMethods,

--- a/test/paper_tiger/contract_test.exs
+++ b/test/paper_tiger/contract_test.exs
@@ -1092,6 +1092,99 @@ defmodule PaperTiger.ContractTest do
     end
   end
 
+  describe "Hosted Product APIs" do
+    @tag :contract
+    test "creates and updates payment links with line items" do
+      {:ok, payment_link} =
+        TestClient.create_payment_link(%{
+          "line_items" => [
+            %{
+              "price_data" => %{
+                "currency" => "usd",
+                "product_data" => %{"name" => "Payment Link Contract"},
+                "unit_amount" => 1800
+              },
+              "quantity" => 2
+            }
+          ],
+          "metadata" => %{"contract" => "payment_link"}
+        })
+
+      assert payment_link["object"] == "payment_link"
+      assert String.starts_with?(payment_link["id"], "plink_")
+      assert payment_link["active"] == true
+      assert is_binary(payment_link["url"])
+
+      {:ok, retrieved} = TestClient.get_payment_link(payment_link["id"])
+      assert retrieved["id"] == payment_link["id"]
+      assert retrieved["object"] == "payment_link"
+
+      {:ok, line_items} = TestClient.list_payment_link_line_items(payment_link["id"], %{"limit" => 1})
+      assert line_items["object"] == "list"
+      assert length(line_items["data"]) == 1
+
+      [line_item] = line_items["data"]
+      assert line_item["object"] == "item"
+      assert line_item["quantity"] == 2
+
+      {:ok, updated} =
+        TestClient.update_payment_link(payment_link["id"], %{
+          "active" => false,
+          "metadata" => %{"contract" => ""}
+        })
+
+      assert updated["id"] == payment_link["id"]
+      assert updated["active"] == false
+    end
+
+    @tag :contract
+    test "creates billing portal configurations and sessions" do
+      {:ok, customer} = TestClient.create_customer(%{"email" => "portal-contract@example.com"})
+
+      {:ok, configuration} =
+        TestClient.create_billing_portal_configuration(%{
+          "default_return_url" => "https://example.com/account",
+          "features" => %{
+            "customer_update" => %{
+              "allowed_updates" => ["email"],
+              "enabled" => true
+            },
+            "invoice_history" => %{"enabled" => true}
+          }
+        })
+
+      assert configuration["object"] == "billing_portal.configuration"
+      assert String.starts_with?(configuration["id"], "bpc_")
+      assert configuration["active"] == true
+
+      {:ok, retrieved} = TestClient.get_billing_portal_configuration(configuration["id"])
+      assert retrieved["id"] == configuration["id"]
+
+      {:ok, session} =
+        TestClient.create_billing_portal_session(%{
+          "configuration" => configuration["id"],
+          "customer" => customer["id"],
+          "return_url" => "https://example.com/account"
+        })
+
+      assert session["object"] == "billing_portal.session"
+      assert String.starts_with?(session["id"], "bps_")
+      assert session["configuration"] == configuration["id"]
+      assert session["customer"] == customer["id"]
+      assert session["return_url"] == "https://example.com/account"
+      assert is_binary(session["url"])
+
+      {:ok, updated} =
+        TestClient.update_billing_portal_configuration(configuration["id"], %{
+          "metadata" => %{"contract" => "billing_portal"}
+        })
+
+      assert updated["metadata"]["contract"] == "billing_portal"
+
+      cleanup_customer(customer["id"])
+    end
+  end
+
   describe "Error Response Format Validation" do
     @tag :contract
     test "non-existent customer returns resource_missing error" do

--- a/test/paper_tiger/resources/billing_portal_test.exs
+++ b/test/paper_tiger/resources/billing_portal_test.exs
@@ -1,0 +1,165 @@
+defmodule PaperTiger.Resources.BillingPortalTest do
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
+
+  alias PaperTiger.Router
+
+  setup :checkout_paper_tiger
+
+  defp conn(method, path, params, headers) do
+    conn = Plug.Test.conn(method, path, params)
+
+    headers_with_defaults =
+      headers ++
+        [
+          {"content-type", "application/json"},
+          {"authorization", "Bearer sk_test_billing_portal_key"}
+        ] ++ sandbox_headers()
+
+    Enum.reduce(headers_with_defaults, conn, fn {key, value}, acc ->
+      Plug.Conn.put_req_header(acc, key, value)
+    end)
+  end
+
+  defp public_conn(method, path) do
+    conn = Plug.Test.conn(method, path, nil)
+
+    Enum.reduce(sandbox_headers(), conn, fn {key, value}, acc ->
+      Plug.Conn.put_req_header(acc, key, value)
+    end)
+  end
+
+  defp request(method, path, params \\ nil, headers \\ []) do
+    method
+    |> conn(path, params, headers)
+    |> Router.call([])
+  end
+
+  defp public_request(method, path) do
+    method
+    |> public_conn(path)
+    |> Router.call([])
+  end
+
+  defp json_response(conn), do: Jason.decode!(conn.resp_body)
+
+  describe "billing portal configurations" do
+    test "creates, retrieves, updates, and lists configurations" do
+      create_conn =
+        request(:post, "/v1/billing_portal/configurations", %{
+          "business_profile" => %{"headline" => "Manage billing"},
+          "default_return_url" => "https://example.test/account",
+          "features" => %{
+            "customer_update" => %{"allowed_updates" => ["email"], "enabled" => true},
+            "invoice_history" => %{"enabled" => true}
+          },
+          "metadata" => %{"tier" => "test"}
+        })
+
+      assert create_conn.status == 200
+      configuration = json_response(create_conn)
+      assert String.starts_with?(configuration["id"], "bpc_")
+      assert configuration["object"] == "billing_portal.configuration"
+      assert configuration["active"] == true
+      assert configuration["default_return_url"] == "https://example.test/account"
+
+      retrieve_conn = request(:get, "/v1/billing_portal/configurations/#{configuration["id"]}")
+      assert retrieve_conn.status == 200
+      assert json_response(retrieve_conn)["id"] == configuration["id"]
+
+      update_conn =
+        request(:post, "/v1/billing_portal/configurations/#{configuration["id"]}", %{
+          "active" => false,
+          "metadata" => %{"tier" => ""}
+        })
+
+      assert update_conn.status == 200
+      updated = json_response(update_conn)
+      assert updated["active"] == false
+      assert updated["metadata"] == %{}
+
+      list_conn = request(:get, "/v1/billing_portal/configurations")
+      assert list_conn.status == 200
+      assert [configuration["id"]] == Enum.map(json_response(list_conn)["data"], & &1["id"])
+    end
+  end
+
+  describe "POST /v1/billing_portal/sessions" do
+    test "creates a session for a customer and redirects browser visits to return_url" do
+      customer = create_customer()
+      configuration = create_configuration("https://example.test/billing")
+
+      create_conn =
+        request(:post, "/v1/billing_portal/sessions", %{
+          "configuration" => configuration["id"],
+          "customer" => customer["id"],
+          "return_url" => "https://example.test/account"
+        })
+
+      assert create_conn.status == 200
+      session = json_response(create_conn)
+      assert String.starts_with?(session["id"], "bps_")
+      assert session["object"] == "billing_portal.session"
+      assert session["configuration"] == configuration["id"]
+      assert session["customer"] == customer["id"]
+      assert session["url"] =~ "/billing_portal/sessions/#{session["id"]}"
+
+      browser_conn = public_request(:get, URI.parse(session["url"]).path)
+
+      assert browser_conn.status == 302
+      assert Plug.Conn.get_resp_header(browser_conn, "location") == ["https://example.test/account"]
+    end
+
+    test "creates a default configuration when no configuration is supplied" do
+      customer = create_customer()
+
+      create_conn =
+        request(:post, "/v1/billing_portal/sessions", %{
+          "customer" => customer["id"],
+          "return_url" => "https://example.test/default"
+        })
+
+      assert create_conn.status == 200
+      session = json_response(create_conn)
+      assert String.starts_with?(session["configuration"], "bpc_")
+      assert session["return_url"] == "https://example.test/default"
+    end
+
+    test "rejects unknown customers and configurations" do
+      unknown_customer_conn =
+        request(:post, "/v1/billing_portal/sessions", %{"customer" => "cus_missing"})
+
+      assert unknown_customer_conn.status == 404
+      assert json_response(unknown_customer_conn)["error"]["code"] == "resource_missing"
+
+      customer = create_customer()
+
+      unknown_configuration_conn =
+        request(:post, "/v1/billing_portal/sessions", %{
+          "configuration" => "bpc_missing",
+          "customer" => customer["id"]
+        })
+
+      assert unknown_configuration_conn.status == 404
+      assert json_response(unknown_configuration_conn)["error"]["code"] == "resource_missing"
+    end
+  end
+
+  defp create_customer do
+    conn = request(:post, "/v1/customers", %{"email" => "portal@example.test"})
+    assert conn.status == 200
+    json_response(conn)
+  end
+
+  defp create_configuration(return_url) do
+    conn =
+      request(:post, "/v1/billing_portal/configurations", %{
+        "default_return_url" => return_url,
+        "features" => %{"invoice_history" => %{"enabled" => true}}
+      })
+
+    assert conn.status == 200
+    json_response(conn)
+  end
+end

--- a/test/paper_tiger/resources/payment_link_test.exs
+++ b/test/paper_tiger/resources/payment_link_test.exs
@@ -1,0 +1,217 @@
+defmodule PaperTiger.Resources.PaymentLinkTest do
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
+
+  alias PaperTiger.Router
+  alias PaperTiger.Store.CheckoutSessions
+
+  setup :checkout_paper_tiger
+
+  defp conn(method, path, params, headers) do
+    conn = Plug.Test.conn(method, path, params)
+
+    headers_with_defaults =
+      headers ++
+        [
+          {"content-type", "application/json"},
+          {"authorization", "Bearer sk_test_payment_link_key"}
+        ] ++ sandbox_headers()
+
+    Enum.reduce(headers_with_defaults, conn, fn {key, value}, acc ->
+      Plug.Conn.put_req_header(acc, key, value)
+    end)
+  end
+
+  defp public_conn(method, path) do
+    conn = Plug.Test.conn(method, path, nil)
+
+    Enum.reduce(sandbox_headers(), conn, fn {key, value}, acc ->
+      Plug.Conn.put_req_header(acc, key, value)
+    end)
+  end
+
+  defp request(method, path, params \\ nil, headers \\ []) do
+    method
+    |> conn(path, params, headers)
+    |> Router.call([])
+  end
+
+  defp public_request(method, path) do
+    method
+    |> public_conn(path)
+    |> Router.call([])
+  end
+
+  defp json_response(conn), do: Jason.decode!(conn.resp_body)
+
+  describe "POST /v1/payment_links" do
+    test "creates a payment link with hosted URL and normalized line items" do
+      conn =
+        request(:post, "/v1/payment_links", %{
+          "line_items" => [
+            price_data_line_item("Hosted product", 1500, 2)
+          ],
+          "metadata" => %{"source" => "test"}
+        })
+
+      assert conn.status == 200
+      payment_link = json_response(conn)
+      assert String.starts_with?(payment_link["id"], "plink_")
+      assert payment_link["object"] == "payment_link"
+      assert payment_link["active"] == true
+      assert payment_link["amount_subtotal"] == 3000
+      assert payment_link["amount_total"] == 3000
+      assert payment_link["currency"] == "usd"
+      assert payment_link["metadata"] == %{"source" => "test"}
+      assert payment_link["url"] =~ "/payment_links/#{payment_link["id"]}"
+
+      assert [
+               %{
+                 "amount_total" => 3000,
+                 "description" => "Hosted product",
+                 "payment_link" => payment_link_id,
+                 "quantity" => 2
+               }
+             ] = payment_link["line_items"]
+
+      assert payment_link_id == payment_link["id"]
+    end
+
+    test "requires at least one line item" do
+      conn = request(:post, "/v1/payment_links", %{"line_items" => []})
+
+      assert conn.status == 400
+      assert json_response(conn)["error"]["param"] == "line_items"
+    end
+  end
+
+  describe "GET /v1/payment_links/:id/line_items" do
+    test "returns payment link line items with cursor pagination" do
+      payment_link =
+        create_payment_link(%{
+          "line_items" => [
+            price_data_line_item("One", 100, 1),
+            price_data_line_item("Two", 200, 1),
+            price_data_line_item("Three", 300, 1)
+          ]
+        })
+
+      page1_conn = request(:get, "/v1/payment_links/#{payment_link["id"]}/line_items?limit=2")
+
+      assert page1_conn.status == 200
+      page1 = json_response(page1_conn)
+      assert page1["object"] == "list"
+      assert page1["url"] == "/v1/payment_links/#{payment_link["id"]}/line_items"
+      assert page1["has_more"] == true
+      assert Enum.map(page1["data"], & &1["description"]) == ["One", "Two"]
+
+      last_id = List.last(page1["data"])["id"]
+      page2_conn = request(:get, "/v1/payment_links/#{payment_link["id"]}/line_items?starting_after=#{last_id}")
+
+      assert page2_conn.status == 200
+      page2 = json_response(page2_conn)
+      assert page2["has_more"] == false
+      assert Enum.map(page2["data"], & &1["description"]) == ["Three"]
+    end
+
+    test "supports expand[]=line_items on retrieve" do
+      payment_link =
+        create_payment_link(%{
+          "line_items" => [price_data_line_item("Expanded", 700, 1)]
+        })
+
+      conn = request(:get, "/v1/payment_links/#{payment_link["id"]}?expand[]=line_items")
+
+      assert conn.status == 200
+      retrieved = json_response(conn)
+      assert retrieved["line_items"]["object"] == "list"
+      assert [%{"description" => "Expanded"}] = retrieved["line_items"]["data"]
+    end
+  end
+
+  describe "POST /v1/payment_links/:id" do
+    test "updates metadata, active state, and line items" do
+      payment_link =
+        create_payment_link(%{
+          "line_items" => [price_data_line_item("Original", 1000, 1)],
+          "metadata" => %{"keep" => "yes", "remove" => "old"}
+        })
+
+      conn =
+        request(:post, "/v1/payment_links/#{payment_link["id"]}", %{
+          "active" => false,
+          "line_items" => [price_data_line_item("Replacement", 400, 3)],
+          "metadata" => %{"add" => "new", "remove" => ""}
+        })
+
+      assert conn.status == 200
+      updated = json_response(conn)
+      assert updated["active"] == false
+      assert updated["amount_total"] == 1200
+      assert updated["metadata"] == %{"add" => "new", "keep" => "yes"}
+      assert [%{"description" => "Replacement", "quantity" => 3}] = updated["line_items"]
+    end
+  end
+
+  describe "browser Payment Link flow" do
+    test "creates a checkout session and uses the existing checkout completion path" do
+      payment_link =
+        create_payment_link(%{
+          "after_completion" => %{
+            "redirect" => %{"url" => "https://example.test/success"},
+            "type" => "redirect"
+          },
+          "line_items" => [price_data_line_item("Browser", 2500, 1)]
+        })
+
+      payment_link_path = URI.parse(payment_link["url"]).path
+      payment_link_conn = public_request(:get, payment_link_path)
+
+      assert payment_link_conn.status == 302
+      [checkout_url] = Plug.Conn.get_resp_header(payment_link_conn, "location")
+      assert checkout_url =~ "/checkout/"
+
+      [_, session_id] = Regex.run(~r{/checkout/([^/]+)/complete}, checkout_url)
+      checkout_conn = public_request(:get, URI.parse(checkout_url).path)
+
+      assert checkout_conn.status == 302
+      assert Plug.Conn.get_resp_header(checkout_conn, "location") == ["https://example.test/success"]
+
+      assert {:ok, session} = CheckoutSessions.get(session_id)
+      assert session.status == "complete"
+      assert session.payment_status == "paid"
+      assert session.payment_link == payment_link["id"]
+    end
+
+    test "rejects inactive payment links" do
+      payment_link =
+        create_payment_link(%{
+          "active" => false,
+          "line_items" => [price_data_line_item("Inactive", 100, 1)]
+        })
+
+      conn = public_request(:get, URI.parse(payment_link["url"]).path)
+
+      assert conn.status == 400
+      assert json_response(conn)["error"]["param"] == "active"
+    end
+  end
+
+  defp create_payment_link(params) do
+    conn = request(:post, "/v1/payment_links", params)
+    assert conn.status == 200
+    json_response(conn)
+  end
+
+  defp price_data_line_item(name, unit_amount, quantity) do
+    %{
+      "price_data" => %{
+        "currency" => "usd",
+        "product_data" => %{"name" => name},
+        "unit_amount" => unit_amount
+      },
+      "quantity" => quantity
+    }
+  end
+end

--- a/test/support/test_client.ex
+++ b/test/support/test_client.ex
@@ -1015,6 +1015,140 @@ defmodule PaperTiger.TestClient do
     end
   end
 
+  ## Payment Link Operations
+
+  @doc """
+  Creates a Payment Link.
+  """
+  def create_payment_link(params) do
+    case mode() do
+      :real_stripe ->
+        create_payment_link_real(params)
+
+      :paper_tiger ->
+        create_payment_link_mock(params)
+    end
+  end
+
+  @doc """
+  Retrieves a Payment Link.
+  """
+  def get_payment_link(payment_link_id) do
+    case mode() do
+      :real_stripe ->
+        get_payment_link_real(payment_link_id)
+
+      :paper_tiger ->
+        get_payment_link_mock(payment_link_id)
+    end
+  end
+
+  @doc """
+  Updates a Payment Link.
+  """
+  def update_payment_link(payment_link_id, params) do
+    case mode() do
+      :real_stripe ->
+        update_payment_link_real(payment_link_id, params)
+
+      :paper_tiger ->
+        update_payment_link_mock(payment_link_id, params)
+    end
+  end
+
+  @doc """
+  Lists Payment Links.
+  """
+  def list_payment_links(params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        list_payment_links_real(params)
+
+      :paper_tiger ->
+        list_payment_links_mock(params)
+    end
+  end
+
+  @doc """
+  Lists Payment Link line items.
+  """
+  def list_payment_link_line_items(payment_link_id, params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        list_payment_link_line_items_real(payment_link_id, params)
+
+      :paper_tiger ->
+        list_payment_link_line_items_mock(payment_link_id, params)
+    end
+  end
+
+  ## Billing Portal Operations
+
+  @doc """
+  Creates a Billing Portal Configuration.
+  """
+  def create_billing_portal_configuration(params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        create_billing_portal_configuration_real(params)
+
+      :paper_tiger ->
+        create_billing_portal_configuration_mock(params)
+    end
+  end
+
+  @doc """
+  Retrieves a Billing Portal Configuration.
+  """
+  def get_billing_portal_configuration(configuration_id) do
+    case mode() do
+      :real_stripe ->
+        get_billing_portal_configuration_real(configuration_id)
+
+      :paper_tiger ->
+        get_billing_portal_configuration_mock(configuration_id)
+    end
+  end
+
+  @doc """
+  Updates a Billing Portal Configuration.
+  """
+  def update_billing_portal_configuration(configuration_id, params) do
+    case mode() do
+      :real_stripe ->
+        update_billing_portal_configuration_real(configuration_id, params)
+
+      :paper_tiger ->
+        update_billing_portal_configuration_mock(configuration_id, params)
+    end
+  end
+
+  @doc """
+  Lists Billing Portal Configurations.
+  """
+  def list_billing_portal_configurations(params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        list_billing_portal_configurations_real(params)
+
+      :paper_tiger ->
+        list_billing_portal_configurations_mock(params)
+    end
+  end
+
+  @doc """
+  Creates a Billing Portal Session.
+  """
+  def create_billing_portal_session(params) do
+    case mode() do
+      :real_stripe ->
+        create_billing_portal_session_real(params)
+
+      :paper_tiger ->
+        create_billing_portal_session_mock(params)
+    end
+  end
+
   ## Invoice Operations
 
   @doc """
@@ -1554,6 +1688,46 @@ defmodule PaperTiger.TestClient do
     stripe_request(:post, "/v1/checkout/sessions/#{session_id}/expire")
   end
 
+  defp create_payment_link_real(params) do
+    stripe_request(:post, "/v1/payment_links", params)
+  end
+
+  defp get_payment_link_real(payment_link_id) do
+    stripe_request(:get, "/v1/payment_links/#{payment_link_id}")
+  end
+
+  defp update_payment_link_real(payment_link_id, params) do
+    stripe_request(:post, "/v1/payment_links/#{payment_link_id}", params)
+  end
+
+  defp list_payment_links_real(params) do
+    stripe_request(:get, "/v1/payment_links", params)
+  end
+
+  defp list_payment_link_line_items_real(payment_link_id, params) do
+    stripe_request(:get, "/v1/payment_links/#{payment_link_id}/line_items", params)
+  end
+
+  defp create_billing_portal_configuration_real(params) do
+    stripe_request(:post, "/v1/billing_portal/configurations", params)
+  end
+
+  defp get_billing_portal_configuration_real(configuration_id) do
+    stripe_request(:get, "/v1/billing_portal/configurations/#{configuration_id}")
+  end
+
+  defp update_billing_portal_configuration_real(configuration_id, params) do
+    stripe_request(:post, "/v1/billing_portal/configurations/#{configuration_id}", params)
+  end
+
+  defp list_billing_portal_configurations_real(params) do
+    stripe_request(:get, "/v1/billing_portal/configurations", params)
+  end
+
+  defp create_billing_portal_session_real(params) do
+    stripe_request(:post, "/v1/billing_portal/sessions", params)
+  end
+
   ## Private - PaperTiger Mock
 
   defp create_customer_mock(params) do
@@ -1888,6 +2062,56 @@ defmodule PaperTiger.TestClient do
 
   defp expire_checkout_session_mock(session_id) do
     conn = request(:post, "/v1/checkout/sessions/#{session_id}/expire", %{})
+    handle_response(conn)
+  end
+
+  defp create_payment_link_mock(params) do
+    conn = request(:post, "/v1/payment_links", params)
+    handle_response(conn)
+  end
+
+  defp get_payment_link_mock(payment_link_id) do
+    conn = request(:get, "/v1/payment_links/#{payment_link_id}", %{})
+    handle_response(conn)
+  end
+
+  defp update_payment_link_mock(payment_link_id, params) do
+    conn = request(:post, "/v1/payment_links/#{payment_link_id}", params)
+    handle_response(conn)
+  end
+
+  defp list_payment_links_mock(params) do
+    conn = request(:get, "/v1/payment_links", params)
+    handle_response(conn)
+  end
+
+  defp list_payment_link_line_items_mock(payment_link_id, params) do
+    conn = request(:get, "/v1/payment_links/#{payment_link_id}/line_items", params)
+    handle_response(conn)
+  end
+
+  defp create_billing_portal_configuration_mock(params) do
+    conn = request(:post, "/v1/billing_portal/configurations", params)
+    handle_response(conn)
+  end
+
+  defp get_billing_portal_configuration_mock(configuration_id) do
+    conn = request(:get, "/v1/billing_portal/configurations/#{configuration_id}", %{})
+    handle_response(conn)
+  end
+
+  defp update_billing_portal_configuration_mock(configuration_id, params) do
+    conn = request(:post, "/v1/billing_portal/configurations/#{configuration_id}", params)
+    handle_response(conn)
+  end
+
+  defp list_billing_portal_configurations_mock(params) do
+    conn = request(:get, "/v1/billing_portal/configurations", params)
+    handle_response(conn)
+  end
+
+  defp create_billing_portal_session_mock(params) do
+    conn = request(:post, "/v1/billing_portal/sessions", params)
     handle_response(conn)
   end
 


### PR DESCRIPTION
## Summary

Closes #67.

Adds Stripe-hosted product surfaces for common SaaS test flows:

- Payment Link create/retrieve/update/list plus paginated `GET /v1/payment_links/:id/line_items`
- deterministic browser Payment Link URLs that create a Checkout Session and reuse PaperTiger's existing checkout completion path
- Billing Portal Configuration create/retrieve/update/list
- Billing Portal Session creation plus deterministic browser redirect behavior
- shared line-item normalization/pagination helpers for hosted-product resources
- contract-client methods and live Stripe contract coverage for the new surfaces

## Notes

Payment Link browser visits are intentionally local and deterministic: PaperTiger redirects the hosted link to an auto-completing Checkout Session, then redirects to the configured `after_completion` URL or a local completion page.

Billing Portal sessions do not host a full interactive subscription-management UI. Visiting the session URL redirects to `return_url` when present, or returns a deterministic completion response. Portal configuration/session API shapes follow Stripe's documented objects.

References:

- https://docs.stripe.com/api/payment_links
- https://docs.stripe.com/api/payment_links/line_items
- https://docs.stripe.com/api/customer_portal/configurations
- https://docs.stripe.com/api/customer_portal/sessions

## Validation

- `mise exec -- mix test`
- `mise exec -- mix dialyzer`
- `mise exec -- mix credo --strict`
- `VALIDATE_AGAINST_STRIPE=true mix test test/paper_tiger/contract_test.exs:1097 test/paper_tiger/contract_test.exs:1142` with a Stripe test-mode key
