### PR TITLE
Add billing discount and credit APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Modern payment-method adjunct APIs: test-helper ConfirmationToken creation plus retrieval, PaymentMethodDomain create/retrieve/update/list, PaymentMethodConfiguration create/retrieve/update/list, CustomerSession creation with client secrets, and stored Mandate retrieval for successful mandate-bearing SetupIntent/PaymentIntent flows.
 - Invoice lifecycle endpoints for `POST /v1/invoices/:id/send`, `POST /v1/invoices/:id/mark_uncollectible`, and PaymentIntent-backed `POST /v1/invoices/:id/attach_payment`, including `invoice.sent`, `invoice.marked_uncollectible`, and `invoice.voided` webhook emission plus status-transition timestamps.
 - Hosted product APIs for Payment Links and Billing Portal: `POST/GET/POST/GET-list /v1/payment_links`, paginated `GET /v1/payment_links/:id/line_items`, browser-visible Payment Link URLs backed by deterministic Checkout Session completion, `POST /v1/billing_portal/sessions`, and Billing Portal Configuration create/retrieve/update/list endpoints.
+- Billing discount and credit APIs: Promotion Codes, Customer Balance Transactions, Customer Cash Balance, and Credit Notes with invoice/customer balance mutation for common credit workflows.
 
 ### Fixed
 

--- a/lib/paper_tiger.ex
+++ b/lib/paper_tiger.ex
@@ -50,6 +50,8 @@ defmodule PaperTiger do
     CheckoutSessions,
     ConfirmationTokens,
     Coupons,
+    CreditNotes,
+    CustomerBalanceTransactions,
     Customers,
     Disputes,
     Events,
@@ -65,6 +67,7 @@ defmodule PaperTiger do
     Plans,
     Prices,
     Products,
+    PromotionCodes,
     Refunds,
     Reviews,
     SetupAttempts,
@@ -226,6 +229,7 @@ defmodule PaperTiger do
   def flush(:subscription_items), do: SubscriptionItems.clear()
   def flush(:invoices), do: Invoices.clear()
   def flush(:invoice_items), do: InvoiceItems.clear()
+  def flush(:credit_notes), do: CreditNotes.clear()
   def flush(:products), do: Products.clear()
   def flush(:prices), do: Prices.clear()
   def flush(:payment_links), do: PaymentLinks.clear()
@@ -242,6 +246,8 @@ defmodule PaperTiger do
   def flush(:refunds), do: Refunds.clear()
   def flush(:disputes), do: Disputes.clear()
   def flush(:coupons), do: Coupons.clear()
+  def flush(:promotion_codes), do: PromotionCodes.clear()
+  def flush(:customer_balance_transactions), do: CustomerBalanceTransactions.clear()
   def flush(:tax_rates), do: TaxRates.clear()
   def flush(:cards), do: Cards.clear()
   def flush(:bank_accounts), do: BankAccounts.clear()

--- a/lib/paper_tiger/application.ex
+++ b/lib/paper_tiger/application.ex
@@ -15,6 +15,8 @@ defmodule PaperTiger.Application do
   alias PaperTiger.Store.CheckoutSessions
   alias PaperTiger.Store.ConfirmationTokens
   alias PaperTiger.Store.Coupons
+  alias PaperTiger.Store.CreditNotes
+  alias PaperTiger.Store.CustomerBalanceTransactions
   alias PaperTiger.Store.Customers
   alias PaperTiger.Store.Disputes
   alias PaperTiger.Store.Events
@@ -30,6 +32,7 @@ defmodule PaperTiger.Application do
   alias PaperTiger.Store.Plans
   alias PaperTiger.Store.Prices
   alias PaperTiger.Store.Products
+  alias PaperTiger.Store.PromotionCodes
   alias PaperTiger.Store.Refunds
   alias PaperTiger.Store.Reviews
   alias PaperTiger.Store.SetupAttempts
@@ -78,6 +81,7 @@ defmodule PaperTiger.Application do
         Prices,
         PaymentLinks,
         Invoices,
+        CreditNotes,
         PaymentMethods,
         PaymentMethodDomains,
         PaymentMethodConfigurations,
@@ -93,6 +97,8 @@ defmodule PaperTiger.Application do
         InvoiceItems,
         Plans,
         Coupons,
+        PromotionCodes,
+        CustomerBalanceTransactions,
         TaxRates,
         Cards,
         BankAccounts,

--- a/lib/paper_tiger/customer_balance.ex
+++ b/lib/paper_tiger/customer_balance.ex
@@ -1,0 +1,105 @@
+defmodule PaperTiger.CustomerBalance do
+  @moduledoc false
+
+  import PaperTiger.Resource, only: [generate_id: 1, to_integer: 1]
+
+  alias PaperTiger.Store.CustomerBalanceTransactions
+  alias PaperTiger.Store.Customers
+
+  @doc """
+  Creates a customer balance transaction and mutates the customer's balance.
+  """
+  @spec create_transaction(String.t(), map()) ::
+          {:ok, map()} | {:error, :not_found}
+  def create_transaction(customer_id, params) when is_binary(customer_id) and is_map(params) do
+    with {:ok, customer} <- Customers.get(customer_id) do
+      amount = params |> value(:amount) |> to_integer()
+      currency = value(params, :currency) || Map.get(customer, :currency) || "usd"
+      ending_balance = Map.get(customer, :balance, 0) + amount
+      now = PaperTiger.now()
+
+      transaction = %{
+        amount: amount,
+        created: now,
+        credit_note: value(params, :credit_note),
+        currency: currency,
+        customer: customer.id,
+        description: value(params, :description),
+        ending_balance: ending_balance,
+        id: generate_id("cbtxn"),
+        invoice: value(params, :invoice),
+        livemode: false,
+        metadata: value(params, :metadata) || %{},
+        object: "customer_balance_transaction",
+        type: value(params, :type) || "adjustment"
+      }
+
+      updated_customer =
+        customer
+        |> Map.put(:balance, ending_balance)
+        |> Map.put(:currency, currency)
+
+      with {:ok, _customer} <- Customers.update(updated_customer) do
+        CustomerBalanceTransactions.insert(transaction)
+      end
+    end
+  end
+
+  @doc """
+  Applies an existing customer credit balance to an invoice.
+  """
+  @spec apply_to_invoice(map()) :: map()
+  def apply_to_invoice(%{customer: customer_id} = invoice) when is_binary(customer_id) do
+    case Customers.get(customer_id) do
+      {:ok, customer} ->
+        apply_customer_credit(invoice, customer)
+
+      {:error, :not_found} ->
+        invoice
+    end
+  end
+
+  def apply_to_invoice(invoice), do: invoice
+
+  @doc false
+  @spec value(term(), atom()) :: term()
+  def value(nil, _key), do: nil
+
+  def value(map, key) when is_map(map) and is_atom(key) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  def value(_other, _key), do: nil
+
+  defp apply_customer_credit(invoice, %{balance: balance} = customer) when is_integer(balance) and balance < 0 do
+    amount_remaining = Map.get(invoice, :amount_remaining, Map.get(invoice, :amount_due, 0))
+    applied_amount = min(amount_remaining, abs(balance))
+    ending_balance = balance + applied_amount
+
+    {:ok, _customer} =
+      customer
+      |> Map.put(:balance, ending_balance)
+      |> Customers.update()
+
+    invoice
+    |> Map.put(:starting_balance, balance)
+    |> Map.put(:ending_balance, ending_balance)
+    |> Map.put(:amount_due, max(Map.get(invoice, :amount_due, 0) - applied_amount, 0))
+    |> Map.put(:amount_remaining, max(amount_remaining - applied_amount, 0))
+    |> maybe_mark_paid()
+  end
+
+  defp apply_customer_credit(invoice, %{balance: balance}) do
+    invoice
+    |> Map.put(:starting_balance, balance || 0)
+    |> Map.put(:ending_balance, balance || 0)
+  end
+
+  defp maybe_mark_paid(%{amount_remaining: 0} = invoice) do
+    invoice
+    |> Map.put(:paid, true)
+    |> Map.put(:status, "paid")
+  end
+
+  defp maybe_mark_paid(invoice), do: invoice
+end

