### PR TITLE
Add Connect platform semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Invoice lifecycle endpoints for `POST /v1/invoices/:id/send`, `POST /v1/invoices/:id/mark_uncollectible`, and PaymentIntent-backed `POST /v1/invoices/:id/attach_payment`, including `invoice.sent`, `invoice.marked_uncollectible`, and `invoice.voided` webhook emission plus status-transition timestamps.
 - Hosted product APIs for Payment Links and Billing Portal: `POST/GET/POST/GET-list /v1/payment_links`, paginated `GET /v1/payment_links/:id/line_items`, browser-visible Payment Link URLs backed by deterministic Checkout Session completion, `POST /v1/billing_portal/sessions`, and Billing Portal Configuration create/retrieve/update/list endpoints.
 - Billing discount and credit APIs: Promotion Codes, Customer Balance Transactions, Customer Cash Balance, and Credit Notes with invoice/customer balance mutation for common credit workflows.
+- Properly scoped Connect platform APIs: legacy `/v1/accounts`, `POST /v1/account_links`, per-request `Stripe-Account` resource isolation, `POST/GET/POST/GET-list /v1/transfers`, nested transfer reversals, and nested application fee refunds with transfer/fee/reversal balance transaction effects.
 
 ### Fixed
 
@@ -37,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `:webhook_mode` config (`:sync` / `:async` / `:collect`) is unchanged and continues to control *when* delivery is dispatched. The new adapter controls *where/how* the signed request goes. The two are orthogonal.
 - `deliver_event_sync/2`'s public contract is unchanged (`{:ok, :delivered | :failed} | {:error, term()}`); adapter handoff does not leak a new return value.
+- Connect support intentionally targets Stripe API v1 compatibility first. Accounts v2, Persons, external-account mutation, capability review workflows, Treasury, and Issuing remain explicitly unsupported rather than partially mocked.
 
 ## [1.0.2] - 2026-02-28
 

--- a/README.md
+++ b/README.md
@@ -727,11 +727,25 @@ PaperTiger provides comprehensive coverage of core Stripe resources with full CR
 
 **Payment Sources**: Cards, BankAccounts, Sources, Tokens
 