--- a/lib/paper_tiger/discounts.ex
+++ b/lib/paper_tiger/discounts.ex
@@ -1,0 +1,126 @@
+defmodule PaperTiger.Discounts do
+  @moduledoc false
+
+  import PaperTiger.Resource, only: [generate_id: 1, to_integer: 1]
+
+  alias PaperTiger.Store.Coupons
+  alias PaperTiger.Store.PromotionCodes
+
+  @doc """
+  Builds a Stripe-shaped discount from coupon/promotion_code params.
+  """
+  @spec build_from_params(map()) :: map() | nil
+  def build_from_params(params) when is_map(params) do
+    params
+    |> discount_params()
+    |> build_discount()
+  end
+
+  @doc """
+  Calculates the discount amount for a subtotal/currency.
+  """
+  @spec amount(map() | nil, non_neg_integer(), String.t()) :: non_neg_integer()
+  def amount(nil, _subtotal, _currency), do: 0
+
+  def amount(%{coupon: coupon}, subtotal, currency) when is_map(coupon) do
+    cond do
+      percent = value(coupon, :percent_off) ->
+        min(subtotal, round(subtotal * to_integer(percent) / 100))
+
+      amount_off = value(coupon, :amount_off) ->
+        if value(coupon, :currency) in [nil, currency] do
+          min(subtotal, to_integer(amount_off))
+        else
+          0
+        end
+
+      true ->
+        0
+    end
+  end
+
+  def amount(_discount, _subtotal, _currency), do: 0
+
+  @doc false
+  @spec value(term(), atom()) :: term()
+  def value(nil, _key), do: nil
+
+  def value(map, key) when is_map(map) and is_atom(key) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  def value(_other, _key), do: nil
+
+  defp discount_params(params) do
+    cond do
+      value(params, :promotion_code) not in [nil, ""] ->
+        %{promotion_code: value(params, :promotion_code)}
+
+      value(params, :coupon) not in [nil, ""] ->
+        %{coupon: value(params, :coupon)}
+
+      true ->
+        first_discount(value(params, :discounts))
+    end
+  end
+
+  defp first_discount(nil), do: nil
+  defp first_discount([discount | _rest]) when is_map(discount), do: discount
+
+  defp first_discount(discounts) when is_map(discounts) do
+    discounts
+    |> Enum.sort_by(fn {key, _value} -> to_string(key) end)
+    |> Enum.map(fn {_key, value} -> value end)
+    |> Enum.find(&is_map/1)
+  end
+
+  defp first_discount(_discounts), do: nil
+
+  defp build_discount(%{promotion_code: promotion_code_id}) do
+    case PromotionCodes.get(to_string(promotion_code_id)) do
+      {:ok, promotion_code} ->
+        coupon_id = promotion_code |> value(:promotion) |> value(:coupon)
+        coupon = fetch_coupon(coupon_id)
+
+        if coupon do
+          %{
+            coupon: coupon,
+            id: generate_id("di"),
+            object: "discount",
+            promotion_code: promotion_code.id,
+            start: PaperTiger.now()
+          }
+        end
+
+      {:error, :not_found} ->
+        nil
+    end
+  end
+
+  defp build_discount(%{coupon: coupon_id}) do
+    case fetch_coupon(coupon_id) do
+      nil ->
+        nil
+
+      coupon ->
+        %{
+          coupon: coupon,
+          id: generate_id("di"),
+          object: "discount",
+          promotion_code: nil,
+          start: PaperTiger.now()
+        }
+    end
+  end
+
+  defp build_discount(_discount), do: nil
+
+  defp fetch_coupon(coupon_id) when is_binary(coupon_id) do
+    case Coupons.get(coupon_id) do
+      {:ok, coupon} -> coupon
+      {:error, :not_found} -> nil
+    end
+  end
+
+  defp fetch_coupon(_coupon_id), do: nil
+end

--- a/lib/paper_tiger/hydrator.ex
+++ b/lib/paper_tiger/hydrator.ex
@@ -38,6 +38,8 @@ defmodule PaperTiger.Hydrator do
   alias PaperTiger.Store.CheckoutSessions
   alias PaperTiger.Store.ConfirmationTokens
   alias PaperTiger.Store.Coupons
+  alias PaperTiger.Store.CreditNotes
+  alias PaperTiger.Store.CustomerBalanceTransactions
   alias PaperTiger.Store.Customers
   alias PaperTiger.Store.Disputes
   alias PaperTiger.Store.Events
@@ -53,6 +55,7 @@ defmodule PaperTiger.Hydrator do
   alias PaperTiger.Store.Plans
   alias PaperTiger.Store.Prices
   alias PaperTiger.Store.Products
+  alias PaperTiger.Store.PromotionCodes
   alias PaperTiger.Store.Refunds
   alias PaperTiger.Store.Reviews
   alias PaperTiger.Store.SetupAttempts
@@ -77,7 +80,9 @@ defmodule PaperTiger.Hydrator do
     Charges,
     CheckoutSessions,
     ConfirmationTokens,
+    CreditNotes,
     Coupons,
+    CustomerBalanceTransactions,
     Customers,
     Disputes,
     Events,
@@ -93,6 +98,7 @@ defmodule PaperTiger.Hydrator do
     Plans,
     Prices,
     Products,
+    PromotionCodes,
     Refunds,
     Reviews,
     SetupAttempts,

--- a/lib/paper_tiger/resources/cash_balance.ex
+++ b/lib/paper_tiger/resources/cash_balance.ex
@@ -1,0 +1,76 @@
+defmodule PaperTiger.Resources.CashBalance do
+  @moduledoc """
+  Handles Customer Cash Balance endpoints.
+  """
+
+  import PaperTiger.Resource
+
+  alias PaperTiger.Store.Customers
+
+  @doc """
+  Retrieves a customer's cash balance.
+  """
+  @spec retrieve(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def retrieve(conn, customer_id) do
+    case Customers.get(customer_id) do
+      {:ok, customer} ->
+        json_response(conn, 200, cash_balance(customer))
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("customer", customer_id))
+    end
+  end
+
+  @doc """
+  Updates a customer's cash balance settings.
+  """
+  @spec update(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def update(conn, customer_id) do
+    case Customers.get(customer_id) do
+      {:ok, customer} ->
+        existing = cash_balance(customer)
+
+        settings =
+          existing.settings
+          |> Map.merge(normalize_settings(Map.get(conn.params, :settings, %{})))
+
+        updated_cash_balance = Map.put(existing, :settings, settings)
+        {:ok, _customer} = Customers.update(Map.put(customer, :cash_balance, updated_cash_balance))
+
+        json_response(conn, 200, updated_cash_balance)
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("customer", customer_id))
+    end
+  end
+
+  defp cash_balance(customer) do
+    Map.get(customer, :cash_balance) ||
+      %{
+        available: %{},
+        customer: customer.id,
+        livemode: false,
+        object: "cash_balance",
+        settings: %{
+          reconciliation_mode: "automatic",
+          using_merchant_default: true
+        }
+      }
+  end
+
+  defp normalize_settings(settings) when is_map(settings) do
+    Map.new(settings, fn
+      {key, value} when is_binary(key) ->
+        {settings_key(key), value}
+
+      {key, value} ->
+        {key, value}
+    end)
+  end
+
+  defp normalize_settings(_settings), do: %{}
+
+  defp settings_key("reconciliation_mode"), do: :reconciliation_mode
+  defp settings_key("using_merchant_default"), do: :using_merchant_default
+  defp settings_key(key), do: key
+end

--- a/lib/paper_tiger/resources/credit_note.ex
+++ b/lib/paper_tiger/resources/credit_note.ex
@@ -1,0 +1,389 @@
+defmodule PaperTiger.Resources.CreditNote do
+  @moduledoc """
+  Handles Credit Note resource endpoints.
+  """
+
+  import PaperTiger.Resource
+
+  alias PaperTiger.CustomerBalance
+  alias PaperTiger.Store.CreditNotes
+  alias PaperTiger.Store.Invoices
+
+  @doc """
+  Creates a credit note and adjusts the finalized invoice.
+  """
+  @spec create(Plug.Conn.t()) :: Plug.Conn.t()
+  def create(conn) do
+    with {:ok, _params} <- validate_params(conn.params, [:invoice]),
+         :ok <- validate_credit_amount_source(conn.params),
+         {:ok, invoice} <- Invoices.get(conn.params.invoice),
+         :ok <- validate_invoice_finalized(invoice),
+         credit_note = build_credit_note(conn.params, invoice),
+         {:ok, invoice} <- apply_credit_note(invoice, credit_note),
+         {:ok, credit_note} <- CreditNotes.insert(credit_note) do
+      maybe_store_idempotency(conn, credit_note)
+      :telemetry.execute([:paper_tiger, :credit_note, :created], %{}, %{object: credit_note})
+      :telemetry.execute([:paper_tiger, :invoice, :updated], %{}, %{object: invoice})
+
+      credit_note
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :invalid_params, field} ->
+        error_response(conn, PaperTiger.Error.invalid_request("Missing required parameter", field))
+
+      {:error, :missing_amount_source} ->
+        error_response(conn, PaperTiger.Error.invalid_request("Must provide amount, lines, or shipping_cost"))
+
+      {:error, :invoice_not_finalized} ->
+        error_response(conn, PaperTiger.Error.invalid_request("Credit notes can only be issued for finalized invoices"))
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("invoice", conn.params.invoice))
+    end
+  end
+
+  @doc """
+  Previews a credit note without persisting it.
+  """
+  @spec preview(Plug.Conn.t()) :: Plug.Conn.t()
+  def preview(conn) do
+    with {:ok, _params} <- validate_params(conn.params, [:invoice]),
+         :ok <- validate_credit_amount_source(conn.params),
+         {:ok, invoice} <- Invoices.get(conn.params.invoice),
+         :ok <- validate_invoice_finalized(invoice) do
+      conn.params
+      |> build_credit_note(invoice, false)
+      |> Map.put(:id, nil)
+      |> Map.put(:number, nil)
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :invalid_params, field} ->
+        error_response(conn, PaperTiger.Error.invalid_request("Missing required parameter", field))
+
+      {:error, :missing_amount_source} ->
+        error_response(conn, PaperTiger.Error.invalid_request("Must provide amount, lines, or shipping_cost"))
+
+      {:error, :invoice_not_finalized} ->
+        error_response(conn, PaperTiger.Error.invalid_request("Credit notes can only be issued for finalized invoices"))
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("invoice", conn.params.invoice))
+    end
+  end
+
+  @doc """
+  Retrieves a credit note.
+  """
+  @spec retrieve(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def retrieve(conn, id) do
+    case CreditNotes.get(id) do
+      {:ok, credit_note} ->
+        credit_note
+        |> maybe_expand(conn.params)
+        |> then(&json_response(conn, 200, &1))
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("credit_note", id))
+    end
+  end
+
+  @doc """
+  Updates a credit note's memo/metadata.
+  """
+  @spec update(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def update(conn, id) do
+    case CreditNotes.get(id) do
+      {:ok, existing} ->
+        updated =
+          merge_updates(existing, conn.params, [
+            :amount,
+            :created,
+            :currency,
+            :customer,
+            :id,
+            :invoice,
+            :lines,
+            :livemode,
+            :object,
+            :number,
+            :status,
+            :type
+          ])
+
+        {:ok, updated} = CreditNotes.update(updated)
+        :telemetry.execute([:paper_tiger, :credit_note, :updated], %{}, %{object: updated})
+        json_response(conn, 200, updated)
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("credit_note", id))
+    end
+  end
+
+  @doc """
+  Lists credit notes.
+  """
+  @spec list(Plug.Conn.t()) :: Plug.Conn.t()
+  def list(conn) do
+    pagination_opts = parse_pagination_params(conn.params)
+
+    result =
+      case Map.get(conn.params, :invoice) do
+        invoice_id when is_binary(invoice_id) and invoice_id != "" ->
+          invoice_id
+          |> CreditNotes.find_by_invoice()
+          |> PaperTiger.List.paginate(Map.put(pagination_opts, :url, "/v1/credit_notes"))
+
+        _ ->
+          CreditNotes.list(pagination_opts)
+      end
+
+    json_response(conn, 200, result)
+  end
+
+  @doc """
+  Lists credit note line items.
+  """
+  @spec lines(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def lines(conn, id) do
+    case CreditNotes.get(id) do
+      {:ok, credit_note} ->
+        credit_note.lines
+        |> Map.get(:data, [])
+        |> paginate_lines(conn.params, "/v1/credit_notes/#{id}/lines")
+        |> then(&json_response(conn, 200, &1))
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("credit_note", id))
+    end
+  end
+
+  @doc """
+  Lists preview line items.
+  """
+  @spec preview_lines(Plug.Conn.t()) :: Plug.Conn.t()
+  def preview_lines(conn) do
+    case Invoices.get(conn.params.invoice || "") do
+      {:ok, invoice} ->
+        conn.params
+        |> build_credit_note(invoice, false)
+        |> Map.fetch!(:lines)
+        |> Map.get(:data, [])
+        |> paginate_lines(conn.params, "/v1/credit_notes/preview/lines")
+        |> then(&json_response(conn, 200, &1))
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("invoice", conn.params.invoice || ""))
+    end
+  end
+
+  @doc """
+  Voids a credit note.
+  """
+  @spec void(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def void(conn, id) do
+    case CreditNotes.get(id) do
+      {:ok, %{status: "void"} = credit_note} ->
+        json_response(conn, 200, credit_note)
+
+      {:ok, credit_note} ->
+        voided =
+          credit_note
+          |> Map.put(:status, "void")
+          |> Map.put(:voided_at, PaperTiger.now())
+
+        {:ok, voided} = CreditNotes.update(voided)
+        :telemetry.execute([:paper_tiger, :credit_note, :voided], %{}, %{object: voided})
+        json_response(conn, 200, voided)
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("credit_note", id))
+    end
+  end
+
+  defp validate_credit_amount_source(params) do
+    if Map.has_key?(params, :amount) or Map.has_key?(params, :lines) or Map.has_key?(params, :shipping_cost) do
+      :ok
+    else
+      {:error, :missing_amount_source}
+    end
+  end
+
+  defp validate_invoice_finalized(%{status: "draft"}), do: {:error, :invoice_not_finalized}
+  defp validate_invoice_finalized(_invoice), do: :ok
+
+  defp build_credit_note(params, invoice, create_balance_transaction? \\ true) do
+    amount = credit_amount(params, invoice)
+    amount_remaining = Map.get(invoice, :amount_remaining, 0)
+    pre_payment_amount = min(amount, amount_remaining)
+    post_payment_amount = amount - pre_payment_amount
+    credit_amount = get_integer(params, :credit_amount, post_payment_amount)
+    id = generate_id("cn", Map.get(params, :id))
+    lines = build_lines(params, invoice, id, amount)
+
+    %{
+      amount: amount,
+      amount_shipping: 0,
+      created: PaperTiger.now(),
+      currency: invoice.currency || "usd",
+      customer: invoice.customer,
+      customer_balance_transaction: nil,
+      discount_amount: 0,
+      discount_amounts: [],
+      effective_at: get_optional_integer(params, :effective_at) || PaperTiger.now(),
+      id: id,
+      invoice: invoice.id,
+      lines: %{data: lines, has_more: false, object: "list", url: "/v1/credit_notes/#{id}/lines"},
+      livemode: false,
+      memo: Map.get(params, :memo),
+      metadata: Map.get(params, :metadata, %{}),
+      number:
+        "#{invoice.number || invoice.id}-CN-#{CreditNotes.find_by_invoice(invoice.id) |> length() |> Kernel.+(1)}",
+      object: "credit_note",
+      out_of_band_amount: get_optional_integer(params, :out_of_band_amount),
+      pdf: "https://pay.stripe.com/credit_notes/#{id}/pdf",
+      post_payment_amount: post_payment_amount,
+      pre_payment_amount: pre_payment_amount,
+      reason: Map.get(params, :reason),
+      refunds: [],
+      shipping_cost: Map.get(params, :shipping_cost),
+      status: "issued",
+      subtotal: amount,
+      subtotal_excluding_tax: amount,
+      total: amount,
+      total_excluding_tax: amount,
+      total_taxes: [],
+      type: if(post_payment_amount > 0, do: "post_payment", else: "pre_payment"),
+      voided_at: nil
+    }
+    |> maybe_create_customer_balance_transaction(credit_amount, create_balance_transaction?)
+  end
+
+  defp maybe_create_customer_balance_transaction(credit_note, credit_amount, true) when credit_amount > 0 do
+    {:ok, transaction} =
+      CustomerBalance.create_transaction(credit_note.customer, %{
+        amount: -credit_amount,
+        credit_note: credit_note.id,
+        currency: credit_note.currency,
+        description: "Credit note #{credit_note.number}",
+        type: "credit_note"
+      })
+
+    Map.put(credit_note, :customer_balance_transaction, transaction.id)
+  end
+
+  defp maybe_create_customer_balance_transaction(credit_note, _credit_amount, _create_balance_transaction?),
+    do: credit_note
+
+  defp credit_amount(%{amount: amount}, _invoice), do: to_integer(amount)
+  defp credit_amount(%{lines: lines}, _invoice) when is_list(lines), do: Enum.reduce(lines, 0, &(&2 + line_amount(&1)))
+  defp credit_amount(_params, invoice), do: Map.get(invoice, :amount_remaining, 0)
+
+  defp build_lines(%{lines: lines}, invoice, credit_note_id, _amount) when is_list(lines) do
+    Enum.map(lines, &build_line(&1, invoice, credit_note_id))
+  end
+
+  defp build_lines(_params, invoice, _credit_note_id, amount) do
+    [
+      %{
+        amount: amount,
+        description: "Credit for invoice #{invoice.id}",
+        discount_amount: 0,
+        discount_amounts: [],
+        id: generate_id("cnli"),
+        invoice_line_item: nil,
+        livemode: false,
+        object: "credit_note_line_item",
+        quantity: 1,
+        tax_rates: [],
+        taxes: [],
+        type: "custom_line_item",
+        unit_amount: amount,
+        unit_amount_decimal: to_string(amount)
+      }
+    ]
+  end
+
+  defp build_line(line, _invoice, _credit_note_id) do
+    amount = line_amount(line)
+
+    %{
+      amount: amount,
+      description: Map.get(line, :description),
+      discount_amount: 0,
+      discount_amounts: [],
+      id: generate_id("cnli"),
+      invoice_line_item: Map.get(line, :invoice_line_item),
+      livemode: false,
+      object: "credit_note_line_item",
+      quantity: get_integer(line, :quantity, 1),
+      tax_rates: Map.get(line, :tax_rates, []),
+      taxes: [],
+      type: Map.get(line, :type, "custom_line_item"),
+      unit_amount: get_integer(line, :unit_amount, amount),
+      unit_amount_decimal: to_string(get_integer(line, :unit_amount, amount))
+    }
+  end
+
+  defp line_amount(line) do
+    cond do
+      Map.has_key?(line, :amount) ->
+        get_integer(line, :amount)
+
+      Map.has_key?(line, :unit_amount) ->
+        get_integer(line, :unit_amount) * get_integer(line, :quantity, 1)
+
+      true ->
+        0
+    end
+  end
+
+  defp apply_credit_note(invoice, credit_note) do
+    amount_due = max(Map.get(invoice, :amount_due, 0) - credit_note.pre_payment_amount, 0)
+    amount_remaining = max(Map.get(invoice, :amount_remaining, 0) - credit_note.pre_payment_amount, 0)
+
+    updated =
+      invoice
+      |> Map.put(:amount_due, amount_due)
+      |> Map.put(:amount_remaining, amount_remaining)
+      |> Map.update(
+        :pre_payment_credit_notes_amount,
+        credit_note.pre_payment_amount,
+        &(&1 + credit_note.pre_payment_amount)
+      )
+      |> Map.update(
+        :post_payment_credit_notes_amount,
+        credit_note.post_payment_amount,
+        &(&1 + credit_note.post_payment_amount)
+      )
+      |> maybe_mark_invoice_paid()
+
+    Invoices.update(updated)
+  end
+
+  defp maybe_mark_invoice_paid(%{amount_remaining: 0} = invoice) do
+    invoice
+    |> Map.put(:paid, true)
+    |> Map.put(:status, "paid")
+  end
+
+  defp maybe_mark_invoice_paid(invoice), do: invoice
+
+  defp paginate_lines(lines, params, url) do
+    limit = params |> get_integer(:limit, 10) |> min(100)
+
+    %{
+      data: Enum.take(lines, limit),
+      has_more: length(lines) > limit,
+      object: "list",
+      url: url
+    }
+  end
+
+  defp maybe_expand(credit_note, params) do
+    params
+    |> parse_expand_params()
+    |> then(&PaperTiger.Hydrator.hydrate(credit_note, &1))
+  end
+end