-**Platform & Connect**: Payouts, BalanceTransactions, ApplicationFees, Disputes
+**Platform & Connect**: Accounts, AccountLinks, Transfers, TransferReversals, ApplicationFees, ApplicationFeeRefunds, Payouts, BalanceTransactions, Disputes
 
 **Checkout & Events**: CheckoutSessions, WebhookEndpoints, Events, Reviews, Topups
 
 > **Note**: PaperTiger implements Stripe API v1 resources. Some v2-only resources (e.g., v2 billing features) are not yet supported. Check the [issues page](https://github.com/EnaiaInc/paper_tiger/issues) for planned additions or open a feature request.
+
+### Connect Semantics
+
+PaperTiger models legacy Stripe Connect `/v1/accounts` first because current server-side Stripe clients commonly use the v1 Account resource. Connected account request context follows Stripe's `Stripe-Account` header: when a request includes `Stripe-Account: acct_...`, ordinary resources are read and written in that connected account's isolated scope. Platform-owned resources such as Accounts and Application Fees stay in platform scope.
+
+Supported Connect surfaces:
+
+- `/v1/accounts` create/retrieve/update/delete/list
+- `/v1/account_links` create
+- `/v1/transfers` create/retrieve/update/list
+- `/v1/transfers/:id/reversals` create/retrieve/update/list
+- `/v1/application_fees/:id/refunds` create/retrieve/update/list
+
+Unsupported Connect surfaces are explicit: Accounts v2, Persons, external-account mutation, capability verification/review workflows, Treasury, and Issuing are not partially mocked.
 
 ## API Examples
 
@@ -1201,6 +1215,7 @@ Cursor-based pagination using `starting_after`, `ending_before`, and `limit`:
 
 - No persistent storage (in-memory only)
 - Webhook delivery is asynchronous but not distributed
+- Connect support is scoped to common platform tests. It does not implement Accounts v2, Persons, external-account mutation, Treasury, Issuing, or real capability review/onboarding state machines.
 - Some Stripe API edge cases may differ from production
 - Time-based features (trials, billing periods) require manual time control
 

--- a/lib/paper_tiger.ex
+++ b/lib/paper_tiger.ex
@@ -40,6 +40,8 @@ defmodule PaperTiger do
   """
 
   alias PaperTiger.Store.{
+    Accounts,
+    ApplicationFeeRefunds,
     ApplicationFees,
     BalanceTransactions,
     BankAccounts,
@@ -78,6 +80,8 @@ defmodule PaperTiger do
     TaxRates,
     Tokens,
     Topups,
+    TransferReversals,
+    Transfers,
     Webhooks
   }
 
@@ -225,6 +229,7 @@ defmodule PaperTiger do
 
   @spec flush(atom()) :: :ok | {:error, :unknown_resource}
   def flush(:customers), do: Customers.clear()
+  def flush(:accounts), do: Accounts.clear()
   def flush(:subscriptions), do: Subscriptions.clear()
   def flush(:subscription_items), do: SubscriptionItems.clear()
   def flush(:invoices), do: Invoices.clear()
@@ -259,8 +264,11 @@ defmodule PaperTiger do
   def flush(:webhooks), do: Webhooks.clear()
   def flush(:events), do: Events.clear()
   def flush(:payouts), do: Payouts.clear()
+  def flush(:transfers), do: Transfers.clear()
+  def flush(:transfer_reversals), do: TransferReversals.clear()
   def flush(:balance_transactions), do: BalanceTransactions.clear()
   def flush(:application_fees), do: ApplicationFees.clear()
+  def flush(:application_fee_refunds), do: ApplicationFeeRefunds.clear()
   def flush(:reviews), do: Reviews.clear()
   def flush(:topups), do: Topups.clear()
   def flush(_), do: {:error, :unknown_resource}

--- a/lib/paper_tiger/application.ex
+++ b/lib/paper_tiger/application.ex
@@ -5,6 +5,8 @@ defmodule PaperTiger.Application do
   use Application
 
   alias PaperTiger.Bootstrap
+  alias PaperTiger.Store.Accounts
+  alias PaperTiger.Store.ApplicationFeeRefunds
   alias PaperTiger.Store.ApplicationFees
   alias PaperTiger.Store.BalanceTransactions
   alias PaperTiger.Store.BankAccounts
@@ -44,6 +46,8 @@ defmodule PaperTiger.Application do
   alias PaperTiger.Store.TaxRates
   alias PaperTiger.Store.Tokens
   alias PaperTiger.Store.Topups
+  alias PaperTiger.Store.TransferReversals
+  alias PaperTiger.Store.Transfers
   alias PaperTiger.Store.WebhookDeliveries
   alias PaperTiger.Store.Webhooks
 
@@ -75,6 +79,7 @@ defmodule PaperTiger.Application do
         PaperTiger.WebhookDelivery,
 
         # Resource stores
+        Accounts,
         Customers,
         Subscriptions,
         Products,
@@ -106,6 +111,8 @@ defmodule PaperTiger.Application do
         Tokens,
         BalanceTransactions,
         Payouts,
+        Transfers,
+        TransferReversals,
         CheckoutSessions,
         BillingPortalConfigurations,
         BillingPortalSessions,
@@ -114,6 +121,7 @@ defmodule PaperTiger.Application do
         Webhooks,
         Disputes,
         ApplicationFees,
+        ApplicationFeeRefunds,
         Reviews,
         Topups,
         # Must be last so all Stores are up

--- a/lib/paper_tiger/balance_transaction_helper.ex
+++ b/lib/paper_tiger/balance_transaction_helper.ex
@@ -82,6 +82,182 @@ defmodule PaperTiger.BalanceTransactionHelper do
   end
 
   @doc """
+  Creates the platform-side balance transaction for a transfer.
+  """
+  @spec create_for_transfer(map()) :: {:ok, String.t()} | {:error, term()}
+  def create_for_transfer(transfer) do
+    amount = get_field(transfer, :amount, 0)
+    currency = get_field(transfer, :currency, "usd")
+
+    balance_transaction = %{
+      amount: -amount,
+      available_on: PaperTiger.now(),
+      created: PaperTiger.now(),
+      currency: currency,
+      description: get_field(transfer, :description, "Transfer"),
+      fee: 0,
+      fee_details: [],
+      id: PaperTiger.Resource.generate_id("txn"),
+      net: -amount,
+      object: "balance_transaction",
+      reporting_category: "transfer",
+      source: get_field(transfer, :id, nil),
+      status: "available",
+      type: "transfer"
+    }
+
+    PaperTiger.Connect.without_account(fn ->
+      insert_and_return_id(balance_transaction)
+    end)
+  end
+
+  @doc """
+  Creates a connected-account balance transaction for funds received by transfer.
+  """
+  @spec create_for_destination_transfer(map()) :: {:ok, String.t()} | {:error, term()}
+  def create_for_destination_transfer(transfer) do
+    amount = get_field(transfer, :amount, 0)
+    currency = get_field(transfer, :currency, "usd")
+
+    balance_transaction = %{
+      amount: amount,
+      available_on: PaperTiger.now(),
+      created: PaperTiger.now(),
+      currency: currency,
+      description: get_field(transfer, :description, "Transfer"),
+      fee: 0,
+      fee_details: [],
+      id: PaperTiger.Resource.generate_id("txn"),
+      net: amount,
+      object: "balance_transaction",
+      reporting_category: "transfer",
+      source: get_field(transfer, :id, nil),
+      status: "available",
+      type: "transfer"
+    }
+
+    insert_and_return_id(balance_transaction)
+  end
+
+  @doc """
+  Creates the platform-side balance transaction for a transfer reversal.
+  """
+  @spec create_for_transfer_reversal(map()) :: {:ok, String.t()} | {:error, term()}
+  def create_for_transfer_reversal(reversal) do
+    amount = get_field(reversal, :amount, 0)
+    currency = get_field(reversal, :currency, "usd")
+
+    balance_transaction = %{
+      amount: amount,
+      available_on: PaperTiger.now(),
+      created: PaperTiger.now(),
+      currency: currency,
+      description: "Transfer reversal",
+      fee: 0,
+      fee_details: [],
+      id: PaperTiger.Resource.generate_id("txn"),
+      net: amount,
+      object: "balance_transaction",
+      reporting_category: "transfer_reversal",
+      source: get_field(reversal, :id, nil),
+      status: "available",
+      type: "transfer_reversal"
+    }
+
+    PaperTiger.Connect.without_account(fn ->
+      insert_and_return_id(balance_transaction)
+    end)
+  end
+
+  @doc """
+  Creates the connected-account balance transaction for a transfer reversal.
+  """
+  @spec create_for_destination_transfer_reversal(map()) :: {:ok, String.t()} | {:error, term()}
+  def create_for_destination_transfer_reversal(reversal) do
+    amount = get_field(reversal, :amount, 0)
+    currency = get_field(reversal, :currency, "usd")
+
+    balance_transaction = %{
+      amount: -amount,
+      available_on: PaperTiger.now(),
+      created: PaperTiger.now(),
+      currency: currency,
+      description: "Transfer reversal",
+      fee: 0,
+      fee_details: [],
+      id: PaperTiger.Resource.generate_id("txn"),
+      net: -amount,
+      object: "balance_transaction",
+      reporting_category: "transfer_reversal",
+      source: get_field(reversal, :id, nil),
+      status: "available",
+      type: "transfer_reversal"
+    }
+
+    insert_and_return_id(balance_transaction)
+  end
+
+  @doc """
+  Creates a platform-side balance transaction for an application fee.
+  """
+  @spec create_for_application_fee(map()) :: {:ok, String.t()} | {:error, term()}
+  def create_for_application_fee(application_fee) do
+    amount = get_field(application_fee, :amount, 0)
+    currency = get_field(application_fee, :currency, "usd")
+
+    balance_transaction = %{
+      amount: amount,
+      available_on: PaperTiger.now(),
+      created: PaperTiger.now(),
+      currency: currency,
+      description: "Application fee",
+      fee: 0,
+      fee_details: [],
+      id: PaperTiger.Resource.generate_id("txn"),
+      net: amount,
+      object: "balance_transaction",
+      reporting_category: "application_fee",
+      source: get_field(application_fee, :id, nil),
+      status: "available",
+      type: "application_fee"
+    }
+
+    PaperTiger.Connect.without_account(fn ->
+      insert_and_return_id(balance_transaction)
+    end)
+  end
+
+  @doc """
+  Creates a platform-side balance transaction for an application fee refund.
+  """
+  @spec create_for_application_fee_refund(map()) :: {:ok, String.t()} | {:error, term()}
+  def create_for_application_fee_refund(refund) do
+    amount = get_field(refund, :amount, 0)
+    currency = get_field(refund, :currency, "usd")
+
+    balance_transaction = %{
+      amount: -amount,
+      available_on: PaperTiger.now(),
+      created: PaperTiger.now(),
+      currency: currency,
+      description: "Application fee refund",
+      fee: 0,
+      fee_details: [],
+      id: PaperTiger.Resource.generate_id("txn"),
+      net: -amount,
+      object: "balance_transaction",
+      reporting_category: "application_fee_refund",
+      source: get_field(refund, :id, nil),
+      status: "available",
+      type: "application_fee_refund"
+    }
+
+    PaperTiger.Connect.without_account(fn ->
+      insert_and_return_id(balance_transaction)
+    end)
+  end
+
+  @doc """
   Calculates Stripe's processing fee for a given amount.
 
   Formula: 2.9% + $0.30 (in cents)

--- a/lib/paper_tiger/charge_helper.ex
+++ b/lib/paper_tiger/charge_helper.ex
@@ -10,7 +10,7 @@ defmodule PaperTiger.ChargeHelper do
   import PaperTiger.Resource, only: [generate_id: 1]
 
   alias PaperTiger.BalanceTransactionHelper
-  alias PaperTiger.Store.{Charges, PaymentIntents}
+  alias PaperTiger.Store.{ApplicationFees, Charges, PaymentIntents}
 
   @doc """
   Creates a Charge (and its BalanceTransaction) for a succeeded PaymentIntent.
@@ -31,12 +31,16 @@ defmodule PaperTiger.ChargeHelper do
 
     {:ok, charge} =
       if captured? do
-        create_balance_transaction(charge, Map.get(charge, :amount, 0))
+        charge
+        |> create_balance_transaction(Map.get(charge, :amount, 0))
+        |> maybe_create_application_fee()
       else
         {:ok, charge}
       end
 
     # Update the PI with latest_charge
+    # The stored Charge keeps the authorization amount; the balance transaction
+    # records the amount actually captured in this operation.
     updated_pi = Map.put(payment_intent, :latest_charge, charge.id)
     PaymentIntents.update(updated_pi)
 
@@ -59,7 +63,9 @@ defmodule PaperTiger.ChargeHelper do
         |> Map.put(:captured, final_capture?)
         |> Map.put(:status, "succeeded")
 
-      create_balance_transaction(charge, amount_to_capture)
+      charge
+      |> create_balance_transaction(amount_to_capture)
+      |> maybe_create_application_fee()
     end
   end
 
@@ -72,12 +78,41 @@ defmodule PaperTiger.ChargeHelper do
   end
 
   defp create_balance_transaction(charge, amount) do
-    # The stored Charge keeps the authorization amount; the balance transaction
-    # records the amount actually captured in this operation.
     {:ok, txn_id} = charge |> Map.put(:amount, amount) |> BalanceTransactionHelper.create_for_charge()
 
     charge
     |> Map.put(:balance_transaction, txn_id)
+    |> Charges.update()
+  end
+
+  defp maybe_create_application_fee({:ok, charge}) do
+    amount = Map.get(charge, :application_fee_amount)
+
+    cond do
+      not is_integer(amount) or amount <= 0 ->
+        {:ok, charge}
+
+      is_binary(Map.get(charge, :application_fee)) ->
+        {:ok, charge}
+
+      true ->
+        create_application_fee(charge, amount)
+    end
+  end
+
+  defp create_application_fee(charge, amount) do
+    fee = build_application_fee(charge, amount)
+
+    {:ok, balance_transaction_id} = BalanceTransactionHelper.create_for_application_fee(fee)
+    fee = Map.put(fee, :balance_transaction, balance_transaction_id)
+
+    {:ok, _fee} =
+      PaperTiger.Connect.without_account(fn ->
+        ApplicationFees.insert(fee)
+      end)
+
+    charge
+    |> Map.put(:application_fee, fee.id)
     |> Charges.update()
   end
 
@@ -88,6 +123,8 @@ defmodule PaperTiger.ChargeHelper do
       amount: amount,
       amount_captured: if(captured?, do: amount, else: 0),
       amount_refunded: 0,
+      application_fee: nil,
+      application_fee_amount: Map.get(pi, :application_fee_amount),
       balance_transaction: nil,
       billing_details: nil,
       captured: captured?,
@@ -103,12 +140,8 @@ defmodule PaperTiger.ChargeHelper do
       livemode: false,
       metadata: Map.get(pi, :metadata, %{}),
       object: "charge",
-      outcome: %{
-        network_status: "approved_by_network",
-        reason: nil,
-        risk_level: "normal",
-        type: "authorized"
-      },
+      on_behalf_of: Map.get(pi, :on_behalf_of),
+      outcome: %{network_status: "approved_by_network", reason: nil, risk_level: "normal", type: "authorized"},
       paid: true,
       payment_intent: Map.get(pi, :id),
       payment_method: Map.get(pi, :payment_method),
@@ -117,7 +150,45 @@ defmodule PaperTiger.ChargeHelper do
       receipt_url: nil,
       refunded: false,
       statement_descriptor: Map.get(pi, :statement_descriptor),
-      status: "succeeded"
+      status: "succeeded",
+      transfer_data: Map.get(pi, :transfer_data)
     }
+  end
+
+  defp build_application_fee(charge, amount) do
+    %{
+      account: connected_account_for_fee(charge),
+      amount: amount,
+      amount_refunded: 0,
+      application: nil,
+      balance_transaction: nil,
+      charge: charge.id,
+      created: PaperTiger.now(),
+      currency: Map.get(charge, :currency),
+      id: generate_id("fee"),
+      livemode: false,
+      metadata: %{},
+      object: "application_fee",
+      originating_transaction: nil,
+      refunded: false,
+      refunds: %{
+        data: [],
+        has_more: false,
+        object: "list",
+        total_count: 0,
+        url: "/v1/application_fees/pending/refunds"
+      }
+    }
+    |> then(fn fee ->
+      put_in(fee, [:refunds, :url], "/v1/application_fees/#{fee.id}/refunds")
+    end)
+  end
+
+  defp connected_account_for_fee(charge) do
+    case Map.get(charge, :transfer_data) do
+      %{destination: destination} when is_binary(destination) -> destination
+      %{"destination" => destination} when is_binary(destination) -> destination
+      _ -> Map.get(charge, :on_behalf_of) || PaperTiger.Connect.current_account()
+    end
   end
 end

--- a/lib/paper_tiger/connect.ex
+++ b/lib/paper_tiger/connect.ex
@@ -1,0 +1,96 @@
+defmodule PaperTiger.Connect do
+  @moduledoc """
+  Request-scoped helpers for Stripe Connect behavior.
+
+  Stripe's `Stripe-Account` header is per request. PaperTiger models that by
+  storing the connected account ID in the process dictionary for the duration
+  of a request, then using it as part of the ETS storage namespace for normal
+  resources. Platform-owned resources can temporarily opt back into the base
+  namespace with `without_account/1`.
+  """
+
+  @account_key :paper_tiger_connected_account
+
+  @type account_id :: String.t()
+  @type storage_namespace :: pid() | :global | {pid() | :global, account_id()}
+
+  @doc """
+  Returns the connected account ID for the current request, if any.
+  """
+  @spec current_account() :: account_id() | nil
+  def current_account do
+    Process.get(@account_key)
+  end
+
+  @doc """
+  Returns the storage namespace for the current sandbox + connected account.
+  """
+  @spec storage_namespace() :: storage_namespace()
+  def storage_namespace do
+    storage_namespace(PaperTiger.Test.current_namespace())
+  end
+
+  @doc """
+  Returns the storage namespace for a base sandbox namespace.
+  """
+  @spec storage_namespace(pid() | :global) :: storage_namespace()
+  def storage_namespace(base_namespace) do
+    case current_account() do
+      nil -> base_namespace
+      account_id -> {base_namespace, account_id}
+    end
+  end
+
+  @doc """
+  Sets the connected account for the current process.
+  """
+  @spec put_account(account_id()) :: :ok
+  def put_account(account_id) when is_binary(account_id) do
+    Process.put(@account_key, account_id)
+    :ok
+  end
+
+  @doc """
+  Clears any connected account from the current process.
+  """
+  @spec clear_account() :: :ok
+  def clear_account do
+    Process.delete(@account_key)
+    :ok
+  end
+
+  @doc """
+  Runs `fun` with the given connected account ID in the process dictionary.
+  """
+  @spec with_account(account_id() | nil, (-> result)) :: result when result: term()
+  def with_account(account_id, fun) when is_function(fun, 0) do
+    previous = Process.get(@account_key, :unset)
+
+    if is_nil(account_id) do
+      Process.delete(@account_key)
+    else
+      Process.put(@account_key, account_id)
+    end
+
+    try do
+      fun.()
+    after
+      restore(previous)
+    end
+  end
+
+  @doc """
+  Runs `fun` in platform scope even if the request is account-scoped.
+  """
+  @spec without_account((-> result)) :: result when result: term()
+  def without_account(fun) when is_function(fun, 0), do: with_account(nil, fun)
+
+  @doc """
+  Returns true when an ID looks like a Stripe connected account ID.
+  """
+  @spec account_id?(term()) :: boolean()
+  def account_id?(id), do: is_binary(id) and String.starts_with?(id, "acct_")
+
+  defp restore(:unset), do: Process.delete(@account_key)
+  defp restore(account_id), do: Process.put(@account_key, account_id)
+end

--- a/lib/paper_tiger/hydrator.ex
+++ b/lib/paper_tiger/hydrator.ex
@@ -28,6 +28,8 @@ defmodule PaperTiger.Hydrator do
       hydrated = PaperTiger.Hydrator.hydrate(subscription, expand_params)
   """
 
+  alias PaperTiger.Store.Accounts
+  alias PaperTiger.Store.ApplicationFeeRefunds
   alias PaperTiger.Store.ApplicationFees
   alias PaperTiger.Store.BalanceTransactions
   alias PaperTiger.Store.BankAccounts
@@ -66,12 +68,16 @@ defmodule PaperTiger.Hydrator do
   alias PaperTiger.Store.TaxRates
   alias PaperTiger.Store.Tokens
   alias PaperTiger.Store.Topups
+  alias PaperTiger.Store.TransferReversals
+  alias PaperTiger.Store.Transfers
   alias PaperTiger.Store.Webhooks
 
   require Logger
 
   @stores [
+    Accounts,
     ApplicationFees,
+    ApplicationFeeRefunds,
     BalanceTransactions,
     BankAccounts,
     BillingPortalConfigurations,
@@ -109,6 +115,8 @@ defmodule PaperTiger.Hydrator do
     TaxRates,
     Tokens,
     Topups,
+    Transfers,
+    TransferReversals,
     Webhooks
   ]
 

--- a/lib/paper_tiger/idempotency.ex
+++ b/lib/paper_tiger/idempotency.ex
@@ -60,7 +60,7 @@ defmodule PaperTiger.Idempotency do
   """
   @spec check(String.t()) :: {:cached, map()} | :new_request | :in_progress
   def check(idempotency_key) when is_binary(idempotency_key) do
-    namespace = PaperTiger.Test.current_namespace()
+    namespace = PaperTiger.Connect.storage_namespace()
     key = {namespace, idempotency_key}
     now = PaperTiger.Clock.now()
 
@@ -101,7 +101,7 @@ defmodule PaperTiger.Idempotency do
   """
   @spec store(String.t(), map()) :: :ok
   def store(idempotency_key, response) when is_binary(idempotency_key) do
-    namespace = PaperTiger.Test.current_namespace()
+    namespace = PaperTiger.Connect.storage_namespace()
     key = {namespace, idempotency_key}
     expires_at = PaperTiger.Clock.now() + @ttl_seconds
     :ets.insert(@table, {key, response, expires_at})
@@ -148,6 +148,7 @@ defmodule PaperTiger.Idempotency do
 
   def handle_call({:clear_namespace, namespace}, _from, state) do
     :ets.match_delete(@table, {{namespace, :_}, :_, :_})
+    :ets.match_delete(@table, {{{namespace, :_}, :_}, :_, :_})
     Logger.debug("Idempotency cache cleared for namespace")
     {:reply, :ok, state}
   end

--- a/lib/paper_tiger/plugs/connect_context.ex
+++ b/lib/paper_tiger/plugs/connect_context.ex
@@ -1,0 +1,56 @@
+defmodule PaperTiger.Plugs.ConnectContext do
+  @moduledoc """
+  Applies Stripe Connect request context from the `Stripe-Account` header.
+
+  The header must contain an existing connected account ID. Once accepted,
+  normal resource stores scope reads and writes to that connected account for
+  the rest of the request.
+  """
+
+  @behaviour Plug
+
+  import Plug.Conn
+
+  alias PaperTiger.Connect
+  alias PaperTiger.Resource
+  alias PaperTiger.Store.Accounts
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts) do
+    case get_req_header(conn, "stripe-account") do
+      [] ->
+        Connect.clear_account()
+        conn
+
+      [account_id | _] ->
+        connect_as(conn, account_id)
+    end
+  end
+
+  defp connect_as(conn, account_id) do
+    cond do
+      not Connect.account_id?(account_id) ->
+        conn
+        |> Resource.error_response(PaperTiger.Error.invalid_request("Invalid Stripe-Account header", "Stripe-Account"))
+        |> halt()
+
+      account_exists?(account_id) ->
+        Connect.put_account(account_id)
+        assign(conn, :stripe_account, account_id)
+
+      true ->
+        conn
+        |> Resource.error_response(PaperTiger.Error.not_found("account", account_id))
+        |> halt()
+    end
+  end
+
+  defp account_exists?(account_id) do
+    Connect.without_account(fn ->
+      match?({:ok, _account}, Accounts.get(account_id))
+    end)
+  end
+end