--- a/lib/paper_tiger/resources/customer_balance_transaction.ex
+++ b/lib/paper_tiger/resources/customer_balance_transaction.ex
@@ -1,0 +1,94 @@
+defmodule PaperTiger.Resources.CustomerBalanceTransaction do
+  @moduledoc """
+  Handles nested Customer Balance Transaction endpoints.
+  """
+
+  import PaperTiger.Resource
+
+  alias PaperTiger.CustomerBalance
+  alias PaperTiger.Store.CustomerBalanceTransactions
+
+  @doc """
+  Creates a customer balance transaction and mutates the customer's balance.
+  """
+  @spec create(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def create(conn, customer_id) do
+    with {:ok, _params} <- validate_params(conn.params, [:amount, :currency]),
+         {:ok, transaction} <- CustomerBalance.create_transaction(customer_id, conn.params) do
+      maybe_store_idempotency(conn, transaction)
+      json_response(conn, 200, transaction)
+    else
+      {:error, :invalid_params, field} ->
+        error_response(conn, PaperTiger.Error.invalid_request("Missing required parameter", field))
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("customer", customer_id))
+    end
+  end
+
+  @doc """
+  Retrieves a customer balance transaction.
+  """
+  @spec retrieve(Plug.Conn.t(), String.t(), String.t()) :: Plug.Conn.t()
+  def retrieve(conn, customer_id, id) do
+    case CustomerBalanceTransactions.get(id) do
+      {:ok, %{customer: ^customer_id} = transaction} ->
+        json_response(conn, 200, transaction)
+
+      {:ok, _transaction} ->
+        error_response(conn, PaperTiger.Error.not_found("customer_balance_transaction", id))
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("customer_balance_transaction", id))
+    end
+  end
+
+  @doc """
+  Updates customer balance transaction metadata/description.
+  """
+  @spec update(Plug.Conn.t(), String.t(), String.t()) :: Plug.Conn.t()
+  def update(conn, customer_id, id) do
+    case CustomerBalanceTransactions.get(id) do
+      {:ok, %{customer: ^customer_id} = existing} ->
+        updated =
+          merge_updates(existing, conn.params, [
+            :amount,
+            :created,
+            :credit_note,
+            :currency,
+            :customer,
+            :ending_balance,
+            :id,
+            :invoice,
+            :livemode,
+            :object,
+            :type
+          ])
+
+        {:ok, updated} = CustomerBalanceTransactions.update(updated)
+        json_response(conn, 200, updated)
+
+      {:ok, _transaction} ->
+        error_response(conn, PaperTiger.Error.not_found("customer_balance_transaction", id))
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("customer_balance_transaction", id))
+    end
+  end
+
+  @doc """
+  Lists customer balance transactions.
+  """
+  @spec list(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def list(conn, customer_id) do
+    conn.params
+    |> parse_pagination_params()
+    |> Map.put(:url, "/v1/customers/#{customer_id}/balance_transactions")
+    |> then(fn opts ->
+      customer_id
+      |> CustomerBalanceTransactions.find_by_customer()
+      |> PaperTiger.List.paginate(opts)
+    end)
+    |> then(&json_response(conn, 200, &1))
+  end
+end

--- a/lib/paper_tiger/resources/invoice.ex
+++ b/lib/paper_tiger/resources/invoice.ex
@@ -39,6 +39,7 @@ defmodule PaperTiger.Resources.Invoice do
   import PaperTiger.Resource
 
   alias PaperTiger.ChaosCoordinator
+  alias PaperTiger.CustomerBalance
   alias PaperTiger.Search
   alias PaperTiger.Store.InvoiceItems
   alias PaperTiger.Store.Invoices
@@ -354,7 +355,7 @@ defmodule PaperTiger.Resources.Invoice do
   def finalize(conn, id) do
     with {:ok, invoice} <- Invoices.get(id),
          :ok <- validate_can_finalize(invoice),
-         finalized = finalize_invoice(invoice),
+         finalized = invoice |> finalize_invoice() |> CustomerBalance.apply_to_invoice(),
          {:ok, finalized} <- Invoices.update(finalized) do
       finalized_with_lines = load_invoice_lines(finalized)
       :telemetry.execute([:paper_tiger, :invoice, :finalized], %{}, %{object: finalized_with_lines})

--- a/lib/paper_tiger/resources/promotion_code.ex
+++ b/lib/paper_tiger/resources/promotion_code.ex
@@ -1,0 +1,178 @@
+defmodule PaperTiger.Resources.PromotionCode do
+  @moduledoc """
+  Handles Promotion Code resource endpoints.
+  """
+
+  import PaperTiger.Resource
+
+  alias PaperTiger.Store.Coupons
+  alias PaperTiger.Store.PromotionCodes
+
+  @doc """
+  Creates a Promotion Code.
+  """
+  @spec create(Plug.Conn.t()) :: Plug.Conn.t()
+  def create(conn) do
+    with {:ok, _params} <- validate_params(conn.params, [:promotion]),
+         {:ok, coupon_id} <- validate_promotion(conn.params.promotion),
+         {:ok, coupon} <- Coupons.get(coupon_id),
+         promotion_code = build_promotion_code(conn.params, coupon),
+         {:ok, promotion_code} <- PromotionCodes.insert(promotion_code) do
+      maybe_store_idempotency(conn, promotion_code)
+
+      promotion_code
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :invalid_params, field} ->
+        error_response(conn, PaperTiger.Error.invalid_request("Missing required parameter", field))
+
+      {:error, :invalid_promotion} ->
+        error_response(conn, PaperTiger.Error.invalid_request("Invalid promotion", "promotion"))
+
+      {:error, :not_found} ->
+        coupon_id = conn.params |> Map.get(:promotion, %{}) |> param(:coupon)
+        error_response(conn, PaperTiger.Error.not_found("coupon", coupon_id || ""))
+    end
+  end
+
+  @doc """
+  Retrieves a Promotion Code.
+  """
+  @spec retrieve(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def retrieve(conn, id) do
+    case PromotionCodes.get(id) do
+      {:ok, promotion_code} ->
+        promotion_code
+        |> maybe_expand(conn.params)
+        |> then(&json_response(conn, 200, &1))
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("promotion_code", id))
+    end
+  end
+
+  @doc """
+  Updates a Promotion Code.
+  """
+  @spec update(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def update(conn, id) do
+    with {:ok, existing} <- PromotionCodes.get(id),
+         updated = update_promotion_code(existing, conn.params),
+         {:ok, updated} <- PromotionCodes.update(updated) do
+      updated
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("promotion_code", id))
+    end
+  end
+
+  @doc """
+  Lists Promotion Codes.
+  """
+  @spec list(Plug.Conn.t()) :: Plug.Conn.t()
+  def list(conn) do
+    pagination_opts = parse_pagination_params(conn.params)
+
+    result =
+      case param(conn.params, :code) do
+        code when is_binary(code) and code != "" ->
+          PromotionCodes.find_active_by_code(code)
+          |> PaperTiger.List.paginate(Map.put(pagination_opts, :url, "/v1/promotion_codes"))
+
+        _ ->
+          PromotionCodes.list(pagination_opts)
+      end
+
+    json_response(conn, 200, result)
+  end
+
+  defp validate_promotion(%{} = promotion) do
+    if param(promotion, :type) == "coupon" and param(promotion, :coupon) not in [nil, ""] do
+      {:ok, param(promotion, :coupon)}
+    else
+      {:error, :invalid_promotion}
+    end
+  end
+
+  defp validate_promotion(_promotion), do: {:error, :invalid_promotion}
+
+  defp build_promotion_code(params, coupon) do
+    now = PaperTiger.now()
+
+    %{
+      active: boolean_param(params, :active, true),
+      code: param(params, :code) || generated_code(),
+      coupon: coupon,
+      created: now,
+      customer: param(params, :customer),
+      expires_at: get_optional_integer(params, :expires_at),
+      id: generate_id("promo", param(params, :id)),
+      livemode: false,
+      max_redemptions: get_optional_integer(params, :max_redemptions),
+      metadata: param(params, :metadata) || %{},
+      object: "promotion_code",
+      promotion: %{coupon: coupon.id, type: "coupon"},
+      restrictions: param(params, :restrictions) || default_restrictions(),
+      times_redeemed: 0
+    }
+  end
+
+  defp update_promotion_code(promotion_code, params) do
+    params =
+      if Map.has_key?(params, :active) do
+        Map.put(params, :active, to_boolean(params.active))
+      else
+        params
+      end
+
+    apply_updates(params, promotion_code)
+  end
+
+  defp apply_updates(params, promotion_code) do
+    merge_updates(promotion_code, params, [
+      :code,
+      :coupon,
+      :created,
+      :customer,
+      :id,
+      :livemode,
+      :object,
+      :promotion,
+      :times_redeemed
+    ])
+  end
+
+  defp default_restrictions do
+    %{
+      first_time_transaction: false,
+      minimum_amount: nil,
+      minimum_amount_currency: nil
+    }
+  end
+
+  defp maybe_expand(promotion_code, params) do
+    params
+    |> parse_expand_params()
+    |> then(&PaperTiger.Hydrator.hydrate(promotion_code, &1))
+  end
+
+  defp generated_code do
+    :crypto.strong_rand_bytes(6)
+    |> Base.encode16(case: :upper)
+    |> binary_part(0, 10)
+  end
+
+  defp boolean_param(params, key, default) do
+    if Map.has_key?(params, key) do
+      to_boolean(Map.get(params, key))
+    else
+      default
+    end
+  end
+
+  defp param(map, key) when is_map(map) and is_atom(key), do: Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  defp param(_map, _key), do: nil
+end

--- a/lib/paper_tiger/resources/subscription.ex
+++ b/lib/paper_tiger/resources/subscription.ex
@@ -40,8 +40,8 @@ defmodule PaperTiger.Resources.Subscription do
   import PaperTiger.Resource
 
   alias PaperTiger.AutomaticTax
+  alias PaperTiger.Discounts
   alias PaperTiger.Search
-  alias PaperTiger.Store.Coupons
   alias PaperTiger.Store.Customers
   alias PaperTiger.Store.InvoiceItems
   alias PaperTiger.Store.Invoices
@@ -385,7 +385,7 @@ defmodule PaperTiger.Resources.Subscription do
       customer: Map.get(params, :customer),
       days_until_due: nil,
       default_payment_method: Map.get(params, :default_payment_method),
-      discount: build_discount_from_coupon(params),
+      discount: Discounts.build_from_params(params),
       ended_at: nil,
       id: generate_id("sub", Map.get(params, :id)),
       items: %{data: [], has_more: false, object: "list", url: "/v1/subscription_items"},
@@ -404,28 +404,10 @@ defmodule PaperTiger.Resources.Subscription do
   end
 
   defp maybe_update_discount(subscription, params) do
-    if Map.has_key?(params, :coupon) do
-      Map.put(subscription, :discount, build_discount_from_coupon(params))
+    if Map.has_key?(params, :coupon) or Map.has_key?(params, :promotion_code) or Map.has_key?(params, :discounts) do
+      Map.put(subscription, :discount, Discounts.build_from_params(params))
     else
       subscription
-    end
-  end
-
-  defp build_discount_from_coupon(params) do
-    coupon_id = Map.get(params, :coupon)
-
-    if coupon_id && coupon_id != "" do
-      case Coupons.get(to_string(coupon_id)) do
-        {:ok, coupon} ->
-          %{
-            coupon: coupon,
-            id: generate_id("di"),
-            object: "discount"
-          }
-
-        _ ->
-          nil
-      end
     end
   end
 
@@ -847,7 +829,9 @@ defmodule PaperTiger.Resources.Subscription do
       invoice_id = generate_id("in")
       line_items = build_initial_invoice_line_items(subscription, invoice_id)
       {line_items, totals} = AutomaticTax.apply_to_line_items(line_items, params, :invoice)
-      total = if(AutomaticTax.enabled?(params), do: totals.total, else: subtotal)
+      discount_amount = Discounts.amount(subscription.discount, subtotal, "usd")
+      total_before_discount = if(AutomaticTax.enabled?(params), do: totals.total, else: subtotal)
+      total = max(total_before_discount - discount_amount, 0)
       amount_paid = if(amt_paid == :paid_total, do: total, else: amt_paid)
       amount_remaining = if(amt_remaining == :remaining_total, do: total, else: amt_remaining)
 
@@ -902,7 +886,8 @@ defmodule PaperTiger.Resources.Subscription do
         subtotal: subtotal,
         tax: totals.amount_tax,
         total: total,
-        total_details: totals.total_details
+        total_details: Map.put(totals.total_details, :amount_discount, discount_amount),
+        total_discount_amounts: discount_amounts(subscription.discount, discount_amount)
       }
 
       Enum.each(line_items, &InvoiceItems.insert/1)
@@ -930,6 +915,14 @@ defmodule PaperTiger.Resources.Subscription do
   end
 
   defp calculate_items_total(_), do: 0
+
+  defp discount_amounts(_discount, 0), do: []
+
+  defp discount_amounts(discount, amount) when is_map(discount) do
+    [%{amount: amount, discount: discount.id}]
+  end
+
+  defp discount_amounts(_discount, _amount), do: []
 
   defp build_initial_invoice_line_items(subscription, invoice_id) do
     now = PaperTiger.now()

--- a/lib/paper_tiger/router.ex
+++ b/lib/paper_tiger/router.ex
@@ -60,11 +60,14 @@ defmodule PaperTiger.Router do
   alias PaperTiger.Resources.BillingPortalConfiguration
   alias PaperTiger.Resources.BillingPortalSession
   alias PaperTiger.Resources.Card
+  alias PaperTiger.Resources.CashBalance
   alias PaperTiger.Resources.Charge
   alias PaperTiger.Resources.CheckoutSession
   alias PaperTiger.Resources.ConfirmationToken
   alias PaperTiger.Resources.Coupon
+  alias PaperTiger.Resources.CreditNote
   alias PaperTiger.Resources.Customer
+  alias PaperTiger.Resources.CustomerBalanceTransaction
   alias PaperTiger.Resources.CustomerSession
   alias PaperTiger.Resources.Dispute
   alias PaperTiger.Resources.Event
@@ -80,6 +83,7 @@ defmodule PaperTiger.Router do
   alias PaperTiger.Resources.Plan
   alias PaperTiger.Resources.Price
   alias PaperTiger.Resources.Product
+  alias PaperTiger.Resources.PromotionCode
   alias PaperTiger.Resources.Refund
   alias PaperTiger.Resources.Review
   alias PaperTiger.Resources.SetupAttempt
@@ -220,6 +224,30 @@ defmodule PaperTiger.Router do
     Customer.search(conn)
   end
 
+  post "/v1/customers/:customer_id/balance_transactions" do
+    CustomerBalanceTransaction.create(conn, customer_id)
+  end
+
+  get "/v1/customers/:customer_id/balance_transactions/:id" do
+    CustomerBalanceTransaction.retrieve(conn, customer_id, id)
+  end
+
+  post "/v1/customers/:customer_id/balance_transactions/:id" do
+    CustomerBalanceTransaction.update(conn, customer_id, id)
+  end
+
+  get "/v1/customers/:customer_id/balance_transactions" do
+    CustomerBalanceTransaction.list(conn, customer_id)
+  end
+
+  get "/v1/customers/:customer_id/cash_balance" do
+    CashBalance.retrieve(conn, customer_id)
+  end
+
+  post "/v1/customers/:customer_id/cash_balance" do
+    CashBalance.update(conn, customer_id)
+  end
+
   stripe_resource("customers", Customer, [])
 
   get "/v1/subscriptions/search" do
@@ -309,6 +337,7 @@ defmodule PaperTiger.Router do
   stripe_resource("charges", Charge, except: [:delete])
   stripe_resource("refunds", Refund, except: [:delete])
   stripe_resource("coupons", Coupon, [])
+  stripe_resource("promotion_codes", PromotionCode, except: [:delete])
   stripe_resource("plans", Plan, [])
   stripe_resource("tax_rates", TaxRate, except: [:delete])
   stripe_resource("payouts", Payout, except: [:delete])
@@ -327,6 +356,24 @@ defmodule PaperTiger.Router do
   stripe_resource("events", Event, only: [:retrieve, :list])
   stripe_resource("tokens", Token, only: [:create, :retrieve])
   stripe_resource("checkout/sessions", CheckoutSession, only: [:create, :retrieve, :update, :list])
+
+  get "/v1/credit_notes/preview/lines" do
+    CreditNote.preview_lines(conn)
+  end
+
+  get "/v1/credit_notes/preview" do
+    CreditNote.preview(conn)
+  end
+
+  get "/v1/credit_notes/:id/lines" do
+    CreditNote.lines(conn, id)
+  end
+
+  post "/v1/credit_notes/:id/void" do
+    CreditNote.void(conn, id)
+  end
+
+  stripe_resource("credit_notes", CreditNote, except: [:delete])
 
   ## Custom Checkout Session Endpoints
 