--- a/lib/paper_tiger/resources/account.ex
+++ b/lib/paper_tiger/resources/account.ex
@@ -1,0 +1,243 @@
+defmodule PaperTiger.Resources.Account do
+  @moduledoc """
+  Handles legacy Connect Account endpoints.
+
+  PaperTiger intentionally models `/v1/accounts` first rather than Accounts v2
+  because current Stripe client libraries still commonly use the v1 resource.
+  Accounts are platform-owned: they are stored in the sandbox namespace, not in
+  the connected account request scope.
+  """
+
+  import PaperTiger.Resource
+
+  alias PaperTiger.Connect
+  alias PaperTiger.Store.Accounts
+
+  @capability_fields ~w(
+    card_payments
+    transfers
+    treasury
+    card_issuing
+    us_bank_account_ach_payments
+  )a
+
+  @doc """
+  Creates a connected account.
+  """
+  @spec create(Plug.Conn.t()) :: Plug.Conn.t()
+  def create(conn) do
+    Connect.without_account(fn ->
+      account = build_account(conn.params)
+
+      {:ok, account} = Accounts.insert(account)
+      maybe_store_idempotency(conn, account)
+
+      account
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    end)
+  end
+
+  @doc """
+  Retrieves a connected account by ID.
+  """
+  @spec retrieve(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def retrieve(conn, id) do
+    Connect.without_account(fn ->
+      case Accounts.get(id) do
+        {:ok, account} ->
+          account
+          |> maybe_expand(conn.params)
+          |> then(&json_response(conn, 200, &1))
+
+        {:error, :not_found} ->
+          error_response(conn, PaperTiger.Error.not_found("account", id))
+      end
+    end)
+  end
+
+  @doc """
+  Updates mutable account fields and requested capabilities.
+  """
+  @spec update(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def update(conn, id) do
+    Connect.without_account(fn ->
+      with {:ok, existing} <- Accounts.get(id),
+           updated = update_account(existing, conn.params),
+           {:ok, updated} <- Accounts.update(updated) do
+        updated
+        |> maybe_expand(conn.params)
+        |> then(&json_response(conn, 200, &1))
+      else
+        {:error, :not_found} ->
+          error_response(conn, PaperTiger.Error.not_found("account", id))
+      end
+    end)
+  end
+
+  @doc """
+  Deletes a connected account from the platform account.
+  """
+  @spec delete(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def delete(conn, id) do
+    Connect.without_account(fn ->
+      case Accounts.get(id) do
+        {:ok, _account} ->
+          :ok = Accounts.delete(id)
+          json_response(conn, 200, %{deleted: true, id: id, object: "account"})
+
+        {:error, :not_found} ->
+          error_response(conn, PaperTiger.Error.not_found("account", id))
+      end
+    end)
+  end
+
+  @doc """
+  Lists accounts connected to the platform.
+  """
+  @spec list(Plug.Conn.t()) :: Plug.Conn.t()
+  def list(conn) do
+    Connect.without_account(fn ->
+      pagination_opts = parse_pagination_params(conn.params)
+      json_response(conn, 200, Accounts.list(pagination_opts))
+    end)
+  end
+
+  defp build_account(params) do
+    capabilities = build_capabilities(Map.get(params, :capabilities, %{}))
+    transfers_active? = Map.get(capabilities, :transfers) == "active"
+    card_payments_active? = Map.get(capabilities, :card_payments) == "active"
+
+    %{
+      business_profile: Map.get(params, :business_profile, %{}),
+      business_type: Map.get(params, :business_type),
+      capabilities: capabilities,
+      charges_enabled: card_payments_active?,
+      controller: build_controller(params),
+      country: Map.get(params, :country, "US"),
+      created: PaperTiger.now(),
+      default_currency: Map.get(params, :default_currency, "usd"),
+      details_submitted: transfers_active? or card_payments_active?,
+      email: Map.get(params, :email),
+      external_accounts: empty_nested_list("/v1/accounts/pending/external_accounts"),
+      future_requirements: empty_requirements(),
+      id: generate_id("acct", Map.get(params, :id)),
+      individual: Map.get(params, :individual),
+      metadata: Map.get(params, :metadata, %{}),
+      object: "account",
+      payouts_enabled: transfers_active?,
+      requirements: empty_requirements(),
+      settings: build_settings(params),
+      tos_acceptance: Map.get(params, :tos_acceptance, %{}),
+      type: Map.get(params, :type, "custom")
+    }
+    |> then(fn account ->
+      Map.put(account, :external_accounts, empty_nested_list("/v1/accounts/#{account.id}/external_accounts"))
+    end)
+  end
+
+  defp update_account(existing, params) do
+    immutable = [:id, :object, :created]
+
+    existing
+    |> merge_updates(params, immutable)
+    |> maybe_update_capabilities(params)
+    |> refresh_capability_flags()
+  end
+
+  defp maybe_update_capabilities(account, %{capabilities: capability_params}) when is_map(capability_params) do
+    Map.put(account, :capabilities, Map.merge(account.capabilities, build_capabilities(capability_params)))
+  end
+
+  defp maybe_update_capabilities(account, _params), do: account
+
+  defp refresh_capability_flags(account) do
+    capabilities = Map.get(account, :capabilities, %{})
+    transfers_active? = Map.get(capabilities, :transfers) == "active"
+    card_payments_active? = Map.get(capabilities, :card_payments) == "active"
+
+    account
+    |> Map.put(:charges_enabled, card_payments_active?)
+    |> Map.put(:payouts_enabled, transfers_active?)
+    |> Map.put(:details_submitted, transfers_active? or card_payments_active?)
+  end
+
+  defp build_capabilities(params) when is_map(params) do
+    requested =
+      params
+      |> Enum.map(fn {key, value} -> {normalize_capability_key(key), requested?(value)} end)
+      |> Enum.filter(fn {key, _requested?} -> key in @capability_fields end)
+      |> Map.new(fn {key, requested?} -> {key, if(requested?, do: "active", else: "inactive")} end)
+
+    @capability_fields
+    |> Map.new(&{&1, "inactive"})
+    |> Map.merge(requested)
+  end
+
+  defp build_capabilities(_params), do: build_capabilities(%{})
+
+  defp normalize_capability_key(key) when is_atom(key), do: key
+
+  defp normalize_capability_key(key) when is_binary(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> :unknown
+  end
+
+  defp requested?(%{requested: requested}), do: to_boolean(requested)
+  defp requested?(%{"requested" => requested}), do: to_boolean(requested)
+  defp requested?(requested), do: to_boolean(requested)
+
+  defp build_controller(params) do
+    controller = Map.get(params, :controller, %{})
+    dashboard = Map.get(controller, :dashboard, %{})
+    dashboard_type = Map.get(dashboard, :type) || Map.get(controller, :stripe_dashboard, %{})[:type]
+
+    dashboard_type =
+      cond do
+        is_binary(dashboard_type) -> dashboard_type
+        Map.get(params, :type, "custom") == "standard" -> "full"
+        true -> "none"
+      end
+
+    %{
+      dashboard: %{type: dashboard_type},
+      fees: Map.get(controller, :fees, %{payer: "application"}),
+      losses: Map.get(controller, :losses, %{payments: "application"}),
+      requirement_collection: Map.get(controller, :requirement_collection, "application"),
+      stripe_dashboard: %{type: dashboard_type}
+    }
+  end
+
+  defp build_settings(params) do
+    Map.merge(
+      %{
+        card_payments: %{decline_on: %{avs_failure: false, cvc_failure: false}},
+        payouts: %{debit_negative_balances: true, schedule: %{interval: "daily"}, statement_descriptor: nil}
+      },
+      Map.get(params, :settings, %{})
+    )
+  end
+
+  defp empty_requirements do
+    %{
+      alternatives: [],
+      current_deadline: nil,
+      currently_due: [],
+      disabled_reason: nil,
+      errors: [],
+      eventually_due: [],
+      past_due: [],
+      pending_verification: []
+    }
+  end
+
+  defp empty_nested_list(url) do
+    %{data: [], has_more: false, object: "list", total_count: 0, url: url}
+  end
+
+  defp maybe_expand(account, params) do
+    expand_params = parse_expand_params(params)
+    PaperTiger.Hydrator.hydrate(account, expand_params)
+  end
+end

--- a/lib/paper_tiger/resources/account_link.ex
+++ b/lib/paper_tiger/resources/account_link.ex
@@ -1,0 +1,58 @@
+defmodule PaperTiger.Resources.AccountLink do
+  @moduledoc """
+  Handles Connect Account Link creation.
+
+  Account Links are ephemeral in Stripe and are therefore not stored.
+  """
+
+  import PaperTiger.Resource
+
+  alias PaperTiger.Connect
+  alias PaperTiger.Store.Accounts
+
+  @valid_types ~w(account_onboarding account_update)
+
+  @doc """
+  Creates an account link for onboarding or account updates.
+  """
+  @spec create(Plug.Conn.t()) :: Plug.Conn.t()
+  def create(conn) do
+    Connect.without_account(fn ->
+      with {:ok, _params} <- validate_params(conn.params, [:account, :refresh_url, :return_url, :type]),
+           :ok <- validate_type(Map.get(conn.params, :type)),
+           {:ok, _account} <- Accounts.get(Map.get(conn.params, :account)) do
+        link = build_account_link(conn.params)
+        maybe_store_idempotency(conn, link)
+        json_response(conn, 200, link)
+      else
+        {:error, :invalid_params, field} ->
+          error_response(conn, PaperTiger.Error.invalid_request("Missing required parameter", field))
+
+        {:error, :invalid_type, type} ->
+          error_response(conn, PaperTiger.Error.invalid_request("Invalid account link type: #{type}", "type"))
+
+        {:error, :not_found} ->
+          error_response(conn, PaperTiger.Error.not_found("account", Map.get(conn.params, :account)))
+      end
+    end)
+  end
+
+  defp validate_type(type) when type in @valid_types, do: :ok
+  defp validate_type(type), do: {:error, :invalid_type, type}
+
+  defp build_account_link(params) do
+    created = PaperTiger.now()
+
+    %{
+      account: Map.fetch!(params, :account),
+      collect: Map.get(params, :collect),
+      created: created,
+      expires_at: created + 300,
+      object: "account_link",
+      refresh_url: Map.fetch!(params, :refresh_url),
+      return_url: Map.fetch!(params, :return_url),
+      type: Map.fetch!(params, :type),
+      url: "https://connect.stripe.com/setup/s/#{generate_id("link")}"
+    }
+  end
+end

--- a/lib/paper_tiger/resources/application_fee.ex
+++ b/lib/paper_tiger/resources/application_fee.ex
@@ -34,15 +34,17 @@ defmodule PaperTiger.Resources.ApplicationFee do
   """
   @spec retrieve(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
   def retrieve(conn, id) do
-    case ApplicationFees.get(id) do
-      {:ok, fee} ->
-        fee
-        |> maybe_expand(conn.params)
-        |> then(&json_response(conn, 200, &1))
+    PaperTiger.Connect.without_account(fn ->
+      case ApplicationFees.get(id) do
+        {:ok, fee} ->
+          fee
+          |> maybe_expand(conn.params)
+          |> then(&json_response(conn, 200, &1))
 
-      {:error, :not_found} ->
-        error_response(conn, PaperTiger.Error.not_found("application_fee", id))
-    end
+        {:error, :not_found} ->
+          error_response(conn, PaperTiger.Error.not_found("application_fee", id))
+      end
+    end)
   end
 
   @doc """
@@ -57,11 +59,22 @@ defmodule PaperTiger.Resources.ApplicationFee do
   """
   @spec list(Plug.Conn.t()) :: Plug.Conn.t()
   def list(conn) do
-    pagination_opts = parse_pagination_params(conn.params)
+    PaperTiger.Connect.without_account(fn ->
+      pagination_opts = parse_pagination_params(conn.params)
 
-    result = ApplicationFees.list(pagination_opts)
+      result =
+        case Map.get(conn.params, :charge) do
+          charge when is_binary(charge) and charge != "" ->
+            charge
+            |> ApplicationFees.find_by_charge()
+            |> PaperTiger.List.paginate(Map.put(pagination_opts, :url, "/v1/application_fees"))
 
-    json_response(conn, 200, result)
+          _ ->
+            ApplicationFees.list(pagination_opts)
+        end
+
+      json_response(conn, 200, result)
+    end)
   end
 
   ## Private Functions

--- a/lib/paper_tiger/resources/application_fee_refund.ex
+++ b/lib/paper_tiger/resources/application_fee_refund.ex
@@ -1,0 +1,179 @@
+defmodule PaperTiger.Resources.ApplicationFeeRefund do
+  @moduledoc """
+  Handles Application Fee Refund endpoints nested under Application Fees.
+  """
+
+  import PaperTiger.Resource
+
+  alias PaperTiger.BalanceTransactionHelper
+  alias PaperTiger.Connect
+  alias PaperTiger.Store.ApplicationFeeRefunds
+  alias PaperTiger.Store.ApplicationFees
+
+  @doc """
+  Creates an application fee refund.
+  """
+  @spec create(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def create(conn, fee_id) do
+    case create_for_fee(fee_id, conn.params) do
+      {:ok, refund} ->
+        maybe_store_idempotency(conn, refund)
+
+        refund
+        |> maybe_expand(conn.params)
+        |> then(&json_response(conn, 200, &1))
+
+      {:error, :fee_not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("application_fee", fee_id))
+
+      {:error, :invalid_amount, message} ->
+        error_response(conn, PaperTiger.Error.invalid_request(message, "amount"))
+    end
+  end
+
+  @doc """
+  Creates an application fee refund from internal code.
+  """
+  @spec create_for_fee(String.t(), map()) ::
+          {:ok, map()} | {:error, :fee_not_found} | {:error, :invalid_amount, String.t()}
+  def create_for_fee(fee_id, params) do
+    Connect.without_account(fn ->
+      with {:ok, fee} <- ApplicationFees.get(fee_id),
+           {:ok, amount} <- parse_refund_amount(params, fee),
+           refund = build_refund(params, fee, amount),
+           {:ok, refund} <- insert_refund_with_balance_transaction(refund),
+           {:ok, _fee} <- update_fee_for_refund(fee, refund) do
+        {:ok, refund}
+      else
+        {:error, :not_found} -> {:error, :fee_not_found}
+        {:error, :invalid_amount, message} -> {:error, :invalid_amount, message}
+      end
+    end)
+  end
+
+  @doc """
+  Retrieves an application fee refund.
+  """
+  @spec retrieve(Plug.Conn.t(), String.t(), String.t()) :: Plug.Conn.t()
+  def retrieve(conn, fee_id, id) do
+    Connect.without_account(fn ->
+      with {:ok, _fee} <- ApplicationFees.get(fee_id),
+           {:ok, refund} <- ApplicationFeeRefunds.get(id),
+           true <- refund.fee == fee_id do
+        refund
+        |> maybe_expand(conn.params)
+        |> then(&json_response(conn, 200, &1))
+      else
+        false ->
+          error_response(conn, PaperTiger.Error.not_found("fee_refund", id))
+
+        {:error, :not_found} ->
+          error_response(conn, PaperTiger.Error.not_found("fee_refund", id))
+      end
+    end)
+  end
+
+  @doc """
+  Updates application fee refund metadata.
+  """
+  @spec update(Plug.Conn.t(), String.t(), String.t()) :: Plug.Conn.t()
+  def update(conn, fee_id, id) do
+    Connect.without_account(fn ->
+      with {:ok, _fee} <- ApplicationFees.get(fee_id),
+           {:ok, refund} <- ApplicationFeeRefunds.get(id),
+           true <- refund.fee == fee_id,
+           updated = merge_updates(refund, conn.params, [:id, :object, :created, :amount, :currency, :fee]),
+           {:ok, updated} <- ApplicationFeeRefunds.update(updated) do
+        updated
+        |> maybe_expand(conn.params)
+        |> then(&json_response(conn, 200, &1))
+      else
+        false ->
+          error_response(conn, PaperTiger.Error.not_found("fee_refund", id))
+
+        {:error, :not_found} ->
+          error_response(conn, PaperTiger.Error.not_found("fee_refund", id))
+      end
+    end)
+  end
+
+  @doc """
+  Lists refunds for an application fee.
+  """
+  @spec list(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def list(conn, fee_id) do
+    Connect.without_account(fn ->
+      case ApplicationFees.get(fee_id) do
+        {:ok, _fee} ->
+          pagination_opts = parse_pagination_params(conn.params)
+
+          fee_id
+          |> ApplicationFeeRefunds.find_by_fee()
+          |> PaperTiger.List.paginate(Map.put(pagination_opts, :url, "/v1/application_fees/#{fee_id}/refunds"))
+          |> then(&json_response(conn, 200, &1))
+
+        {:error, :not_found} ->
+          error_response(conn, PaperTiger.Error.not_found("application_fee", fee_id))
+      end
+    end)
+  end
+
+  defp parse_refund_amount(params, fee) do
+    remaining = fee.amount - fee.amount_refunded
+    amount = get_integer(params, :amount, remaining)
+
+    cond do
+      amount <= 0 ->
+        {:error, :invalid_amount, "Amount must be greater than zero"}
+
+      amount > remaining ->
+        {:error, :invalid_amount, "Amount exceeds the unrefunded application fee amount"}
+
+      true ->
+        {:ok, amount}
+    end
+  end
+
+  defp build_refund(params, fee, amount) do
+    %{
+      amount: amount,
+      balance_transaction: nil,
+      created: PaperTiger.now(),
+      currency: fee.currency,
+      fee: fee.id,
+      id: generate_id("fr"),
+      metadata: Map.get(params, :metadata, %{}),
+      object: "fee_refund"
+    }
+  end
+
+  defp insert_refund_with_balance_transaction(refund) do
+    {:ok, balance_transaction_id} = BalanceTransactionHelper.create_for_application_fee_refund(refund)
+    refund = Map.put(refund, :balance_transaction, balance_transaction_id)
+    ApplicationFeeRefunds.insert(refund)
+  end
+
+  defp update_fee_for_refund(fee, refund) do
+    amount_refunded = fee.amount_refunded + refund.amount
+    refunded? = amount_refunded == fee.amount
+
+    fee
+    |> Map.put(:amount_refunded, amount_refunded)
+    |> Map.put(:refunded, refunded?)
+    |> Map.put(:refunds, add_refund_to_nested_list(fee.refunds, refund))
+    |> ApplicationFees.update()
+  end
+
+  defp add_refund_to_nested_list(list, refund) do
+    data = [refund | Map.get(list, :data, [])] |> Enum.take(10)
+
+    list
+    |> Map.put(:data, data)
+    |> Map.put(:total_count, Map.get(list, :total_count, 0) + 1)
+  end
+
+  defp maybe_expand(refund, params) do
+    expand_params = parse_expand_params(params)
+    PaperTiger.Hydrator.hydrate(refund, expand_params)
+  end
+end

--- a/lib/paper_tiger/resources/charge.ex
+++ b/lib/paper_tiger/resources/charge.ex
@@ -173,7 +173,7 @@ defmodule PaperTiger.Resources.Charge do
   """
   @spec search(Plug.Conn.t()) :: Plug.Conn.t()
   def search(conn) do
-    Charges.list_namespace(PaperTiger.Test.current_namespace())
+    Charges.list_namespace(PaperTiger.Connect.storage_namespace())
     |> Search.run(conn.params,
       fields: @search_fields,
       url: "/v1/charges/search",

--- a/lib/paper_tiger/resources/customer.ex
+++ b/lib/paper_tiger/resources/customer.ex
@@ -172,7 +172,7 @@ defmodule PaperTiger.Resources.Customer do
   """
   @spec search(Plug.Conn.t()) :: Plug.Conn.t()
   def search(conn) do
-    Customers.list_namespace(PaperTiger.Test.current_namespace())
+    Customers.list_namespace(PaperTiger.Connect.storage_namespace())
     |> Search.run(conn.params,
       fields: @search_fields,
       url: "/v1/customers/search",

--- a/lib/paper_tiger/resources/invoice.ex
+++ b/lib/paper_tiger/resources/invoice.ex
@@ -217,7 +217,7 @@ defmodule PaperTiger.Resources.Invoice do
   """
   @spec search(Plug.Conn.t()) :: Plug.Conn.t()
   def search(conn) do
-    Invoices.list_namespace(PaperTiger.Test.current_namespace())
+    Invoices.list_namespace(PaperTiger.Connect.storage_namespace())
     |> Search.run(conn.params,
       fields: @search_fields,
       url: "/v1/invoices/search",

--- a/lib/paper_tiger/resources/payment_intent.ex
+++ b/lib/paper_tiger/resources/payment_intent.ex
@@ -160,7 +160,7 @@ defmodule PaperTiger.Resources.PaymentIntent do
   """
   @spec search(Plug.Conn.t()) :: Plug.Conn.t()
   def search(conn) do
-    PaymentIntents.list_namespace(PaperTiger.Test.current_namespace())
+    PaymentIntents.list_namespace(PaperTiger.Connect.storage_namespace())
     |> Search.run(conn.params,
       fields: @search_fields,
       url: "/v1/payment_intents/search",
@@ -445,7 +445,7 @@ defmodule PaperTiger.Resources.PaymentIntent do
       amount_details: Map.get(params, :amount_details),
       amount_received: 0,
       application: nil,
-      application_fee_amount: nil,
+      application_fee_amount: get_optional_integer(params, :application_fee_amount),
       canceled_at: nil,
       cancellation_reason: nil,
       capture_method: Map.get(params, :capture_method, "automatic"),
@@ -474,7 +474,8 @@ defmodule PaperTiger.Resources.PaymentIntent do
       shipping: Map.get(params, :shipping),
       source: Map.get(params, :source),
       statement_descriptor: Map.get(params, :statement_descriptor),
-      status: "requires_payment_method"
+      status: "requires_payment_method",
+      transfer_data: Map.get(params, :transfer_data)
     }
   end
 

--- a/lib/paper_tiger/resources/subscription.ex
+++ b/lib/paper_tiger/resources/subscription.ex
@@ -215,7 +215,7 @@ defmodule PaperTiger.Resources.Subscription do
   @spec list(Plug.Conn.t()) :: Plug.Conn.t()
   def list(conn) do
     pagination_opts = parse_pagination_params(conn.params)
-    all_subscriptions = Subscriptions.list_namespace(PaperTiger.Test.current_namespace())
+    all_subscriptions = Subscriptions.list_namespace(PaperTiger.Connect.storage_namespace())
 
     filtered_subscriptions =
       case {Map.get(conn.params, :customer), Map.get(conn.params, :status)} do
@@ -256,7 +256,7 @@ defmodule PaperTiger.Resources.Subscription do
   """
   @spec search(Plug.Conn.t()) :: Plug.Conn.t()
   def search(conn) do
-    Subscriptions.list_namespace(PaperTiger.Test.current_namespace())
+    Subscriptions.list_namespace(PaperTiger.Connect.storage_namespace())
     |> Search.run(conn.params,
       fields: @search_fields,
       url: "/v1/subscriptions/search",

--- a/lib/paper_tiger/resources/transfer.ex
+++ b/lib/paper_tiger/resources/transfer.ex
@@ -1,0 +1,324 @@
+defmodule PaperTiger.Resources.Transfer do
+  @moduledoc """
+  Handles Connect Transfer and Transfer Reversal endpoints.
+  """
+
+  import PaperTiger.Resource
+
+  alias PaperTiger.BalanceTransactionHelper
+  alias PaperTiger.Connect
+  alias PaperTiger.Resources.ApplicationFeeRefund
+  alias PaperTiger.Store.Accounts
+  alias PaperTiger.Store.TransferReversals
+  alias PaperTiger.Store.Transfers
+
+  @doc """
+  Creates a transfer to a connected account.
+  """
+  @spec create(Plug.Conn.t()) :: Plug.Conn.t()
+  def create(conn) do
+    with {:ok, _params} <- validate_params(conn.params, [:amount, :currency, :destination]),
+         amount when amount > 0 <- get_integer(conn.params, :amount),
+         :ok <- validate_destination(Map.get(conn.params, :destination)),
+         transfer = build_transfer(conn.params),
+         {:ok, transfer} <- insert_transfer_with_balance_transactions(transfer) do
+      maybe_store_idempotency(conn, transfer)
+
+      transfer
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :invalid_params, field} ->
+        error_response(conn, PaperTiger.Error.invalid_request("Missing required parameter", field))
+
+      amount when is_integer(amount) ->
+        error_response(conn, PaperTiger.Error.invalid_request("Amount must be greater than zero", "amount"))
+
+      {:error, :invalid_destination, destination} ->
+        error_response(conn, PaperTiger.Error.not_found("account", destination))
+    end
+  end
+
+  @doc """
+  Retrieves a transfer.
+  """
+  @spec retrieve(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def retrieve(conn, id) do
+    case Transfers.get(id) do
+      {:ok, transfer} ->
+        transfer
+        |> maybe_expand(conn.params)
+        |> then(&json_response(conn, 200, &1))
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("transfer", id))
+    end
+  end
+
+  @doc """
+  Updates a transfer. Stripe only allows metadata updates; PaperTiger also keeps
+  description mutable for common test setup ergonomics.
+  """
+  @spec update(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def update(conn, id) do
+    with {:ok, existing} <- Transfers.get(id),
+         updated =
+           merge_updates(existing, conn.params, [
+             :id,
+             :object,
+             :created,
+             :amount,
+             :currency,
+             :destination,
+             :destination_payment,
+             :reversed,
+             :amount_reversed
+           ]),
+         {:ok, updated} <- Transfers.update(updated) do
+      updated
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("transfer", id))
+    end
+  end
+
+  @doc """
+  Lists transfers with optional destination filtering.
+  """
+  @spec list(Plug.Conn.t()) :: Plug.Conn.t()
+  def list(conn) do
+    pagination_opts = parse_pagination_params(conn.params)
+
+    result =
+      case Map.get(conn.params, :destination) do
+        destination when is_binary(destination) and destination != "" ->
+          destination
+          |> Transfers.find_by_destination()
+          |> PaperTiger.List.paginate(Map.put(pagination_opts, :url, "/v1/transfers"))
+
+        _ ->
+          Transfers.list(pagination_opts)
+      end
+
+    json_response(conn, 200, result)
+  end
+
+  @doc """
+  Creates a reversal against a transfer.
+  """
+  @spec create_reversal(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def create_reversal(conn, transfer_id) do
+    with {:ok, transfer} <- Transfers.get(transfer_id),
+         {:ok, amount} <- parse_reversal_amount(conn.params, transfer),
+         reversal = build_reversal(conn.params, transfer, amount),
+         {:ok, reversal, transfer} <- insert_reversal_with_balance_transactions(reversal, transfer) do
+      maybe_refund_application_fee(conn.params, transfer)
+      maybe_store_idempotency(conn, reversal)
+
+      reversal
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("transfer", transfer_id))
+
+      {:error, :invalid_reversal_amount, message} ->
+        error_response(conn, PaperTiger.Error.invalid_request(message, "amount"))
+    end
+  end
+
+  @doc """
+  Retrieves a transfer reversal.
+  """
+  @spec retrieve_reversal(Plug.Conn.t(), String.t(), String.t()) :: Plug.Conn.t()
+  def retrieve_reversal(conn, transfer_id, id) do
+    with {:ok, _transfer} <- Transfers.get(transfer_id),
+         {:ok, reversal} <- TransferReversals.get(id),
+         true <- reversal.transfer == transfer_id do
+      reversal
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      false ->
+        error_response(conn, PaperTiger.Error.not_found("transfer_reversal", id))
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("transfer_reversal", id))
+    end
+  end
+
+  @doc """
+  Updates transfer reversal metadata.
+  """
+  @spec update_reversal(Plug.Conn.t(), String.t(), String.t()) :: Plug.Conn.t()
+  def update_reversal(conn, transfer_id, id) do
+    with {:ok, _transfer} <- Transfers.get(transfer_id),
+         {:ok, reversal} <- TransferReversals.get(id),
+         true <- reversal.transfer == transfer_id,
+         updated = merge_updates(reversal, conn.params, [:id, :object, :created, :amount, :currency, :transfer]),
+         {:ok, updated} <- TransferReversals.update(updated) do
+      updated
+      |> maybe_expand(conn.params)
+      |> then(&json_response(conn, 200, &1))
+    else
+      false ->
+        error_response(conn, PaperTiger.Error.not_found("transfer_reversal", id))
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("transfer_reversal", id))
+    end
+  end
+
+  @doc """
+  Lists reversals for a transfer.
+  """
+  @spec list_reversals(Plug.Conn.t(), String.t()) :: Plug.Conn.t()
+  def list_reversals(conn, transfer_id) do
+    case Transfers.get(transfer_id) do
+      {:ok, _transfer} ->
+        pagination_opts = parse_pagination_params(conn.params)
+
+        transfer_id
+        |> TransferReversals.find_by_transfer()
+        |> PaperTiger.List.paginate(Map.put(pagination_opts, :url, "/v1/transfers/#{transfer_id}/reversals"))
+        |> then(&json_response(conn, 200, &1))
+
+      {:error, :not_found} ->
+        error_response(conn, PaperTiger.Error.not_found("transfer", transfer_id))
+    end
+  end
+
+  defp build_transfer(params) do
+    %{
+      amount: get_integer(params, :amount),
+      amount_reversed: 0,
+      application_fee: Map.get(params, :application_fee),
+      balance_transaction: nil,
+      created: PaperTiger.now(),
+      currency: Map.get(params, :currency),
+      description: Map.get(params, :description),
+      destination: Map.get(params, :destination),
+      destination_payment: generate_id("py"),
+      id: generate_id("tr"),
+      livemode: false,
+      metadata: Map.get(params, :metadata, %{}),
+      object: "transfer",
+      reversals: nested_reversal_list("pending"),
+      reversed: false,
+      source_transaction: Map.get(params, :source_transaction),
+      source_type: Map.get(params, :source_type, "card"),
+      transfer_group: Map.get(params, :transfer_group)
+    }
+    |> then(fn transfer ->
+      %{transfer | reversals: nested_reversal_list(transfer.id)}
+    end)
+  end
+
+  defp build_reversal(params, transfer, amount) do
+    %{
+      amount: amount,
+      balance_transaction: nil,
+      created: PaperTiger.now(),
+      currency: transfer.currency,
+      destination_payment_refund: nil,
+      id: generate_id("trr"),
+      metadata: Map.get(params, :metadata, %{}),
+      object: "transfer_reversal",
+      source_refund: Map.get(params, :source_refund),
+      transfer: transfer.id
+    }
+  end
+
+  defp insert_transfer_with_balance_transactions(transfer) do
+    {:ok, balance_transaction_id} = BalanceTransactionHelper.create_for_transfer(transfer)
+
+    Connect.with_account(transfer.destination, fn ->
+      {:ok, _destination_transaction_id} = BalanceTransactionHelper.create_for_destination_transfer(transfer)
+    end)
+
+    transfer = Map.put(transfer, :balance_transaction, balance_transaction_id)
+    Transfers.insert(transfer)
+  end
+
+  defp insert_reversal_with_balance_transactions(reversal, transfer) do
+    {:ok, balance_transaction_id} = BalanceTransactionHelper.create_for_transfer_reversal(reversal)
+
+    Connect.with_account(transfer.destination, fn ->
+      {:ok, _destination_transaction_id} =
+        BalanceTransactionHelper.create_for_destination_transfer_reversal(reversal)
+    end)
+
+    reversal = Map.put(reversal, :balance_transaction, balance_transaction_id)
+    {:ok, reversal} = TransferReversals.insert(reversal)
+
+    amount_reversed = transfer.amount_reversed + reversal.amount
+    reversed? = amount_reversed == transfer.amount
+
+    updated_transfer =
+      transfer
+      |> Map.put(:amount_reversed, amount_reversed)
+      |> Map.put(:reversed, reversed?)
+      |> Map.put(:reversals, add_reversal_to_nested_list(transfer.reversals, reversal))
+
+    {:ok, updated_transfer} = Transfers.update(updated_transfer)
+    {:ok, reversal, updated_transfer}
+  end
+
+  defp parse_reversal_amount(params, transfer) do
+    remaining = transfer.amount - transfer.amount_reversed
+    amount = get_integer(params, :amount, remaining)
+
+    cond do
+      amount <= 0 ->
+        {:error, :invalid_reversal_amount, "Amount must be greater than zero"}
+
+      amount > remaining ->
+        {:error, :invalid_reversal_amount, "Amount exceeds the unreversed transfer amount"}
+
+      true ->
+        {:ok, amount}
+    end
+  end
+
+  defp validate_destination(destination) do
+    Connect.without_account(fn ->
+      case Accounts.get(destination) do
+        {:ok, _account} -> :ok
+        {:error, :not_found} -> {:error, :invalid_destination, destination}
+      end
+    end)
+  end
+
+  defp maybe_refund_application_fee(params, transfer) do
+    if to_boolean(Map.get(params, :refund_application_fee)) and is_binary(Map.get(transfer, :application_fee)) do
+      ApplicationFeeRefund.create_for_fee(transfer.application_fee, %{})
+    else
+      :ok
+    end
+  end
+
+  defp nested_reversal_list(transfer_id) do
+    %{
+      data: [],
+      has_more: false,
+      object: "list",
+      total_count: 0,
+      url: "/v1/transfers/#{transfer_id}/reversals"
+    }
+  end
+
+  defp add_reversal_to_nested_list(list, reversal) do
+    data = [reversal | Map.get(list, :data, [])] |> Enum.take(10)
+
+    list
+    |> Map.put(:data, data)
+    |> Map.put(:total_count, Map.get(list, :total_count, 0) + 1)
+  end
+
+  defp maybe_expand(transfer, params) do
+    expand_params = parse_expand_params(params)
+    PaperTiger.Hydrator.hydrate(transfer, expand_params)
+  end
+end

--- a/lib/paper_tiger/router.ex
+++ b/lib/paper_tiger/router.ex
@@ -49,12 +49,16 @@ defmodule PaperTiger.Router do
 
   alias PaperTiger.Plug.APIChaos
   alias PaperTiger.Plugs.Auth
+  alias PaperTiger.Plugs.ConnectContext
   alias PaperTiger.Plugs.CORS
   alias PaperTiger.Plugs.GetFormBody
   alias PaperTiger.Plugs.Idempotency
   alias PaperTiger.Plugs.Sandbox
   alias PaperTiger.Plugs.UnflattenParams
+  alias PaperTiger.Resources.Account
+  alias PaperTiger.Resources.AccountLink
   alias PaperTiger.Resources.ApplicationFee
+  alias PaperTiger.Resources.ApplicationFeeRefund
   alias PaperTiger.Resources.BalanceTransaction
   alias PaperTiger.Resources.BankAccount
   alias PaperTiger.Resources.BillingPortalConfiguration
@@ -95,12 +99,14 @@ defmodule PaperTiger.Router do
   alias PaperTiger.Resources.TaxRate
   alias PaperTiger.Resources.Token
   alias PaperTiger.Resources.Topup
+  alias PaperTiger.Resources.Transfer
   alias PaperTiger.Resources.Webhook
 
   # Plug pipeline
   plug(:match)
   plug(CORS)
   plug(Sandbox)
+  plug(ConnectContext)
   plug(APIChaos)
   plug(GetFormBody)
 
@@ -216,6 +222,12 @@ defmodule PaperTiger.Router do
   ## Resource Routes
 
   # Core resources (Phase 1)
+  post "/v1/account_links" do
+    AccountLink.create(conn)
+  end
+
+  stripe_resource("accounts", Account, [])
+
   post "/v1/customer_sessions" do
     CustomerSession.create(conn)
   end
@@ -350,6 +362,41 @@ defmodule PaperTiger.Router do
   stripe_resource("topups", Topup, except: [:delete])
   stripe_resource("balance_transactions", BalanceTransaction, only: [:retrieve, :list])
   stripe_resource("disputes", Dispute, only: [:retrieve, :update, :list])
+
+  post "/v1/transfers/:transfer_id/reversals" do
+    Transfer.create_reversal(conn, transfer_id)
+  end
+
+  get "/v1/transfers/:transfer_id/reversals/:id" do
+    Transfer.retrieve_reversal(conn, transfer_id, id)
+  end
+
+  post "/v1/transfers/:transfer_id/reversals/:id" do
+    Transfer.update_reversal(conn, transfer_id, id)
+  end
+
+  get "/v1/transfers/:transfer_id/reversals" do
+    Transfer.list_reversals(conn, transfer_id)
+  end
+
+  stripe_resource("transfers", Transfer, except: [:delete])
+
+  post "/v1/application_fees/:fee_id/refunds" do
+    ApplicationFeeRefund.create(conn, fee_id)
+  end
+
+  get "/v1/application_fees/:fee_id/refunds/:id" do
+    ApplicationFeeRefund.retrieve(conn, fee_id, id)
+  end
+
+  post "/v1/application_fees/:fee_id/refunds/:id" do
+    ApplicationFeeRefund.update(conn, fee_id, id)
+  end
+
+  get "/v1/application_fees/:fee_id/refunds" do
+    ApplicationFeeRefund.list(conn, fee_id)
+  end
+
   stripe_resource("application_fees", ApplicationFee, only: [:retrieve, :list])
   stripe_resource("reviews", Review, only: [:retrieve, :update, :list])
   stripe_resource("webhook_endpoints", Webhook, [])

--- a/lib/paper_tiger/store.ex
+++ b/lib/paper_tiger/store.ex
@@ -89,7 +89,7 @@ defmodule PaperTiger.Store do
 
       # Returns the current namespace for data isolation
       defp current_namespace do
-        PaperTiger.Test.current_namespace()
+        PaperTiger.Connect.storage_namespace()
       end
     end
   end
@@ -212,7 +212,7 @@ defmodule PaperTiger.Store do
 
       Used by `PaperTiger.Test` to clean up after each test.
       """
-      @spec clear_namespace(pid() | :global) :: :ok
+      @spec clear_namespace(pid() | :global | {pid() | :global, String.t()}) :: :ok
       def clear_namespace(namespace) do
         GenServer.call(__MODULE__, {:clear_namespace, namespace})
       end
@@ -222,7 +222,7 @@ defmodule PaperTiger.Store do
 
       Useful for debugging test isolation.
       """
-      @spec list_namespace(pid() | :global) :: [map()]
+      @spec list_namespace(pid() | :global | {pid() | :global, String.t()}) :: [map()]
       def list_namespace(namespace) do
         :ets.match_object(unquote(table), {{namespace, :_}, :_})
         |> Enum.map(fn {_key, item} -> item end)
@@ -273,6 +273,7 @@ defmodule PaperTiger.Store do
       def handle_call({:clear_namespace, namespace}, _from, state) do
         # Delete all entries matching the namespace
         :ets.match_delete(unquote(table), {{namespace, :_}, :_})
+        :ets.match_delete(unquote(table), {{{namespace, :_}, :_}, :_})
         {:reply, :ok, state}
       end
 

--- a/lib/paper_tiger/store/accounts.ex
+++ b/lib/paper_tiger/store/accounts.ex
@@ -1,0 +1,11 @@
+defmodule PaperTiger.Store.Accounts do
+  @moduledoc """
+  ETS-backed storage for Connect Account resources.
+  """
+
+  use PaperTiger.Store,
+    table: :paper_tiger_accounts,
+    resource: "account",
+    prefix: "acct",
+    plural: "accounts"
+end

--- a/lib/paper_tiger/store/application_fee_refunds.ex
+++ b/lib/paper_tiger/store/application_fee_refunds.ex
@@ -1,0 +1,25 @@
+defmodule PaperTiger.Store.ApplicationFeeRefunds do
+  @moduledoc """
+  ETS-backed storage for Application Fee Refund resources.
+  """
+
+  use PaperTiger.Store,
+    table: :paper_tiger_application_fee_refunds,
+    resource: "fee_refund",
+    prefix: "fr",
+    plural: "application_fee_refunds",
+    url_path: "/v1/application_fees"
+
+  @doc """
+  Lists refunds for an application fee in platform scope.
+  """
+  @spec find_by_fee(String.t()) :: [map()]
+  def find_by_fee(fee_id) when is_binary(fee_id) do
+    PaperTiger.Connect.without_account(fn ->
+      namespace = PaperTiger.Connect.storage_namespace()
+
+      :ets.match_object(@table, {{namespace, :_}, %{fee: fee_id}})
+      |> Enum.map(fn {_key, refund} -> refund end)
+    end)
+  end
+end

--- a/lib/paper_tiger/store/application_fees.ex
+++ b/lib/paper_tiger/store/application_fees.ex
@@ -38,7 +38,11 @@ defmodule PaperTiger.Store.ApplicationFees do
   """
   @spec find_by_charge(String.t()) :: [map()]
   def find_by_charge(charge_id) when is_binary(charge_id) do
-    :ets.match_object(@table, {:_, %{charge: charge_id}})
-    |> Enum.map(fn {_id, fee} -> fee end)
+    PaperTiger.Connect.without_account(fn ->
+      namespace = PaperTiger.Connect.storage_namespace()
+
+      :ets.match_object(@table, {{namespace, :_}, %{charge: charge_id}})
+      |> Enum.map(fn {_id, fee} -> fee end)
+    end)
   end
 end

--- a/lib/paper_tiger/store/balance_transactions.ex
+++ b/lib/paper_tiger/store/balance_transactions.ex
@@ -38,7 +38,9 @@ defmodule PaperTiger.Store.BalanceTransactions do
   """
   @spec find_by_source(String.t()) :: [map()]
   def find_by_source(source_id) when is_binary(source_id) do
-    :ets.match_object(@table, {:_, %{source: source_id}})
+    namespace = PaperTiger.Connect.storage_namespace()
+
+    :ets.match_object(@table, {{namespace, :_}, %{source: source_id}})
     |> Enum.map(fn {_id, balance_transaction} -> balance_transaction end)
   end
 end

--- a/lib/paper_tiger/store/credit_notes.ex
+++ b/lib/paper_tiger/store/credit_notes.ex
@@ -13,7 +13,7 @@ defmodule PaperTiger.Store.CreditNotes do
   """
   @spec find_by_invoice(String.t()) :: [map()]
   def find_by_invoice(invoice_id) when is_binary(invoice_id) do
-    namespace = PaperTiger.Test.current_namespace()
+    namespace = PaperTiger.Connect.storage_namespace()
 
     @table
     |> :ets.match_object({{namespace, :_}, :_})

--- a/lib/paper_tiger/store/customer_balance_transactions.ex
+++ b/lib/paper_tiger/store/customer_balance_transactions.ex
@@ -13,7 +13,7 @@ defmodule PaperTiger.Store.CustomerBalanceTransactions do
   """
   @spec find_by_customer(String.t()) :: [map()]
   def find_by_customer(customer_id) when is_binary(customer_id) do
-    namespace = PaperTiger.Test.current_namespace()
+    namespace = PaperTiger.Connect.storage_namespace()
 
     @table
     |> :ets.match_object({{namespace, :_}, :_})

--- a/lib/paper_tiger/store/invoices.ex
+++ b/lib/paper_tiger/store/invoices.ex
@@ -39,7 +39,7 @@ defmodule PaperTiger.Store.Invoices do
   """
   @spec all() :: [map()]
   def all do
-    namespace = PaperTiger.Test.current_namespace()
+    namespace = PaperTiger.Connect.storage_namespace()
 
     :ets.match_object(@table, {{namespace, :_}, :_})
     |> Enum.map(fn {_key, invoice} -> invoice end)
@@ -52,7 +52,7 @@ defmodule PaperTiger.Store.Invoices do
   """
   @spec find_by_customer(String.t()) :: [map()]
   def find_by_customer(customer_id) when is_binary(customer_id) do
-    namespace = PaperTiger.Test.current_namespace()
+    namespace = PaperTiger.Connect.storage_namespace()
 
     :ets.match_object(@table, {{namespace, :_}, %{customer: customer_id}})
     |> Enum.map(fn {_id, invoice} -> invoice end)
@@ -65,7 +65,7 @@ defmodule PaperTiger.Store.Invoices do
   """
   @spec find_by_subscription(String.t()) :: [map()]
   def find_by_subscription(subscription_id) when is_binary(subscription_id) do
-    namespace = PaperTiger.Test.current_namespace()
+    namespace = PaperTiger.Connect.storage_namespace()
 
     :ets.match_object(@table, {{namespace, :_}, %{subscription: subscription_id}})
     |> Enum.map(fn {_id, invoice} -> invoice end)
@@ -89,7 +89,7 @@ defmodule PaperTiger.Store.Invoices do
   """
   @spec find_by_status(String.t()) :: [map()]
   def find_by_status(status) when is_binary(status) do
-    namespace = PaperTiger.Test.current_namespace()
+    namespace = PaperTiger.Connect.storage_namespace()
 
     :ets.match_object(@table, {{namespace, :_}, %{status: status}})
     |> Enum.map(fn {_id, invoice} -> invoice end)

--- a/lib/paper_tiger/store/payment_methods.ex
+++ b/lib/paper_tiger/store/payment_methods.ex
@@ -42,7 +42,7 @@ defmodule PaperTiger.Store.PaymentMethods do
   """
   @spec get(String.t()) :: {:ok, map()} | {:error, :not_found}
   def get(id) when is_binary(id) do
-    namespace = PaperTiger.Test.current_namespace()
+    namespace = PaperTiger.Connect.storage_namespace()
     key = {namespace, id}
 
     case :ets.lookup(@table, key) do
@@ -76,7 +76,7 @@ defmodule PaperTiger.Store.PaymentMethods do
   def find_by_customer(nil), do: []
 
   def find_by_customer(customer_id) when is_binary(customer_id) do
-    namespace = PaperTiger.Test.current_namespace()
+    namespace = PaperTiger.Connect.storage_namespace()
 
     :ets.match_object(@table, {{namespace, :_}, %{customer: customer_id}})
     |> Enum.map(fn {_key, payment_method} -> payment_method end)

--- a/lib/paper_tiger/store/promotion_codes.ex
+++ b/lib/paper_tiger/store/promotion_codes.ex
@@ -13,7 +13,7 @@ defmodule PaperTiger.Store.PromotionCodes do
   """
   @spec find_active_by_code(String.t()) :: [map()]
   def find_active_by_code(code) when is_binary(code) do
-    namespace = PaperTiger.Test.current_namespace()
+    namespace = PaperTiger.Connect.storage_namespace()
     normalized_code = String.downcase(code)
 
     @table

--- a/lib/paper_tiger/store/setup_attempts.ex
+++ b/lib/paper_tiger/store/setup_attempts.ex
@@ -21,7 +21,7 @@ defmodule PaperTiger.Store.SetupAttempts do
   def find_by_setup_intent(nil), do: []
 
   def find_by_setup_intent(setup_intent_id) when is_binary(setup_intent_id) do
-    namespace = PaperTiger.Test.current_namespace()
+    namespace = PaperTiger.Connect.storage_namespace()
 
     :ets.match_object(@table, {{namespace, :_}, %{setup_intent: setup_intent_id}})
     |> Enum.map(fn {_key, setup_attempt} -> setup_attempt end)

--- a/lib/paper_tiger/store/tokens.ex
+++ b/lib/paper_tiger/store/tokens.ex
@@ -39,7 +39,7 @@ defmodule PaperTiger.Store.Tokens do
   """
   @spec get(String.t()) :: {:ok, map()} | {:error, :not_found}
   def get(id) when is_binary(id) do
-    namespace = PaperTiger.Test.current_namespace()
+    namespace = PaperTiger.Connect.storage_namespace()
     key = {namespace, id}
 
     case :ets.lookup(@table, key) do

--- a/lib/paper_tiger/store/transfer_reversals.ex
+++ b/lib/paper_tiger/store/transfer_reversals.ex
@@ -1,0 +1,23 @@
+defmodule PaperTiger.Store.TransferReversals do
+  @moduledoc """
+  ETS-backed storage for Connect Transfer Reversal resources.
+  """
+
+  use PaperTiger.Store,
+    table: :paper_tiger_transfer_reversals,
+    resource: "transfer_reversal",
+    prefix: "trr",
+    plural: "transfer_reversals",
+    url_path: "/v1/transfers"
+
+  @doc """
+  Lists reversals for a transfer in the current request scope.
+  """
+  @spec find_by_transfer(String.t()) :: [map()]
+  def find_by_transfer(transfer_id) when is_binary(transfer_id) do
+    namespace = PaperTiger.Connect.storage_namespace()
+
+    :ets.match_object(@table, {{namespace, :_}, %{transfer: transfer_id}})
+    |> Enum.map(fn {_key, reversal} -> reversal end)
+  end
+end

--- a/lib/paper_tiger/store/transfers.ex
+++ b/lib/paper_tiger/store/transfers.ex
@@ -1,0 +1,22 @@
+defmodule PaperTiger.Store.Transfers do
+  @moduledoc """
+  ETS-backed storage for Connect Transfer resources.
+  """
+
+  use PaperTiger.Store,
+    table: :paper_tiger_transfers,
+    resource: "transfer",
+    prefix: "tr",
+    plural: "transfers"
+
+  @doc """
+  Finds transfers by destination account in the current request scope.
+  """
+  @spec find_by_destination(String.t()) :: [map()]
+  def find_by_destination(destination) when is_binary(destination) do
+    namespace = PaperTiger.Connect.storage_namespace()
+
+    :ets.match_object(@table, {{namespace, :_}, %{destination: destination}})
+    |> Enum.map(fn {_key, transfer} -> transfer end)
+  end
+end

--- a/lib/paper_tiger/test.ex
+++ b/lib/paper_tiger/test.ex
@@ -30,6 +30,8 @@ defmodule PaperTiger.Test do
   with each other's data.
   """
 
+  alias PaperTiger.Store.Accounts
+  alias PaperTiger.Store.ApplicationFeeRefunds
   alias PaperTiger.Store.ApplicationFees
   alias PaperTiger.Store.BalanceTransactions
   alias PaperTiger.Store.BankAccounts
@@ -69,6 +71,8 @@ defmodule PaperTiger.Test do
   alias PaperTiger.Store.TaxRates
   alias PaperTiger.Store.Tokens
   alias PaperTiger.Store.Topups
+  alias PaperTiger.Store.TransferReversals
+  alias PaperTiger.Store.Transfers
   alias PaperTiger.Store.WebhookDeliveries
   alias PaperTiger.Store.Webhooks
 
@@ -205,7 +209,9 @@ defmodule PaperTiger.Test do
   @spec cleanup_namespace(pid() | :global) :: :ok
   def cleanup_namespace(namespace) do
     stores = [
+      Accounts,
       ApplicationFees,
+      ApplicationFeeRefunds,
       BalanceTransactions,
       BankAccounts,
       BillingPortalConfigurations,
@@ -244,6 +250,8 @@ defmodule PaperTiger.Test do
       TaxRates,
       Tokens,
       Topups,
+      Transfers,
+      TransferReversals,
       WebhookDeliveries,
       Webhooks
     ]

--- a/test/paper_tiger/contract_test.exs
+++ b/test/paper_tiger/contract_test.exs
@@ -1262,6 +1262,81 @@ defmodule PaperTiger.ContractTest do
     end
   end
 
+  describe "Connect Platform APIs" do
+    @tag :contract
+    test "creates connected accounts and account links" do
+      result =
+        TestClient.create_account(%{
+          "capabilities" => %{"transfers" => %{"requested" => true}},
+          "country" => "US",
+          "email" => "connect-account-#{System.unique_integer([:positive])}@example.com",
+          "type" => "express"
+        })
+
+      case result do
+        {:ok, account} ->
+          assert account["object"] == "account"
+          assert String.starts_with?(account["id"], "acct_")
+          assert Map.has_key?(account, "capabilities")
+
+          {:ok, retrieved} = TestClient.get_account(account["id"])
+          assert retrieved["id"] == account["id"]
+
+          {:ok, link} =
+            TestClient.create_account_link(%{
+              "account" => account["id"],
+              "refresh_url" => "https://example.test/reauth",
+              "return_url" => "https://example.test/return",
+              "type" => "account_onboarding"
+            })
+
+          assert link["object"] == "account_link"
+          assert is_binary(link["url"])
+
+          cleanup_account(account["id"])
+
+        {:error, error} ->
+          assert_connect_environment_error(error)
+      end
+    end
+
+    @tag :contract
+    test "creates transfers and reversals for connected accounts" do
+      with {:ok, account} <-
+             TestClient.create_account(%{
+               "capabilities" => %{"transfers" => %{"requested" => true}},
+               "country" => "US",
+               "type" => "express"
+             }),
+           {:ok, transfer} <-
+             TestClient.create_transfer(%{
+               "amount" => 400,
+               "currency" => "usd",
+               "destination" => account["id"],
+               "transfer_group" => "pt_contract_#{System.unique_integer([:positive])}"
+             }) do
+        assert transfer["object"] == "transfer"
+        assert String.starts_with?(transfer["id"], "tr_")
+        assert transfer["amount"] == 400
+        assert transfer["destination"] == account["id"]
+        assert Map.has_key?(transfer, "reversals")
+
+        {:ok, reversal} = TestClient.create_transfer_reversal(transfer["id"], %{"amount" => 100})
+        assert reversal["object"] == "transfer_reversal"
+        assert reversal["amount"] == 100
+        assert reversal["transfer"] == transfer["id"]
+
+        {:ok, reversals} = TestClient.list_transfer_reversals(transfer["id"], %{"limit" => 1})
+        assert is_list(reversals["data"])
+
+        cleanup_account(account["id"])
+      else
+        {:error, error} ->
+          assert_connect_environment_error(error)
+      end
+    end
+  end
+
   describe "Error Response Format Validation" do
     @tag :contract
     test "non-existent customer returns resource_missing error" do
@@ -1783,6 +1858,20 @@ defmodule PaperTiger.ContractTest do
   defp cleanup_subscription(subscription_id) do
     if TestClient.real_stripe?() do
       TestClient.delete_subscription(subscription_id)
+    end
+  end
+
+  defp cleanup_account(account_id) do
+    if TestClient.real_stripe?() do
+      TestClient.delete_account(account_id)
+    end
+  end
+
+  defp assert_connect_environment_error(error) do
+    if TestClient.real_stripe?() do
+      assert error["error"]["type"] in ["invalid_request_error", "api_error"]
+    else
+      flunk("Unexpected PaperTiger Connect error: #{inspect(error)}")
     end
   end
 

--- a/test/paper_tiger/resources/connect_platform_test.exs
+++ b/test/paper_tiger/resources/connect_platform_test.exs
@@ -1,0 +1,278 @@
+defmodule PaperTiger.Resources.ConnectPlatformTest do
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
+
+  alias PaperTiger.Router
+
+  setup :checkout_paper_tiger
+
+  defp request(method, path, params \\ nil, headers \\ []) do
+    conn = Plug.Test.conn(method, path, params)
+
+    headers_with_defaults =
+      headers ++
+        [
+          {"content-type", "application/json"},
+          {"authorization", "Bearer sk_test_connect_key"}
+        ] ++ sandbox_headers()
+
+    headers_with_defaults
+    |> Enum.reduce(conn, fn {key, value}, acc -> Plug.Conn.put_req_header(acc, key, value) end)
+    |> Router.call([])
+  end
+
+  defp json_response(conn), do: Jason.decode!(conn.resp_body)
+  defp account_header(account_id), do: [{"stripe-account", account_id}]
+
+  describe "Accounts and Account Links" do
+    test "creates, updates, lists, retrieves, and deletes legacy connected accounts" do
+      create_conn =
+        request(:post, "/v1/accounts", %{
+          "business_type" => "individual",
+          "capabilities" => %{
+            "card_payments" => %{"requested" => true},
+            "transfers" => %{"requested" => true}
+          },
+          "country" => "US",
+          "email" => "seller@example.test",
+          "type" => "express"
+        })
+
+      assert create_conn.status == 200
+      account = json_response(create_conn)
+      assert String.starts_with?(account["id"], "acct_")
+      assert account["object"] == "account"
+      assert account["capabilities"]["transfers"] == "active"
+      assert account["charges_enabled"] == true
+      assert account["payouts_enabled"] == true
+
+      update_conn =
+        request(:post, "/v1/accounts/#{account["id"]}", %{
+          "metadata" => %{"seller_id" => "seller_123"}
+        })
+
+      assert update_conn.status == 200
+      assert json_response(update_conn)["metadata"] == %{"seller_id" => "seller_123"}
+
+      retrieve_conn = request(:get, "/v1/accounts/#{account["id"]}")
+      assert retrieve_conn.status == 200
+      assert json_response(retrieve_conn)["email"] == "seller@example.test"
+
+      list_conn = request(:get, "/v1/accounts")
+      assert list_conn.status == 200
+      assert [account["id"]] == Enum.map(json_response(list_conn)["data"], & &1["id"])
+
+      link_conn =
+        request(:post, "/v1/account_links", %{
+          "account" => account["id"],
+          "refresh_url" => "https://example.test/reauth",
+          "return_url" => "https://example.test/return",
+          "type" => "account_onboarding"
+        })
+
+      assert link_conn.status == 200
+      link = json_response(link_conn)
+      assert link["object"] == "account_link"
+      assert link["account"] == account["id"]
+      assert link["type"] == "account_onboarding"
+      assert String.starts_with?(link["url"], "https://connect.stripe.com/setup/s/link_")
+
+      delete_conn = request(:delete, "/v1/accounts/#{account["id"]}")
+      assert delete_conn.status == 200
+      assert json_response(delete_conn) == %{"deleted" => true, "id" => account["id"], "object" => "account"}
+    end
+  end
+
+  describe "Stripe-Account request scoping" do
+    test "isolates ordinary resources per connected account" do
+      account = create_account()
+
+      platform_customer =
+        request(:post, "/v1/customers", %{
+          "email" => "platform@example.test",
+          "id" => "cus_connect_shared"
+        })
+        |> json_response()
+
+      connected_customer =
+        request(
+          :post,
+          "/v1/customers",
+          %{"email" => "connected@example.test", "id" => "cus_connect_shared"},
+          account_header(account["id"])
+        )
+        |> json_response()
+
+      assert platform_customer["id"] == connected_customer["id"]
+
+      platform_retrieve =
+        request(:get, "/v1/customers/cus_connect_shared")
+        |> json_response()
+
+      connected_retrieve =
+        request(:get, "/v1/customers/cus_connect_shared", nil, account_header(account["id"]))
+        |> json_response()
+
+      assert platform_retrieve["email"] == "platform@example.test"
+      assert connected_retrieve["email"] == "connected@example.test"
+
+      connected_list =
+        request(:get, "/v1/customers", nil, account_header(account["id"]))
+        |> json_response()
+
+      assert ["connected@example.test"] == Enum.map(connected_list["data"], & &1["email"])
+
+      missing_account_conn =
+        request(:get, "/v1/customers", nil, account_header("acct_missing"))
+
+      assert missing_account_conn.status == 404
+      assert json_response(missing_account_conn)["error"]["code"] == "resource_missing"
+    end
+  end
+
+  describe "Transfers and Transfer Reversals" do
+    test "creates transfers to connected accounts and reverses them coherently" do
+      account = create_account()
+
+      transfer_conn =
+        request(:post, "/v1/transfers", %{
+          "amount" => 1_500,
+          "currency" => "usd",
+          "description" => "Seller payout",
+          "destination" => account["id"],
+          "transfer_group" => "order_123"
+        })
+
+      assert transfer_conn.status == 200
+      transfer = json_response(transfer_conn)
+      assert String.starts_with?(transfer["id"], "tr_")
+      assert transfer["amount"] == 1_500
+      assert transfer["amount_reversed"] == 0
+      assert transfer["destination"] == account["id"]
+      assert transfer["reversed"] == false
+      assert transfer["reversals"]["data"] == []
+
+      reversal_conn =
+        request(:post, "/v1/transfers/#{transfer["id"]}/reversals", %{
+          "amount" => 500,
+          "metadata" => %{"reason" => "partial_refund"}
+        })
+
+      assert reversal_conn.status == 200
+      reversal = json_response(reversal_conn)
+      assert String.starts_with?(reversal["id"], "trr_")
+      assert reversal["amount"] == 500
+      assert reversal["transfer"] == transfer["id"]
+      assert reversal["metadata"] == %{"reason" => "partial_refund"}
+
+      updated_transfer =
+        request(:get, "/v1/transfers/#{transfer["id"]}")
+        |> json_response()
+
+      assert updated_transfer["amount_reversed"] == 500
+      assert updated_transfer["reversed"] == false
+      assert [reversal["id"]] == Enum.map(updated_transfer["reversals"]["data"], & &1["id"])
+
+      list_reversals_conn = request(:get, "/v1/transfers/#{transfer["id"]}/reversals")
+      assert list_reversals_conn.status == 200
+      assert [reversal["id"]] == Enum.map(json_response(list_reversals_conn)["data"], & &1["id"])
+
+      final_reversal_conn = request(:post, "/v1/transfers/#{transfer["id"]}/reversals")
+      assert final_reversal_conn.status == 200
+
+      fully_reversed =
+        request(:get, "/v1/transfers/#{transfer["id"]}")
+        |> json_response()
+
+      assert fully_reversed["amount_reversed"] == 1_500
+      assert fully_reversed["reversed"] == true
+    end
+  end
+
+  describe "Application Fee Refunds" do
+    test "creates application fees from destination-charge payment intents and refunds them" do
+      account = create_account()
+
+      payment_intent =
+        request(:post, "/v1/payment_intents", %{
+          "amount" => 2_000,
+          "application_fee_amount" => 250,
+          "currency" => "usd",
+          "payment_method" => "pm_card_visa",
+          "transfer_data" => %{"destination" => account["id"]}
+        })
+        |> json_response()
+
+      confirmed =
+        request(:post, "/v1/payment_intents/#{payment_intent["id"]}/confirm")
+        |> json_response()
+
+      charge =
+        request(:get, "/v1/charges/#{confirmed["latest_charge"]}")
+        |> json_response()
+
+      assert String.starts_with?(charge["application_fee"], "fee_")
+
+      fee =
+        request(:get, "/v1/application_fees/#{charge["application_fee"]}")
+        |> json_response()
+
+      assert fee["account"] == account["id"]
+      assert fee["amount"] == 250
+      assert fee["amount_refunded"] == 0
+      assert fee["refunded"] == false
+
+      refund_conn =
+        request(:post, "/v1/application_fees/#{fee["id"]}/refunds", %{
+          "amount" => 100,
+          "metadata" => %{"reason" => "seller_refund"}
+        })
+
+      assert refund_conn.status == 200
+      refund = json_response(refund_conn)
+      assert String.starts_with?(refund["id"], "fr_")
+      assert refund["amount"] == 100
+      assert refund["fee"] == fee["id"]
+      assert refund["metadata"] == %{"reason" => "seller_refund"}
+
+      partially_refunded_fee =
+        request(:get, "/v1/application_fees/#{fee["id"]}")
+        |> json_response()
+
+      assert partially_refunded_fee["amount_refunded"] == 100
+      assert partially_refunded_fee["refunded"] == false
+
+      final_refund =
+        request(:post, "/v1/application_fees/#{fee["id"]}/refunds")
+        |> json_response()
+
+      assert final_refund["amount"] == 150
+
+      fully_refunded_fee =
+        request(:get, "/v1/application_fees/#{fee["id"]}")
+        |> json_response()
+
+      assert fully_refunded_fee["amount_refunded"] == 250
+      assert fully_refunded_fee["refunded"] == true
+
+      over_refund_conn =
+        request(:post, "/v1/application_fees/#{fee["id"]}/refunds", %{"amount" => 1})
+
+      assert over_refund_conn.status == 400
+      assert json_response(over_refund_conn)["error"]["param"] == "amount"
+    end
+  end
+
+  defp create_account do
+    conn =
+      request(:post, "/v1/accounts", %{
+        "capabilities" => %{"transfers" => %{"requested" => true}},
+        "country" => "US",
+        "type" => "express"
+      })
+
+    assert conn.status == 200
+    json_response(conn)
+  end
+end

--- a/test/support/test_client.ex
+++ b/test/support/test_client.ex
@@ -1296,6 +1296,99 @@ defmodule PaperTiger.TestClient do
     end
   end
 
+  ## Connect Operations
+
+  def create_account(params) do
+    case mode() do
+      :real_stripe -> create_account_real(params)
+      :paper_tiger -> create_account_mock(params)
+    end
+  end
+
+  def get_account(account_id) do
+    case mode() do
+      :real_stripe -> get_account_real(account_id)
+      :paper_tiger -> get_account_mock(account_id)
+    end
+  end
+
+  def update_account(account_id, params) do
+    case mode() do
+      :real_stripe -> update_account_real(account_id, params)
+      :paper_tiger -> update_account_mock(account_id, params)
+    end
+  end
+
+  def delete_account(account_id) do
+    case mode() do
+      :real_stripe -> delete_account_real(account_id)
+      :paper_tiger -> delete_account_mock(account_id)
+    end
+  end
+
+  def list_accounts(params \\ %{}) do
+    case mode() do
+      :real_stripe -> list_accounts_real(params)
+      :paper_tiger -> list_accounts_mock(params)
+    end
+  end
+
+  def create_account_link(params) do
+    case mode() do
+      :real_stripe -> create_account_link_real(params)
+      :paper_tiger -> create_account_link_mock(params)
+    end
+  end
+
+  def create_transfer(params) do
+    case mode() do
+      :real_stripe -> create_transfer_real(params)
+      :paper_tiger -> create_transfer_mock(params)
+    end
+  end
+
+  def get_transfer(transfer_id) do
+    case mode() do
+      :real_stripe -> get_transfer_real(transfer_id)
+      :paper_tiger -> get_transfer_mock(transfer_id)
+    end
+  end
+
+  def create_transfer_reversal(transfer_id, params \\ %{}) do
+    case mode() do
+      :real_stripe -> create_transfer_reversal_real(transfer_id, params)
+      :paper_tiger -> create_transfer_reversal_mock(transfer_id, params)
+    end
+  end
+
+  def list_transfer_reversals(transfer_id, params \\ %{}) do
+    case mode() do
+      :real_stripe -> list_transfer_reversals_real(transfer_id, params)
+      :paper_tiger -> list_transfer_reversals_mock(transfer_id, params)
+    end
+  end
+
+  def get_application_fee(fee_id) do
+    case mode() do
+      :real_stripe -> get_application_fee_real(fee_id)
+      :paper_tiger -> get_application_fee_mock(fee_id)
+    end
+  end
+
+  def create_application_fee_refund(fee_id, params \\ %{}) do
+    case mode() do
+      :real_stripe -> create_application_fee_refund_real(fee_id, params)
+      :paper_tiger -> create_application_fee_refund_mock(fee_id, params)
+    end
+  end
+
+  def list_application_fee_refunds(fee_id, params \\ %{}) do
+    case mode() do
+      :real_stripe -> list_application_fee_refunds_real(fee_id, params)
+      :paper_tiger -> list_application_fee_refunds_mock(fee_id, params)
+    end
+  end
+
   ## Invoice Operations
 
   @doc """
@@ -1919,6 +2012,58 @@ defmodule PaperTiger.TestClient do
     stripe_request(:post, "/v1/credit_notes", params)
   end
 
+  defp create_account_real(params) do
+    stripe_request(:post, "/v1/accounts", params)
+  end
+
+  defp get_account_real(account_id) do
+    stripe_request(:get, "/v1/accounts/#{account_id}")
+  end
+
+  defp update_account_real(account_id, params) do
+    stripe_request(:post, "/v1/accounts/#{account_id}", params)
+  end
+
+  defp delete_account_real(account_id) do
+    stripe_request(:delete, "/v1/accounts/#{account_id}")
+  end
+
+  defp list_accounts_real(params) do
+    stripe_request(:get, "/v1/accounts", params)
+  end
+
+  defp create_account_link_real(params) do
+    stripe_request(:post, "/v1/account_links", params)
+  end
+
+  defp create_transfer_real(params) do
+    stripe_request(:post, "/v1/transfers", params)
+  end
+
+  defp get_transfer_real(transfer_id) do
+    stripe_request(:get, "/v1/transfers/#{transfer_id}")
+  end
+
+  defp create_transfer_reversal_real(transfer_id, params) do
+    stripe_request(:post, "/v1/transfers/#{transfer_id}/reversals", params)
+  end
+
+  defp list_transfer_reversals_real(transfer_id, params) do
+    stripe_request(:get, "/v1/transfers/#{transfer_id}/reversals", params)
+  end
+
+  defp get_application_fee_real(fee_id) do
+    stripe_request(:get, "/v1/application_fees/#{fee_id}")
+  end
+
+  defp create_application_fee_refund_real(fee_id, params) do
+    stripe_request(:post, "/v1/application_fees/#{fee_id}/refunds", params)
+  end
+
+  defp list_application_fee_refunds_real(fee_id, params) do
+    stripe_request(:get, "/v1/application_fees/#{fee_id}/refunds", params)
+  end
+
   ## Private - PaperTiger Mock
 
   defp create_customer_mock(params) do
@@ -2358,6 +2503,71 @@ defmodule PaperTiger.TestClient do
 
   defp create_credit_note_mock(params) do
     conn = request(:post, "/v1/credit_notes", params)
+    handle_response(conn)
+  end
+
+  defp create_account_mock(params) do
+    conn = request(:post, "/v1/accounts", params)
+    handle_response(conn)
+  end
+
+  defp get_account_mock(account_id) do
+    conn = request(:get, "/v1/accounts/#{account_id}", %{})
+    handle_response(conn)
+  end
+
+  defp update_account_mock(account_id, params) do
+    conn = request(:post, "/v1/accounts/#{account_id}", params)
+    handle_response(conn)
+  end
+
+  defp delete_account_mock(account_id) do
+    conn = request(:delete, "/v1/accounts/#{account_id}", %{})
+    handle_response(conn)
+  end
+
+  defp list_accounts_mock(params) do
+    conn = request(:get, "/v1/accounts", params)
+    handle_response(conn)
+  end
+
+  defp create_account_link_mock(params) do
+    conn = request(:post, "/v1/account_links", params)
+    handle_response(conn)
+  end
+
+  defp create_transfer_mock(params) do
+    conn = request(:post, "/v1/transfers", params)
+    handle_response(conn)
+  end
+
+  defp get_transfer_mock(transfer_id) do
+    conn = request(:get, "/v1/transfers/#{transfer_id}", %{})
+    handle_response(conn)
+  end
+
+  defp create_transfer_reversal_mock(transfer_id, params) do
+    conn = request(:post, "/v1/transfers/#{transfer_id}/reversals", params)
+    handle_response(conn)
+  end
+
+  defp list_transfer_reversals_mock(transfer_id, params) do
+    conn = request(:get, "/v1/transfers/#{transfer_id}/reversals", params)
+    handle_response(conn)
+  end
+
+  defp get_application_fee_mock(fee_id) do
+    conn = request(:get, "/v1/application_fees/#{fee_id}", %{})
+    handle_response(conn)
+  end
+
+  defp create_application_fee_refund_mock(fee_id, params) do
+    conn = request(:post, "/v1/application_fees/#{fee_id}/refunds", params)
+    handle_response(conn)
+  end
+
+  defp list_application_fee_refunds_mock(fee_id, params) do
+    conn = request(:get, "/v1/application_fees/#{fee_id}/refunds", params)
     handle_response(conn)
   end
 


### PR DESCRIPTION
## Summary

Closes #65.

Adds a properly scoped Connect platform slice:
- legacy `/v1/accounts` create/retrieve/update/delete/list
- `POST /v1/account_links` for deterministic onboarding/update links
- `Stripe-Account` request context that isolates ordinary resources per connected account
- `/v1/transfers` create/retrieve/update/list with destination-account balance effects
- nested transfer reversals with transfer mutation and reversal balance effects
- nested application fee refunds with parent fee mutation and refund balance effects
- application fee generation from destination-charge PaymentIntents using `application_fee_amount` + `transfer_data[destination]`
- contract-client helpers and tests for account/account-link/transfer/reversal flows

## Scope Notes

PaperTiger models Stripe API v1 Connect first because current server-side Stripe clients commonly use the legacy Account resource. Accounts v2, Persons, external-account mutation, capability verification/review workflows, Treasury, and Issuing remain explicitly unsupported rather than partially mocked.

Connected-account scoping is implemented at the store/idempotency layer: requests with `Stripe-Account: acct_...` use `{sandbox_namespace, account_id}` storage for ordinary resources, while platform-owned resources such as Accounts and Application Fees explicitly stay in platform scope.

References:
- https://docs.stripe.com/connect/authentication
- https://docs.stripe.com/api/accounts
- https://docs.stripe.com/api/account_links
- https://docs.stripe.com/api/transfers
- https://docs.stripe.com/api/transfer_reversals
- https://docs.stripe.com/api/application_fee_refunds

## Validation

- `mise exec -- mix test`
- `mise exec -- mix test test/paper_tiger/resources/connect_platform_test.exs`
- `mise exec -- mix test test/paper_tiger/contract_test.exs:1267 test/paper_tiger/contract_test.exs:1304`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix dialyzer`
- `mise exec -- mix credo --strict`