--- a/lib/paper_tiger/store/credit_notes.ex
+++ b/lib/paper_tiger/store/credit_notes.ex
@@ -1,0 +1,24 @@
+defmodule PaperTiger.Store.CreditNotes do
+  @moduledoc false
+
+  use PaperTiger.Store,
+    table: :paper_tiger_credit_notes,
+    resource: "credit_note",
+    prefix: "cn",
+    plural: "credit_notes",
+    url_path: "/v1/credit_notes"
+
+  @doc """
+  Lists credit notes for an invoice.
+  """
+  @spec find_by_invoice(String.t()) :: [map()]
+  def find_by_invoice(invoice_id) when is_binary(invoice_id) do
+    namespace = PaperTiger.Test.current_namespace()
+
+    @table
+    |> :ets.match_object({{namespace, :_}, :_})
+    |> Enum.map(fn {_key, credit_note} -> credit_note end)
+    |> Enum.filter(fn credit_note -> Map.get(credit_note, :invoice) == invoice_id end)
+    |> Enum.sort_by(&Map.get(&1, :created), :desc)
+  end
+end

--- a/lib/paper_tiger/store/customer_balance_transactions.ex
+++ b/lib/paper_tiger/store/customer_balance_transactions.ex
@@ -1,0 +1,24 @@
+defmodule PaperTiger.Store.CustomerBalanceTransactions do
+  @moduledoc false
+
+  use PaperTiger.Store,
+    table: :paper_tiger_customer_balance_transactions,
+    resource: "customer_balance_transaction",
+    prefix: "cbtxn",
+    plural: "customer_balance_transactions",
+    url_path: "/v1/customer_balance_transactions"
+
+  @doc """
+  Lists customer balance transactions for a customer.
+  """
+  @spec find_by_customer(String.t()) :: [map()]
+  def find_by_customer(customer_id) when is_binary(customer_id) do
+    namespace = PaperTiger.Test.current_namespace()
+
+    @table
+    |> :ets.match_object({{namespace, :_}, :_})
+    |> Enum.map(fn {_key, transaction} -> transaction end)
+    |> Enum.filter(fn transaction -> Map.get(transaction, :customer) == customer_id end)
+    |> Enum.sort_by(&Map.get(&1, :created), :desc)
+  end
+end

--- a/lib/paper_tiger/store/promotion_codes.ex
+++ b/lib/paper_tiger/store/promotion_codes.ex
@@ -1,0 +1,27 @@
+defmodule PaperTiger.Store.PromotionCodes do
+  @moduledoc false
+
+  use PaperTiger.Store,
+    table: :paper_tiger_promotion_codes,
+    resource: "promotion_code",
+    prefix: "promo",
+    plural: "promotion_codes",
+    url_path: "/v1/promotion_codes"
+
+  @doc """
+  Finds active promotion codes by customer-facing code, case-insensitively.
+  """
+  @spec find_active_by_code(String.t()) :: [map()]
+  def find_active_by_code(code) when is_binary(code) do
+    namespace = PaperTiger.Test.current_namespace()
+    normalized_code = String.downcase(code)
+
+    @table
+    |> :ets.match_object({{namespace, :_}, :_})
+    |> Enum.map(fn {_key, promotion_code} -> promotion_code end)
+    |> Enum.filter(fn promotion_code ->
+      Map.get(promotion_code, :active) == true and
+        promotion_code |> Map.get(:code, "") |> String.downcase() == normalized_code
+    end)
+  end
+end

--- a/lib/paper_tiger/test.ex
+++ b/lib/paper_tiger/test.ex
@@ -40,6 +40,8 @@ defmodule PaperTiger.Test do
   alias PaperTiger.Store.CheckoutSessions
   alias PaperTiger.Store.ConfirmationTokens
   alias PaperTiger.Store.Coupons
+  alias PaperTiger.Store.CreditNotes
+  alias PaperTiger.Store.CustomerBalanceTransactions
   alias PaperTiger.Store.Customers
   alias PaperTiger.Store.Disputes
   alias PaperTiger.Store.Events
@@ -55,6 +57,7 @@ defmodule PaperTiger.Test do
   alias PaperTiger.Store.Plans
   alias PaperTiger.Store.Prices
   alias PaperTiger.Store.Products
+  alias PaperTiger.Store.PromotionCodes
   alias PaperTiger.Store.Refunds
   alias PaperTiger.Store.Reviews
   alias PaperTiger.Store.SetupAttempts
@@ -211,7 +214,9 @@ defmodule PaperTiger.Test do
       Charges,
       CheckoutSessions,
       ConfirmationTokens,
+      CreditNotes,
       Coupons,
+      CustomerBalanceTransactions,
       Customers,
       Disputes,
       Events,
@@ -227,6 +232,7 @@ defmodule PaperTiger.Test do
       Plans,
       Prices,
       Products,
+      PromotionCodes,
       Refunds,
       Reviews,
       SetupAttempts,

--- a/test/paper_tiger/contract_test.exs
+++ b/test/paper_tiger/contract_test.exs
@@ -1185,6 +1185,83 @@ defmodule PaperTiger.ContractTest do
     end
   end
 
+  describe "Billing Discount and Credit APIs" do
+    @tag :contract
+    test "creates promotion codes for coupons" do
+      coupon_id = "pt_coupon_#{System.unique_integer([:positive])}"
+      code = "PT-#{System.unique_integer([:positive])}"
+
+      {:ok, coupon} =
+        TestClient.create_coupon(%{
+          "duration" => "forever",
+          "id" => coupon_id,
+          "percent_off" => 25
+        })
+
+      {:ok, promotion_code} =
+        TestClient.create_promotion_code(%{
+          "code" => code,
+          "promotion" => %{"coupon" => coupon["id"], "type" => "coupon"}
+        })
+
+      assert promotion_code["object"] == "promotion_code"
+      assert String.starts_with?(promotion_code["id"], "promo_")
+      assert promotion_code["active"] == true
+      assert promotion_code["code"] == code
+      assert promotion_code["coupon"]["id"] == coupon["id"]
+
+      {:ok, retrieved} = TestClient.get_promotion_code(promotion_code["id"])
+      assert retrieved["id"] == promotion_code["id"]
+
+      {:ok, updated} =
+        TestClient.update_promotion_code(promotion_code["id"], %{
+          "metadata" => %{"contract" => "promotion_code"}
+        })
+
+      assert updated["metadata"]["contract"] == "promotion_code"
+
+      {:ok, list} = TestClient.list_promotion_codes(%{"code" => code, "limit" => 1})
+      assert Enum.any?(list["data"], fn item -> item["id"] == promotion_code["id"] end)
+    end
+
+    @tag :contract
+    test "creates customer balance transactions and retrieves cash balance" do
+      {:ok, customer} = TestClient.create_customer(%{"email" => "balance-contract@example.com"})
+
+      {:ok, transaction} =
+        TestClient.create_customer_balance_transaction(customer["id"], %{
+          "amount" => -500,
+          "currency" => "usd",
+          "description" => "Contract credit"
+        })
+
+      assert transaction["object"] == "customer_balance_transaction"
+      assert String.starts_with?(transaction["id"], "cbtxn_")
+      assert transaction["amount"] == -500
+      assert transaction["currency"] == "usd"
+      assert transaction["customer"] == customer["id"]
+
+      {:ok, retrieved} = TestClient.get_customer_balance_transaction(customer["id"], transaction["id"])
+      assert retrieved["id"] == transaction["id"]
+
+      {:ok, list} = TestClient.list_customer_balance_transactions(customer["id"], %{"limit" => 1})
+      assert Enum.any?(list["data"], fn item -> item["id"] == transaction["id"] end)
+
+      cash_balance_result = TestClient.get_cash_balance(customer["id"])
+
+      case cash_balance_result do
+        {:ok, cash_balance} ->
+          assert cash_balance["object"] == "cash_balance"
+          assert cash_balance["customer"] == customer["id"]
+
+        {:error, error} ->
+          assert error["error"]["type"] == "invalid_request_error"
+      end
+
+      cleanup_customer(customer["id"])
+    end
+  end
+
   describe "Error Response Format Validation" do
     @tag :contract
     test "non-existent customer returns resource_missing error" do

--- a/test/paper_tiger/resources/billing_discount_credit_test.exs
+++ b/test/paper_tiger/resources/billing_discount_credit_test.exs
@@ -1,0 +1,268 @@
+defmodule PaperTiger.Resources.BillingDiscountCreditTest do
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
+
+  alias PaperTiger.Router
+
+  setup :checkout_paper_tiger
+
+  defp conn(method, path, params, headers) do
+    conn = Plug.Test.conn(method, path, params)
+
+    headers_with_defaults =
+      headers ++
+        [
+          {"content-type", "application/json"},
+          {"authorization", "Bearer sk_test_billing_credit_key"}
+        ] ++ sandbox_headers()
+
+    Enum.reduce(headers_with_defaults, conn, fn {key, value}, acc ->
+      Plug.Conn.put_req_header(acc, key, value)
+    end)
+  end
+
+  defp request(method, path, params \\ nil, headers \\ []) do
+    method
+    |> conn(path, params, headers)
+    |> Router.call([])
+  end
+
+  defp json_response(conn), do: Jason.decode!(conn.resp_body)
+
+  describe "Promotion Codes" do
+    test "creates, retrieves, updates, lists, and applies a promotion code to subscription invoices" do
+      coupon = create_coupon(%{"id" => "coupon_50", "percent_off" => 50})
+
+      create_conn =
+        request(:post, "/v1/promotion_codes", %{
+          "code" => "HALF-OFF",
+          "promotion" => %{"coupon" => coupon["id"], "type" => "coupon"}
+        })
+
+      assert create_conn.status == 200
+      promotion_code = json_response(create_conn)
+      assert String.starts_with?(promotion_code["id"], "promo_")
+      assert promotion_code["object"] == "promotion_code"
+      assert promotion_code["active"] == true
+      assert promotion_code["promotion"] == %{"coupon" => coupon["id"], "type" => "coupon"}
+
+      retrieve_conn = request(:get, "/v1/promotion_codes/#{promotion_code["id"]}")
+      assert retrieve_conn.status == 200
+      assert json_response(retrieve_conn)["code"] == "HALF-OFF"
+
+      update_conn =
+        request(:post, "/v1/promotion_codes/#{promotion_code["id"]}", %{
+          "metadata" => %{"campaign" => "spring"}
+        })
+
+      assert update_conn.status == 200
+      assert json_response(update_conn)["metadata"] == %{"campaign" => "spring"}
+
+      list_conn = request(:get, "/v1/promotion_codes?code=half-off")
+      assert list_conn.status == 200
+      assert [promotion_code["id"]] == Enum.map(json_response(list_conn)["data"], & &1["id"])
+
+      customer = create_customer()
+      price = create_price(1000)
+
+      subscription_conn =
+        request(:post, "/v1/subscriptions", %{
+          "customer" => customer["id"],
+          "items" => [%{"price" => price["id"], "quantity" => 1}],
+          "payment_behavior" => "default_incomplete",
+          "promotion_code" => promotion_code["id"]
+        })
+
+      assert subscription_conn.status == 200
+      subscription = json_response(subscription_conn)
+      assert subscription["discount"]["promotion_code"] == promotion_code["id"]
+      assert subscription["discount"]["coupon"]["id"] == coupon["id"]
+
+      invoice_conn = request(:get, "/v1/invoices/#{subscription["latest_invoice"]}")
+      assert invoice_conn.status == 200
+      invoice = json_response(invoice_conn)
+      assert invoice["amount_remaining"] == 500
+      assert invoice["total"] == 500
+      assert invoice["total_details"]["amount_discount"] == 500
+    end
+  end
+
+  describe "Customer Balance Transactions and Cash Balance" do
+    test "mutates customer credit balance and applies it when an invoice is finalized" do
+      customer = create_customer()
+
+      transaction_conn =
+        request(:post, "/v1/customers/#{customer["id"]}/balance_transactions", %{
+          "amount" => -500,
+          "currency" => "usd",
+          "description" => "Test credit"
+        })
+
+      assert transaction_conn.status == 200
+      transaction = json_response(transaction_conn)
+      assert String.starts_with?(transaction["id"], "cbtxn_")
+      assert transaction["amount"] == -500
+      assert transaction["ending_balance"] == -500
+
+      retrieve_txn_conn =
+        request(:get, "/v1/customers/#{customer["id"]}/balance_transactions/#{transaction["id"]}")
+
+      assert retrieve_txn_conn.status == 200
+      assert json_response(retrieve_txn_conn)["id"] == transaction["id"]
+
+      invoice = create_invoice(customer["id"], 1000)
+      finalize_conn = request(:post, "/v1/invoices/#{invoice["id"]}/finalize")
+
+      assert finalize_conn.status == 200
+      finalized = json_response(finalize_conn)
+      assert finalized["amount_due"] == 500
+      assert finalized["amount_remaining"] == 500
+      assert finalized["starting_balance"] == -500
+      assert finalized["ending_balance"] == 0
+
+      customer_conn = request(:get, "/v1/customers/#{customer["id"]}")
+      assert json_response(customer_conn)["balance"] == 0
+    end
+
+    test "retrieves and updates cash balance settings" do
+      customer = create_customer()
+
+      retrieve_conn = request(:get, "/v1/customers/#{customer["id"]}/cash_balance")
+      assert retrieve_conn.status == 200
+      cash_balance = json_response(retrieve_conn)
+      assert cash_balance["object"] == "cash_balance"
+      assert cash_balance["available"] == %{}
+      assert cash_balance["settings"]["reconciliation_mode"] == "automatic"
+
+      update_conn =
+        request(:post, "/v1/customers/#{customer["id"]}/cash_balance", %{
+          "settings" => %{"reconciliation_mode" => "manual"}
+        })
+
+      assert update_conn.status == 200
+      assert json_response(update_conn)["settings"]["reconciliation_mode"] == "manual"
+    end
+  end
+
+  describe "Credit Notes" do
+    test "creates, previews, lists lines, and voids a pre-payment credit note" do
+      customer = create_customer()
+      invoice = customer["id"] |> create_invoice(1000) |> finalize_invoice()
+
+      preview_conn = request(:get, "/v1/credit_notes/preview?invoice=#{invoice["id"]}&amount=400")
+      assert preview_conn.status == 200
+      preview = json_response(preview_conn)
+      assert preview["object"] == "credit_note"
+      assert preview["id"] == nil
+      assert preview["amount"] == 400
+
+      create_conn =
+        request(:post, "/v1/credit_notes", %{
+          "amount" => 400,
+          "invoice" => invoice["id"],
+          "reason" => "order_change"
+        })
+
+      assert create_conn.status == 200
+      credit_note = json_response(create_conn)
+      assert String.starts_with?(credit_note["id"], "cn_")
+      assert credit_note["pre_payment_amount"] == 400
+      assert credit_note["post_payment_amount"] == 0
+      assert credit_note["status"] == "issued"
+
+      invoice_conn = request(:get, "/v1/invoices/#{invoice["id"]}")
+      adjusted_invoice = json_response(invoice_conn)
+      assert adjusted_invoice["amount_due"] == 600
+      assert adjusted_invoice["amount_remaining"] == 600
+      assert adjusted_invoice["pre_payment_credit_notes_amount"] == 400
+
+      lines_conn = request(:get, "/v1/credit_notes/#{credit_note["id"]}/lines")
+      assert lines_conn.status == 200
+      assert [%{"object" => "credit_note_line_item"}] = json_response(lines_conn)["data"]
+
+      void_conn = request(:post, "/v1/credit_notes/#{credit_note["id"]}/void")
+      assert void_conn.status == 200
+      assert json_response(void_conn)["status"] == "void"
+    end
+
+    test "credits customer balance for post-payment credit notes" do
+      customer = create_customer()
+      invoice = customer["id"] |> create_invoice(1000) |> finalize_invoice() |> pay_invoice()
+
+      create_conn =
+        request(:post, "/v1/credit_notes", %{
+          "amount" => 300,
+          "credit_amount" => 300,
+          "invoice" => invoice["id"]
+        })
+
+      assert create_conn.status == 200
+      credit_note = json_response(create_conn)
+      assert credit_note["pre_payment_amount"] == 0
+      assert credit_note["post_payment_amount"] == 300
+      assert String.starts_with?(credit_note["customer_balance_transaction"], "cbtxn_")
+
+      customer_conn = request(:get, "/v1/customers/#{customer["id"]}")
+      assert json_response(customer_conn)["balance"] == -300
+    end
+  end
+
+  defp create_customer do
+    conn = request(:post, "/v1/customers", %{"email" => "credit@example.test"})
+    assert conn.status == 200
+    json_response(conn)
+  end
+
+  defp create_coupon(attrs) do
+    params = Map.merge(%{"duration" => "forever"}, attrs)
+    conn = request(:post, "/v1/coupons", params)
+    assert conn.status == 200
+    json_response(conn)
+  end
+
+  defp create_price(amount) do
+    product_conn = request(:post, "/v1/products", %{"name" => "Discounted Product"})
+    assert product_conn.status == 200
+    product = json_response(product_conn)
+
+    price_conn =
+      request(:post, "/v1/prices", %{
+        "currency" => "usd",
+        "product" => product["id"],
+        "recurring" => %{"interval" => "month"},
+        "unit_amount" => amount
+      })
+
+    assert price_conn.status == 200
+    json_response(price_conn)
+  end
+
+  defp create_invoice(customer_id, amount) do
+    conn =
+      request(:post, "/v1/invoices", %{
+        "amount_due" => amount,
+        "amount_remaining" => amount,
+        "currency" => "usd",
+        "customer" => customer_id,
+        "status" => "draft",
+        "subtotal" => amount,
+        "total" => amount
+      })
+
+    assert conn.status == 200
+    json_response(conn)
+  end
+
+  defp finalize_invoice(invoice) do
+    conn = request(:post, "/v1/invoices/#{invoice["id"]}/finalize")
+    assert conn.status == 200
+    json_response(conn)
+  end
+
+  defp pay_invoice(invoice) do
+    conn = request(:post, "/v1/invoices/#{invoice["id"]}/pay")
+    assert conn.status == 200
+    json_response(conn)
+  end
+end

--- a/test/support/test_client.ex
+++ b/test/support/test_client.ex
@@ -1082,6 +1082,73 @@ defmodule PaperTiger.TestClient do
     end
   end
 
+  ## Coupon and Promotion Code Operations
+
+  @doc """
+  Creates a coupon.
+  """
+  def create_coupon(params) do
+    case mode() do
+      :real_stripe ->
+        create_coupon_real(params)
+
+      :paper_tiger ->
+        create_coupon_mock(params)
+    end
+  end
+
+  @doc """
+  Creates a Promotion Code.
+  """
+  def create_promotion_code(params) do
+    case mode() do
+      :real_stripe ->
+        create_promotion_code_real(params)
+
+      :paper_tiger ->
+        create_promotion_code_mock(params)
+    end
+  end
+
+  @doc """
+  Retrieves a Promotion Code.
+  """
+  def get_promotion_code(promotion_code_id) do
+    case mode() do
+      :real_stripe ->
+        get_promotion_code_real(promotion_code_id)
+
+      :paper_tiger ->
+        get_promotion_code_mock(promotion_code_id)
+    end
+  end
+
+  @doc """
+  Updates a Promotion Code.
+  """
+  def update_promotion_code(promotion_code_id, params) do
+    case mode() do
+      :real_stripe ->
+        update_promotion_code_real(promotion_code_id, params)
+
+      :paper_tiger ->
+        update_promotion_code_mock(promotion_code_id, params)
+    end
+  end
+
+  @doc """
+  Lists Promotion Codes.
+  """
+  def list_promotion_codes(params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        list_promotion_codes_real(params)
+
+      :paper_tiger ->
+        list_promotion_codes_mock(params)
+    end
+  end
+
   ## Billing Portal Operations
 
   @doc """
@@ -1146,6 +1213,86 @@ defmodule PaperTiger.TestClient do
 
       :paper_tiger ->
         create_billing_portal_session_mock(params)
+    end
+  end
+
+  ## Customer Balance and Credit Operations
+
+  @doc """
+  Creates a customer balance transaction.
+  """
+  def create_customer_balance_transaction(customer_id, params) do
+    case mode() do
+      :real_stripe ->
+        create_customer_balance_transaction_real(customer_id, params)
+
+      :paper_tiger ->
+        create_customer_balance_transaction_mock(customer_id, params)
+    end
+  end
+
+  @doc """
+  Retrieves a customer balance transaction.
+  """
+  def get_customer_balance_transaction(customer_id, transaction_id) do
+    case mode() do
+      :real_stripe ->
+        get_customer_balance_transaction_real(customer_id, transaction_id)
+
+      :paper_tiger ->
+        get_customer_balance_transaction_mock(customer_id, transaction_id)
+    end
+  end
+
+  @doc """
+  Lists customer balance transactions.
+  """
+  def list_customer_balance_transactions(customer_id, params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        list_customer_balance_transactions_real(customer_id, params)
+
+      :paper_tiger ->
+        list_customer_balance_transactions_mock(customer_id, params)
+    end
+  end
+
+  @doc """
+  Retrieves a customer's cash balance.
+  """
+  def get_cash_balance(customer_id) do
+    case mode() do
+      :real_stripe ->
+        get_cash_balance_real(customer_id)
+
+      :paper_tiger ->
+        get_cash_balance_mock(customer_id)
+    end
+  end
+
+  @doc """
+  Updates a customer's cash balance settings.
+  """
+  def update_cash_balance(customer_id, params) do
+    case mode() do
+      :real_stripe ->
+        update_cash_balance_real(customer_id, params)
+
+      :paper_tiger ->
+        update_cash_balance_mock(customer_id, params)
+    end
+  end
+
+  @doc """
+  Creates a credit note.
+  """
+  def create_credit_note(params) do
+    case mode() do
+      :real_stripe ->
+        create_credit_note_real(params)
+
+      :paper_tiger ->
+        create_credit_note_mock(params)
     end
   end
 
@@ -1708,6 +1855,26 @@ defmodule PaperTiger.TestClient do
     stripe_request(:get, "/v1/payment_links/#{payment_link_id}/line_items", params)
   end
 
+  defp create_coupon_real(params) do
+    stripe_request(:post, "/v1/coupons", params)
+  end
+
+  defp create_promotion_code_real(params) do
+    stripe_request(:post, "/v1/promotion_codes", params)
+  end
+
+  defp get_promotion_code_real(promotion_code_id) do
+    stripe_request(:get, "/v1/promotion_codes/#{promotion_code_id}")
+  end
+
+  defp update_promotion_code_real(promotion_code_id, params) do
+    stripe_request(:post, "/v1/promotion_codes/#{promotion_code_id}", params)
+  end
+
+  defp list_promotion_codes_real(params) do
+    stripe_request(:get, "/v1/promotion_codes", params)
+  end
+
   defp create_billing_portal_configuration_real(params) do
     stripe_request(:post, "/v1/billing_portal/configurations", params)
   end
@@ -1726,6 +1893,30 @@ defmodule PaperTiger.TestClient do
 
   defp create_billing_portal_session_real(params) do
     stripe_request(:post, "/v1/billing_portal/sessions", params)
+  end
+
+  defp create_customer_balance_transaction_real(customer_id, params) do
+    stripe_request(:post, "/v1/customers/#{customer_id}/balance_transactions", params)
+  end
+
+  defp get_customer_balance_transaction_real(customer_id, transaction_id) do
+    stripe_request(:get, "/v1/customers/#{customer_id}/balance_transactions/#{transaction_id}")
+  end
+
+  defp list_customer_balance_transactions_real(customer_id, params) do
+    stripe_request(:get, "/v1/customers/#{customer_id}/balance_transactions", params)
+  end
+
+  defp get_cash_balance_real(customer_id) do
+    stripe_request(:get, "/v1/customers/#{customer_id}/cash_balance")
+  end
+
+  defp update_cash_balance_real(customer_id, params) do
+    stripe_request(:post, "/v1/customers/#{customer_id}/cash_balance", params)
+  end
+
+  defp create_credit_note_real(params) do
+    stripe_request(:post, "/v1/credit_notes", params)
   end
 
   ## Private - PaperTiger Mock
@@ -2090,6 +2281,31 @@ defmodule PaperTiger.TestClient do
     handle_response(conn)
   end
 
+  defp create_coupon_mock(params) do
+    conn = request(:post, "/v1/coupons", params)
+    handle_response(conn)
+  end
+
+  defp create_promotion_code_mock(params) do
+    conn = request(:post, "/v1/promotion_codes", params)
+    handle_response(conn)
+  end
+
+  defp get_promotion_code_mock(promotion_code_id) do
+    conn = request(:get, "/v1/promotion_codes/#{promotion_code_id}", %{})
+    handle_response(conn)
+  end
+
+  defp update_promotion_code_mock(promotion_code_id, params) do
+    conn = request(:post, "/v1/promotion_codes/#{promotion_code_id}", params)
+    handle_response(conn)
+  end
+
+  defp list_promotion_codes_mock(params) do
+    conn = request(:get, "/v1/promotion_codes", params)
+    handle_response(conn)
+  end
+
   defp create_billing_portal_configuration_mock(params) do
     conn = request(:post, "/v1/billing_portal/configurations", params)
     handle_response(conn)
@@ -2112,6 +2328,36 @@ defmodule PaperTiger.TestClient do
 
   defp create_billing_portal_session_mock(params) do
     conn = request(:post, "/v1/billing_portal/sessions", params)
+    handle_response(conn)
+  end
+
+  defp create_customer_balance_transaction_mock(customer_id, params) do
+    conn = request(:post, "/v1/customers/#{customer_id}/balance_transactions", params)
+    handle_response(conn)
+  end
+
+  defp get_customer_balance_transaction_mock(customer_id, transaction_id) do
+    conn = request(:get, "/v1/customers/#{customer_id}/balance_transactions/#{transaction_id}", %{})
+    handle_response(conn)
+  end
+
+  defp list_customer_balance_transactions_mock(customer_id, params) do
+    conn = request(:get, "/v1/customers/#{customer_id}/balance_transactions", params)
+    handle_response(conn)
+  end
+
+  defp get_cash_balance_mock(customer_id) do
+    conn = request(:get, "/v1/customers/#{customer_id}/cash_balance", %{})
+    handle_response(conn)
+  end
+
+  defp update_cash_balance_mock(customer_id, params) do
+    conn = request(:post, "/v1/customers/#{customer_id}/cash_balance", params)
+    handle_response(conn)
+  end
+
+  defp create_credit_note_mock(params) do
+    conn = request(:post, "/v1/credit_notes", params)
     handle_response(conn)
   end
 


### PR DESCRIPTION
## Summary

Closes #62.

Adds Billing discount and credit surfaces:
- Promotion Codes create/retrieve/update/list and code filtering
- Customer Balance Transactions nested under customers, with customer.balance mutation
- Customer Cash Balance retrieve/update settings
- Credit Notes create/retrieve/update/list/preview/lines/void, with invoice and customer-balance adjustments
- subscription promotion-code/discount support and discounted initial invoices
- contract-client coverage for the new surfaces

## Notes

Promotion Code responses include Stripe-compatible top-level `coupon` data; PaperTiger also keeps the requested `promotion` shape for compatibility with callers that send `promotion[type]=coupon`.

Customer balance finalization applies negative customer balances to finalized invoices. Credit Notes support deterministic pre-payment invoice reductions and post-payment customer balance credits for common test workflows.

References:
- https://docs.stripe.com/api/promotion_codes
- https://docs.stripe.com/api/credit_notes
- https://docs.stripe.com/api/customer_balance_transactions
- https://docs.stripe.com/api/cash_balance

## Validation

- `mise exec -- mix test`
- `mise exec -- mix dialyzer`
- `mise exec -- mix credo --strict`
- `VALIDATE_AGAINST_STRIPE=true mix test test/paper_tiger/contract_test.exs:1190 test/paper_tiger/contract_test.exs:1228` with a Stripe test-mode key
