### PR TITLE
Add Stripe list filter fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hosted product APIs for Payment Links and Billing Portal: `POST/GET/POST/GET-list /v1/payment_links`, paginated `GET /v1/payment_links/:id/line_items`, browser-visible Payment Link URLs backed by deterministic Checkout Session completion, `POST /v1/billing_portal/sessions`, and Billing Portal Configuration create/retrieve/update/list endpoints.
 - Billing discount and credit APIs: Promotion Codes, Customer Balance Transactions, Customer Cash Balance, and Credit Notes with invoice/customer balance mutation for common credit workflows.
 - Properly scoped Connect platform APIs: legacy `/v1/accounts`, `POST /v1/account_links`, per-request `Stripe-Account` resource isolation, `POST/GET/POST/GET-list /v1/transfers`, nested transfer reversals, and nested application fee refunds with transfer/fee/reversal balance transaction effects.
+- Complete Stripe-style list filtering for Products, Prices, and Refunds, including created-range predicates, documented scalar filters, array filters (`ids[]`, `lookup_keys[]`), Price recurring child filters, list-item expansion such as `expand[]=data.product`, and Refund filtering by Charge or PaymentIntent before cursor pagination.
 
 ### Fixed
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -5,7 +5,10 @@ import Config
 if config_env() == :test do
   if System.get_env("VALIDATE_AGAINST_STRIPE") == "true" do
     config :stripity_stripe,
-      api_key: System.get_env("STRIPE_API_KEY")
+      api_key: System.get_env("STRIPE_API_KEY"),
+      # stripity_stripe sends the HTTP/1-only Connection header. hackney 4 can
+      # negotiate HTTP/2 by default, which Stripe rejects as a protocol error.
+      hackney_opts: [protocols: [:http1]]
   else
     config :stripity_stripe, PaperTiger.stripity_stripe_config()
   end

--- a/lib/paper_tiger/list_filters.ex
+++ b/lib/paper_tiger/list_filters.ex
@@ -1,0 +1,327 @@
+defmodule PaperTiger.ListFilters do
+  @moduledoc """
+  Shared helpers for Stripe-style list endpoint filtering.
+
+  Resource modules still declare their own supported filters. This module only
+  provides typed matching, created-range filtering, and list-item expansion so
+  filtering happens before cursor pagination consistently across resources.
+  """
+
+  alias PaperTiger.Error
+
+  @type filter ::
+          {:boolean, atom()}
+          | {:boolean, atom(), atom()}
+          | {:string, atom()}
+          | {:string, atom(), atom()}
+          | {:enum, atom(), [String.t()]}
+          | {:enum, atom(), atom(), [String.t()]}
+          | {:string_in, atom(), atom(), keyword()}
+          | {:nested_enum, [atom()], [String.t()]}
+          | {:nested_string, [atom()]}
+          | {:created, atom()}
+
+  @range_operators [:gt, :gte, :lt, :lte]
+
+  @doc """
+  Applies a resource's declared list filters to `items`.
+  """
+  @spec apply([map()], map(), [filter()]) :: {:ok, [map()]} | {:error, Error.t()}
+  def apply(items, params, filters) when is_list(items) and is_map(params) do
+    Enum.reduce_while(filters, {:ok, items}, fn filter, {:ok, acc} ->
+      case apply_filter(acc, params, filter) do
+        {:ok, filtered} -> {:cont, {:ok, filtered}}
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
+  end
+
+  @doc """
+  Rejects unsupported parameter combinations before filtering.
+  """
+  @spec reject_combination(map(), atom(), [atom()]) :: :ok | {:error, Error.t()}
+  def reject_combination(params, primary, forbidden) do
+    if present?(params, primary) do
+      case Enum.find(forbidden, &present?(params, &1)) do
+        nil ->
+          :ok
+
+        param ->
+          {:error,
+           Error.invalid_request(
+             "Cannot specify #{format_param(primary)} with #{format_param(param)}",
+             format_param(param)
+           )}
+      end
+    else
+      :ok
+    end
+  end
+
+  @doc """
+  Expands objects inside a list response.
+
+  Stripe list expansion paths are usually prefixed with `data.`, for example
+  `expand[]=data.product`. Single-object paths are accepted too because tests
+  and clients sometimes reuse retrieve-style params with list endpoints.
+  """
+  @spec expand_page(PaperTiger.List.t(), map()) :: PaperTiger.List.t()
+  def expand_page(%PaperTiger.List{} = page, params) do
+    expand_params =
+      params
+      |> PaperTiger.Resource.parse_expand_params()
+      |> Enum.map(&strip_data_prefix/1)
+
+    %{page | data: Enum.map(page.data, &PaperTiger.Hydrator.hydrate(&1, expand_params))}
+  end
+
+  defp apply_filter(items, params, {:boolean, param}) do
+    apply_filter(items, params, {:boolean, param, param})
+  end
+
+  defp apply_filter(items, params, {:boolean, param, field}) do
+    case fetch_param(params, param) do
+      :missing ->
+        {:ok, items}
+
+      value ->
+        with {:ok, expected} <- parse_boolean(value, param) do
+          {:ok, Enum.filter(items, &boolean_match?(value_at(&1, field), expected))}
+        end
+    end
+  end
+
+  defp apply_filter(items, params, {:string, param}) do
+    apply_filter(items, params, {:string, param, param})
+  end
+
+  defp apply_filter(items, params, {:string, param, field}) do
+    case fetch_param(params, param) do
+      :missing -> {:ok, items}
+      value -> {:ok, Enum.filter(items, &(to_string_or_nil(value_at(&1, field)) == to_string(value)))}
+    end
+  end
+
+  defp apply_filter(items, params, {:enum, param, values}) do
+    apply_filter(items, params, {:enum, param, param, values})
+  end
+
+  defp apply_filter(items, params, {:enum, param, field, values}) do
+    case fetch_param(params, param) do
+      :missing ->
+        {:ok, items}
+
+      value ->
+        value = to_string(value)
+
+        if value in values do
+          {:ok, Enum.filter(items, &(to_string_or_nil(value_at(&1, field)) == value))}
+        else
+          invalid("Invalid enum value", param)
+        end
+    end
+  end
+
+  defp apply_filter(items, params, {:string_in, param, field, opts}) do
+    case fetch_param(params, param) do
+      :missing ->
+        {:ok, items}
+
+      value ->
+        with {:ok, values} <- normalize_string_list(value, param),
+             :ok <- validate_max_count(values, Keyword.get(opts, :max), param) do
+          {:ok, Enum.filter(items, &(to_string_or_nil(value_at(&1, field)) in values))}
+        end
+    end
+  end
+
+  defp apply_filter(items, params, {:nested_enum, path, values}) do
+    case fetch_param(params, path) do
+      :missing ->
+        {:ok, items}
+
+      value ->
+        value = to_string(value)
+
+        if value in values do
+          {:ok, Enum.filter(items, &(to_string_or_nil(value_at(&1, path)) == value))}
+        else
+          invalid("Invalid enum value", path)
+        end
+    end
+  end
+
+  defp apply_filter(items, params, {:nested_string, path}) do
+    case fetch_param(params, path) do
+      :missing -> {:ok, items}
+      value -> {:ok, Enum.filter(items, &(to_string_or_nil(value_at(&1, path)) == to_string(value)))}
+    end
+  end
+
+  defp apply_filter(items, params, {:created, field}) do
+    case fetch_param(params, :created) do
+      :missing -> {:ok, items}
+      value -> filter_created(items, value, field)
+    end
+  end
+
+  defp filter_created(items, value, field) when is_map(value) do
+    Enum.reduce_while(value, {:ok, items}, fn {operator, raw_value}, {:ok, acc} ->
+      operator = normalize_operator(operator)
+
+      with :ok <- validate_operator(operator),
+           {:ok, timestamp} <- parse_integer(raw_value, [:created, operator]) do
+        {:cont, {:ok, Enum.filter(acc, &created_match?(value_at(&1, field), operator, timestamp))}}
+      else
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
+  end
+
+  defp filter_created(items, value, field) do
+    with {:ok, timestamp} <- parse_integer(value, :created) do
+      {:ok, Enum.filter(items, &(value_at(&1, field) == timestamp))}
+    end
+  end
+
+  defp created_match?(created, :gt, timestamp), do: created > timestamp
+  defp created_match?(created, :gte, timestamp), do: created >= timestamp
+  defp created_match?(created, :lt, timestamp), do: created < timestamp
+  defp created_match?(created, :lte, timestamp), do: created <= timestamp
+
+  defp parse_boolean(true, _param), do: {:ok, true}
+  defp parse_boolean(false, _param), do: {:ok, false}
+  defp parse_boolean("true", _param), do: {:ok, true}
+  defp parse_boolean("false", _param), do: {:ok, false}
+  defp parse_boolean(_value, param), do: invalid("Invalid boolean value", param)
+
+  defp boolean_match?(value, expected) do
+    case parse_boolean(value, nil) do
+      {:ok, actual} -> actual == expected
+      {:error, _error} -> false
+    end
+  end
+
+  defp normalize_string_list(value, param) when is_list(value) do
+    {:ok, Enum.map(value, &to_string/1)}
+    |> reject_empty_list(param)
+  end
+
+  defp normalize_string_list(value, param) when is_map(value) do
+    if indexed_map?(value) do
+      values =
+        value
+        |> Enum.sort_by(fn {index, _value} -> String.to_integer(to_string(index)) end)
+        |> Enum.map(fn {_index, entry} -> to_string(entry) end)
+
+      {:ok, values}
+      |> reject_empty_list(param)
+    else
+      invalid("Invalid array value", param)
+    end
+  end
+
+  defp normalize_string_list(value, param) when is_binary(value) do
+    {:ok, [value]}
+    |> reject_empty_list(param)
+  end
+
+  defp normalize_string_list(_value, param), do: invalid("Invalid array value", param)
+
+  defp reject_empty_list({:ok, []}, param), do: invalid("Invalid array value", param)
+  defp reject_empty_list(result, _param), do: result
+
+  defp validate_max_count(_values, nil, _param), do: :ok
+
+  defp validate_max_count(values, max, _param) when length(values) <= max, do: :ok
+
+  defp validate_max_count(_values, max, param) do
+    {:error, Error.invalid_request("You can specify up to #{max} values", format_param(param))}
+  end
+
+  defp parse_integer(value, _param) when is_integer(value), do: {:ok, value}
+
+  defp parse_integer(value, param) when is_binary(value) do
+    case Integer.parse(value) do
+      {integer, ""} -> {:ok, integer}
+      _ -> invalid("Invalid integer value", param)
+    end
+  end
+
+  defp parse_integer(_value, param), do: invalid("Invalid integer value", param)
+
+  defp validate_operator(operator) when operator in @range_operators, do: :ok
+  defp validate_operator(operator), do: invalid("Received unknown parameter", [:created, operator])
+
+  defp normalize_operator(operator) when is_atom(operator), do: operator
+
+  defp normalize_operator(operator) when is_binary(operator) do
+    case operator do
+      "gt" -> :gt
+      "gte" -> :gte
+      "lt" -> :lt
+      "lte" -> :lte
+      other -> other
+    end
+  end
+
+  defp present?(params, key), do: fetch_param(params, key) != :missing
+
+  defp fetch_param(params, [key | rest]) do
+    case fetch_param(params, key) do
+      :missing -> :missing
+      value when rest == [] -> value
+      value when is_map(value) -> fetch_param(value, rest)
+      _value -> :missing
+    end
+  end
+
+  defp fetch_param(params, key) when is_map(params) and is_atom(key) do
+    cond do
+      Map.has_key?(params, key) -> Map.get(params, key)
+      Map.has_key?(params, Atom.to_string(key)) -> Map.get(params, Atom.to_string(key))
+      true -> :missing
+    end
+  end
+
+  defp value_at(item, [key | rest]) do
+    case value_at(item, key) do
+      nil -> nil
+      value when rest == [] -> value
+      value when is_map(value) -> value_at(value, rest)
+      _value -> nil
+    end
+  end
+
+  defp value_at(item, key) when is_map(item) and is_atom(key) do
+    cond do
+      Map.has_key?(item, key) -> Map.get(item, key)
+      Map.has_key?(item, Atom.to_string(key)) -> Map.get(item, Atom.to_string(key))
+      true -> nil
+    end
+  end
+
+  defp to_string_or_nil(nil), do: nil
+  defp to_string_or_nil(value), do: to_string(value)
+
+  defp indexed_map?(value) do
+    Enum.all?(Map.keys(value), fn key ->
+      case Integer.parse(to_string(key)) do
+        {_integer, ""} -> true
+        _other -> false
+      end
+    end)
+  end
+
+  defp strip_data_prefix("data." <> rest), do: rest
+  defp strip_data_prefix(path), do: path
+
+  defp invalid(message, param), do: {:error, Error.invalid_request(message, format_param(param))}
+
+  defp format_param(path) when is_list(path) do
+    [root | rest] = Enum.map(path, &to_string/1)
+    root <> Enum.map_join(rest, "", &"[#{&1}]")
+  end
+
+  defp format_param(param), do: to_string(param)
+end

--- a/lib/paper_tiger/resources/price.ex
+++ b/lib/paper_tiger/resources/price.ex
@@ -31,6 +31,7 @@ defmodule PaperTiger.Resources.Price do
 
   import PaperTiger.Resource
 
+  alias PaperTiger.ListFilters
   alias PaperTiger.Store.Plans
   alias PaperTiger.Store.Prices
 
@@ -150,9 +151,30 @@ defmodule PaperTiger.Resources.Price do
   def list(conn) do
     pagination_opts = parse_pagination_params(conn.params)
 
-    result = Prices.list(pagination_opts)
+    Prices.list_namespace(PaperTiger.Connect.storage_namespace())
+    |> ListFilters.apply(conn.params, [
+      {:boolean, :active},
+      {:created, :created},
+      {:string, :currency},
+      {:string_in, :lookup_keys, :lookup_key, max: 10},
+      {:string, :product},
+      {:nested_enum, [:recurring, :interval], ["day", "week", "month", "year"]},
+      {:nested_string, [:recurring, :meter]},
+      {:nested_enum, [:recurring, :usage_type], ["licensed", "metered"]},
+      {:enum, :type, ["one_time", "recurring"]}
+    ])
+    |> case do
+      {:ok, prices} ->
+        result =
+          prices
+          |> PaperTiger.List.paginate(Map.put(pagination_opts, :url, "/v1/prices"))
+          |> ListFilters.expand_page(conn.params)
 
-    json_response(conn, 200, result)
+        json_response(conn, 200, result)
+
+      {:error, error} ->
+        error_response(conn, error)
+    end
   end
 
   defp build_price(params) do
@@ -165,10 +187,11 @@ defmodule PaperTiger.Resources.Price do
     recurring = build_recurring(Map.get(params, :recurring))
 
     %{
-      active: Map.get(params, :active, true),
+      active: to_boolean(Map.get(params, :active, true)),
       billing_scheme: Map.get(params, :billing_scheme, "per_unit"),
       created: PaperTiger.now(),
       currency: Map.get(params, :currency),
+      custom_unit_amount: Map.get(params, :custom_unit_amount),
       id: generate_id("price", Map.get(params, :id)),
       livemode: false,
       lookup_key: Map.get(params, :lookup_key),
@@ -199,13 +222,21 @@ defmodule PaperTiger.Resources.Price do
     interval = Map.get(recurring, :interval) || Map.get(recurring, "interval")
     interval_count = Map.get(recurring, :interval_count) || Map.get(recurring, "interval_count")
 
-    recurring_map = %{interval: interval}
+    %{
+      aggregate_usage: Map.get(recurring, :aggregate_usage) || Map.get(recurring, "aggregate_usage"),
+      interval: interval,
+      interval_count: if(interval_count, do: to_integer(interval_count), else: 1),
+      meter: Map.get(recurring, :meter) || Map.get(recurring, "meter"),
+      trial_period_days: get_recurring_integer(recurring, :trial_period_days),
+      usage_type: Map.get(recurring, :usage_type) || Map.get(recurring, "usage_type") || "licensed"
+    }
+  end
 
-    # Only include interval_count if provided (it's optional per Stripe spec)
-    if interval_count do
-      Map.put(recurring_map, :interval_count, interval_count)
-    else
-      recurring_map
+  defp get_recurring_integer(recurring, key) do
+    value = Map.get(recurring, key) || Map.get(recurring, Atom.to_string(key))
+
+    if !is_nil(value) do
+      to_integer(value)
     end
   end
 

--- a/lib/paper_tiger/resources/product.ex
+++ b/lib/paper_tiger/resources/product.ex
@@ -26,6 +26,7 @@ defmodule PaperTiger.Resources.Product do
 
   import PaperTiger.Resource
 
+  alias PaperTiger.ListFilters
   alias PaperTiger.Store.Products
 
   @doc """
@@ -143,9 +144,26 @@ defmodule PaperTiger.Resources.Product do
   def list(conn) do
     pagination_opts = parse_pagination_params(conn.params)
 
-    result = Products.list(pagination_opts)
+    with :ok <- ListFilters.reject_combination(conn.params, :ids, [:starting_after, :ending_before]),
+         {:ok, products} <-
+           Products.list_namespace(PaperTiger.Connect.storage_namespace())
+           |> ListFilters.apply(conn.params, [
+             {:boolean, :active},
+             {:created, :created},
+             {:string_in, :ids, :id, []},
+             {:boolean, :shippable},
+             {:string, :url}
+           ]) do
+      result =
+        products
+        |> PaperTiger.List.paginate(Map.put(pagination_opts, :url, "/v1/products"))
+        |> ListFilters.expand_page(conn.params)
 
-    json_response(conn, 200, result)
+      json_response(conn, 200, result)
+    else
+      {:error, error} ->
+        error_response(conn, error)
+    end
   end
 
   ## Private Functions
@@ -153,26 +171,32 @@ defmodule PaperTiger.Resources.Product do
   defp build_product(params) do
     # Additional fields
     %{
-      active: Map.get(params, :active, true),
+      active: to_boolean(Map.get(params, :active, true)),
       attributes: Map.get(params, :attributes, []),
       caption: Map.get(params, :caption),
       created: PaperTiger.now(),
+      default_price: Map.get(params, :default_price),
       description: Map.get(params, :description),
       id: generate_id("prod", Map.get(params, :id)),
       images: Map.get(params, :images, []),
       livemode: false,
+      marketing_features: Map.get(params, :marketing_features, []),
       metadata: Map.get(params, :metadata, %{}),
       name: Map.get(params, :name),
       object: "product",
       package_dimensions: Map.get(params, :package_dimensions),
-      shippable: Map.get(params, :shippable),
+      shippable: maybe_boolean(Map.get(params, :shippable)),
       statement_descriptor: Map.get(params, :statement_descriptor),
+      tax_code: Map.get(params, :tax_code),
       type: "service",
       unit_label: Map.get(params, :unit_label),
       updated: PaperTiger.now(),
       url: Map.get(params, :url)
     }
   end
+
+  defp maybe_boolean(nil), do: nil
+  defp maybe_boolean(value), do: to_boolean(value)
 
   defp maybe_expand(product, params) do
     expand_params = parse_expand_params(params)

--- a/lib/paper_tiger/resources/refund.ex
+++ b/lib/paper_tiger/resources/refund.ex
@@ -30,7 +30,9 @@ defmodule PaperTiger.Resources.Refund do
   import PaperTiger.Resource
 
   alias PaperTiger.BalanceTransactionHelper
+  alias PaperTiger.ListFilters
   alias PaperTiger.Store.Charges
+  alias PaperTiger.Store.PaymentIntents
   alias PaperTiger.Store.Refunds
 
   @doc """
@@ -49,9 +51,12 @@ defmodule PaperTiger.Resources.Refund do
   @spec create(Plug.Conn.t()) :: Plug.Conn.t()
   def create(conn) do
     with {:ok, _params} <- validate_params(conn.params, [:charge]),
-         refund = build_refund(conn.params),
+         {:ok, charge} <- fetch_refundable_charge(conn.params),
+         {:ok, amount} <- resolve_refund_amount(conn.params, charge),
+         refund = build_refund(conn.params, charge, amount),
          {:ok, refund} <- Refunds.insert(refund),
-         {:ok, refund} <- create_balance_transaction(refund) do
+         {:ok, refund} <- create_balance_transaction(refund, charge),
+         {:ok, _charge} <- apply_refund_to_charge(charge, refund) do
       maybe_store_idempotency(conn, refund)
 
       refund
@@ -63,6 +68,12 @@ defmodule PaperTiger.Resources.Refund do
           conn,
           PaperTiger.Error.invalid_request("Missing required parameter", field)
         )
+
+      {:error, :charge_not_found, charge_id} ->
+        error_response(conn, PaperTiger.Error.not_found("charge", charge_id))
+
+      {:error, :invalid_amount, message} ->
+        error_response(conn, PaperTiger.Error.invalid_request(message, "amount"))
     end
   end
 
@@ -70,16 +81,8 @@ defmodule PaperTiger.Resources.Refund do
   # Get the original charge for fee calculation
   ## Private Functions
 
-  defp create_balance_transaction(refund) do
-    charge_id = refund[:charge] || refund["charge"]
-    # Additional fields
-    original_charge =
-      case Charges.get(charge_id) do
-        {:ok, charge} -> charge
-        _ -> %{amount: 0}
-      end
-
-    {:ok, txn_id} = BalanceTransactionHelper.create_for_refund(refund, original_charge)
+  defp create_balance_transaction(refund, charge) do
+    {:ok, txn_id} = BalanceTransactionHelper.create_for_refund(refund, charge)
     updated = Map.put(refund, :balance_transaction, txn_id)
     Refunds.update(updated)
   end
@@ -148,28 +151,119 @@ defmodule PaperTiger.Resources.Refund do
   def list(conn) do
     pagination_opts = parse_pagination_params(conn.params)
 
-    result = Refunds.list(pagination_opts)
+    with :ok <- validate_list_reference(:charge, conn.params),
+         :ok <- validate_list_reference(:payment_intent, conn.params),
+         {:ok, refunds} <-
+           Refunds.list_namespace(PaperTiger.Connect.storage_namespace())
+           |> ListFilters.apply(conn.params, [
+             {:string, :charge},
+             {:created, :created},
+             {:string, :payment_intent},
+             {:string, :status}
+           ]) do
+      result =
+        refunds
+        |> PaperTiger.List.paginate(Map.put(pagination_opts, :url, "/v1/refunds"))
+        |> ListFilters.expand_page(conn.params)
 
-    json_response(conn, 200, result)
+      json_response(conn, 200, result)
+    else
+      {:error, error} ->
+        error_response(conn, error)
+    end
   end
 
-  defp build_refund(params) do
+  defp build_refund(params, charge, amount) do
     %{
-      amount: get_integer(params, :amount),
+      amount: amount,
       balance_transaction: nil,
-      charge: Map.get(params, :charge),
+      charge: charge.id,
       created: PaperTiger.now(),
-      currency: Map.get(params, :currency, "usd"),
+      currency: Map.get(params, :currency, charge.currency),
       failure_code: nil,
       failure_reason: nil,
       id: generate_id("re"),
       livemode: false,
       metadata: Map.get(params, :metadata, %{}),
       object: "refund",
+      payment_intent: Map.get(charge, :payment_intent),
       reason: Map.get(params, :reason),
       receipt_number: Map.get(params, :receipt_number),
+      source_transfer_reversal: nil,
       status: Map.get(params, :status, "succeeded")
     }
+  end
+
+  defp fetch_refundable_charge(params) do
+    charge_id = Map.get(params, :charge)
+
+    case Charges.get(charge_id) do
+      {:ok, charge} -> {:ok, charge}
+      {:error, :not_found} -> {:error, :charge_not_found, charge_id}
+    end
+  end
+
+  defp resolve_refund_amount(params, charge) do
+    refundable = refundable_amount(charge)
+    refunded = Map.get(charge, :amount_refunded, 0)
+    remaining = refundable - refunded
+
+    amount =
+      case get_optional_integer(params, :amount) do
+        nil -> remaining
+        value -> value
+      end
+
+    cond do
+      amount <= 0 ->
+        {:error, :invalid_amount, "Amount must be greater than zero"}
+
+      amount > remaining ->
+        {:error, :invalid_amount, "Amount exceeds the unrefunded charge amount"}
+
+      true ->
+        {:ok, amount}
+    end
+  end
+
+  defp apply_refund_to_charge(charge, refund) do
+    amount_refunded = Map.get(charge, :amount_refunded, 0) + refund.amount
+
+    updated =
+      charge
+      |> Map.put(:amount_refunded, amount_refunded)
+      |> Map.put(:refunded, amount_refunded >= refundable_amount(charge))
+
+    Charges.update(updated)
+  end
+
+  defp validate_list_reference(param, params) do
+    case Map.get(params, param) do
+      nil ->
+        :ok
+
+      id ->
+        param
+        |> store_for_list_reference()
+        |> then(& &1.get(id))
+        |> case do
+          {:ok, _resource} -> :ok
+          {:error, :not_found} -> {:error, PaperTiger.Error.not_found(resource_name(param), id)}
+        end
+    end
+  end
+
+  defp store_for_list_reference(:charge), do: Charges
+  defp store_for_list_reference(:payment_intent), do: PaymentIntents
+
+  defp resource_name(:charge), do: "charge"
+  defp resource_name(:payment_intent), do: "payment_intent"
+
+  defp refundable_amount(charge) do
+    case Map.get(charge, :amount_captured) do
+      amount when is_integer(amount) and amount > 0 -> amount
+      _ -> Map.get(charge, :amount, 0)
+    end
   end
 
   defp maybe_expand(refund, params) do

--- a/test/paper_tiger/contract_test.exs
+++ b/test/paper_tiger/contract_test.exs
@@ -741,6 +741,101 @@ defmodule PaperTiger.ContractTest do
     end
   end
 
+  describe "Product and Price List Filter Validation" do
+    @tag :contract
+    test "lists products with documented filters" do
+      suffix = unique_suffix()
+      url = "https://example.com/paper-tiger-product-filter-#{suffix}"
+
+      {:ok, target} =
+        TestClient.create_product(%{
+          "name" => "PT Product Filter Target #{suffix}",
+          "shippable" => true,
+          "url" => url
+        })
+
+      {:ok, inactive} =
+        TestClient.create_product(%{
+          "active" => false,
+          "name" => "PT Product Filter Inactive #{suffix}",
+          "shippable" => false
+        })
+
+      {:ok, active_list} =
+        TestClient.list_products(%{
+          "active" => true,
+          "ids" => [target["id"], inactive["id"]],
+          "limit" => 10
+        })
+
+      assert active_list["object"] == "list"
+      assert Enum.map(active_list["data"], & &1["id"]) == [target["id"]]
+
+      {:ok, url_list} = TestClient.list_products(%{"limit" => 10, "url" => url})
+
+      assert Enum.map(url_list["data"], & &1["id"]) == [target["id"]]
+    end
+
+    @tag :contract
+    test "lists prices with documented filters and product expansion" do
+      suffix = unique_suffix()
+      lookup_key = "pt_filter_#{suffix}"
+
+      {:ok, product} = TestClient.create_product(%{"name" => "PT Price Filter Product #{suffix}"})
+
+      {:ok, target} =
+        TestClient.create_price(%{
+          "currency" => "usd",
+          "lookup_key" => lookup_key,
+          "product" => product["id"],
+          "recurring" => %{"interval" => "month", "usage_type" => "licensed"},
+          "unit_amount" => 1_200
+        })
+
+      {:ok, inactive_once} =
+        TestClient.create_price(%{
+          "active" => false,
+          "currency" => "eur",
+          "product" => product["id"],
+          "unit_amount" => 500
+        })
+
+      {:ok, recurring_list} =
+        TestClient.list_prices(%{
+          "active" => true,
+          "currency" => "usd",
+          "limit" => 10,
+          "lookup_keys" => [lookup_key],
+          "product" => product["id"],
+          "recurring" => %{"interval" => "month", "usage_type" => "licensed"},
+          "type" => "recurring"
+        })
+
+      assert Enum.map(recurring_list["data"], & &1["id"]) == [target["id"]]
+
+      {:ok, inactive_list} =
+        TestClient.list_prices(%{
+          "active" => false,
+          "limit" => 10,
+          "product" => product["id"],
+          "type" => "one_time"
+        })
+
+      assert Enum.map(inactive_list["data"], & &1["id"]) == [inactive_once["id"]]
+
+      {:ok, expanded_list} =
+        TestClient.list_prices(%{
+          "expand" => ["data.product"],
+          "limit" => 10,
+          "product" => product["id"]
+        })
+
+      expanded_target = Enum.find(expanded_list["data"], &(&1["id"] == target["id"]))
+      assert expanded_target["product"]["id"] == product["id"]
+      assert expanded_target["product"]["object"] == "product"
+    end
+  end
+
   describe "PaymentIntent Structure Validation" do
     @tag :contract
     test "creates payment intent with required fields" do
@@ -875,6 +970,24 @@ defmodule PaperTiger.ContractTest do
 
       assert refund["object"] == "refund"
       assert refund["charge"] == charge["id"]
+      assert refund["amount"] == charge["amount"]
+    end
+
+    @tag :contract
+    test "lists refunds filtered by charge" do
+      charge_params = %{
+        "amount" => 2400,
+        "currency" => "usd",
+        "source" => "tok_visa"
+      }
+
+      {:ok, charge} = TestClient.create_charge(charge_params)
+      {:ok, refund} = TestClient.create_refund(%{"amount" => 600, "charge" => charge["id"]})
+
+      {:ok, refunds} = TestClient.list_refunds(%{"charge" => charge["id"], "limit" => 10})
+
+      assert refunds["object"] == "list"
+      assert Enum.map(refunds["data"], & &1["id"]) == [refund["id"]]
     end
   end
 
@@ -1885,6 +1998,10 @@ defmodule PaperTiger.ContractTest do
     # Products can't be deleted in Stripe if they have prices
     # Just leave them - they're in test mode anyway
     :ok
+  end
+
+  defp unique_suffix do
+    "#{System.system_time(:nanosecond)}_#{System.unique_integer([:positive])}"
   end
 
   defp eventually_search_customer(query, customer_id) do

--- a/test/paper_tiger/resources/product_price_test.exs
+++ b/test/paper_tiger/resources/product_price_test.exs
@@ -118,8 +118,8 @@ defmodule PaperTiger.Resources.ProductPriceTest do
   defp normalize_int(other), do: other
 
   # Helper to create a product
-  defp create_product(name, metadata \\ %{}) do
-    conn = request(:post, "/v1/products", %{"metadata" => metadata, "name" => name})
+  defp create_product(name, metadata \\ %{}, attrs \\ %{}) do
+    conn = request(:post, "/v1/products", Map.merge(%{"metadata" => metadata, "name" => name}, attrs))
     assert conn.status == 200
     json_response(conn)
   end
@@ -603,6 +603,70 @@ defmodule PaperTiger.Resources.ProductPriceTest do
       page2 = json_response(conn2)
       assert length(page2["data"]) == 1
       assert page2["has_more"] == true
+    end
+
+    test "filters products by active, shippable, url, ids, and created range" do
+      target =
+        create_product("Physical Active", %{}, %{
+          "shippable" => true,
+          "url" => "https://example.com/physical"
+        })
+
+      inactive =
+        create_product("Inactive Physical", %{}, %{
+          "active" => false,
+          "shippable" => true,
+          "url" => "https://example.com/inactive"
+        })
+
+      digital =
+        create_product("Digital Active", %{}, %{
+          "shippable" => false,
+          "url" => "https://example.com/digital"
+        })
+
+      conn =
+        request(
+          :get,
+          "/v1/products?active=true&shippable=true&url=https%3A%2F%2Fexample.com%2Fphysical&limit=10"
+        )
+
+      assert conn.status == 200
+      assert json_response(conn)["data"] |> Enum.map(& &1["id"]) == [target["id"]]
+
+      conn = request(:get, "/v1/products?active=false&limit=10")
+      assert conn.status == 200
+      assert json_response(conn)["data"] |> Enum.map(& &1["id"]) == [inactive["id"]]
+
+      conn =
+        request(
+          :get,
+          "/v1/products?ids%5B%5D=#{target["id"]}&ids%5B%5D=#{digital["id"]}&limit=10"
+        )
+
+      assert conn.status == 200
+
+      assert json_response(conn)["data"] |> Enum.map(& &1["id"]) |> Enum.sort() ==
+               [digital["id"], target["id"]] |> Enum.sort()
+
+      created = target["created"]
+      conn = request(:get, "/v1/products?created%5Bgte%5D=#{created}&created%5Blte%5D=#{created}&limit=10")
+
+      assert conn.status == 200
+      assert Enum.all?(json_response(conn)["data"], &(&1["created"] == created))
+    end
+
+    test "rejects product ids filter with cursors" do
+      product = create_product("Cursor Conflict")
+
+      conn =
+        request(
+          :get,
+          "/v1/products?ids%5B%5D=#{product["id"]}&starting_after=#{product["id"]}"
+        )
+
+      assert conn.status == 400
+      assert json_response(conn)["error"]["param"] == "starting_after"
     end
   end
 
@@ -1146,10 +1210,92 @@ defmodule PaperTiger.Resources.ProductPriceTest do
       create_price(product1["id"], "usd", 2000)
       create_price(product2["id"], "usd", 3000)
 
-      # List all prices
-      conn_all = request(:get, "/v1/prices")
-      all_prices = json_response(conn_all)["data"]
-      assert length(all_prices) == 3
+      conn = request(:get, "/v1/prices?product=#{product1["id"]}&limit=10")
+
+      assert conn.status == 200
+      prices = json_response(conn)["data"]
+      assert length(prices) == 2
+      assert Enum.all?(prices, &(&1["product"] == product1["id"]))
+    end
+
+    test "filters prices by active, currency, type, lookup keys, recurring fields, and created range" do
+      product1 = create_product("Filtered Product A")
+      product2 = create_product("Filtered Product B")
+
+      target =
+        request(:post, "/v1/prices", %{
+          "currency" => "usd",
+          "lookup_key" => "basic_monthly",
+          "product" => product1["id"],
+          "recurring" => %{"interval" => "month", "usage_type" => "licensed"},
+          "unit_amount" => "1200"
+        })
+        |> json_response()
+
+      _metered =
+        request(:post, "/v1/prices", %{
+          "currency" => "usd",
+          "lookup_key" => "metered_weekly",
+          "product" => product1["id"],
+          "recurring" => %{"interval" => "week", "meter" => "mtr_test", "usage_type" => "metered"},
+          "unit_amount" => "300"
+        })
+        |> json_response()
+
+      inactive_one_time =
+        request(:post, "/v1/prices", %{
+          "active" => false,
+          "currency" => "eur",
+          "lookup_key" => "inactive_once",
+          "product" => product2["id"],
+          "unit_amount" => "5000"
+        })
+        |> json_response()
+
+      conn =
+        request(
+          :get,
+          "/v1/prices?active=true&currency=usd&type=recurring&lookup_keys%5B%5D=basic_monthly&recurring%5Binterval%5D=month&recurring%5Busage_type%5D=licensed&limit=10"
+        )
+
+      assert conn.status == 200
+      assert json_response(conn)["data"] |> Enum.map(& &1["id"]) == [target["id"]]
+
+      conn = request(:get, "/v1/prices?recurring%5Bmeter%5D=mtr_test&limit=10")
+      assert conn.status == 200
+      assert json_response(conn)["data"] |> Enum.map(& &1["lookup_key"]) == ["metered_weekly"]
+
+      conn =
+        request(:get, "/v1/prices?active=false&type=one_time&created%5Blte%5D=#{inactive_one_time["created"]}&limit=10")
+
+      assert conn.status == 200
+      assert json_response(conn)["data"] |> Enum.map(& &1["id"]) == [inactive_one_time["id"]]
+    end
+
+    test "expands product in price list data" do
+      product = create_product("Expandable Product")
+      price = create_price(product["id"], "usd", 1500)
+
+      conn = request(:get, "/v1/prices?expand%5B%5D=data.product&limit=10")
+
+      assert conn.status == 200
+
+      expanded =
+        conn
+        |> json_response()
+        |> Map.fetch!("data")
+        |> Enum.find(&(&1["id"] == price["id"]))
+        |> Map.fetch!("product")
+
+      assert expanded["id"] == product["id"]
+      assert expanded["object"] == "product"
+    end
+
+    test "rejects invalid price list filter values" do
+      conn = request(:get, "/v1/prices?type=usage")
+
+      assert conn.status == 400
+      assert json_response(conn)["error"]["param"] == "type"
     end
   end
 

--- a/test/paper_tiger/resources/refund_list_test.exs
+++ b/test/paper_tiger/resources/refund_list_test.exs
@@ -1,0 +1,149 @@
+defmodule PaperTiger.Resources.RefundListTest do
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
+
+  alias PaperTiger.Router
+
+  setup :checkout_paper_tiger
+
+  defp request(method, path, params) do
+    path = maybe_put_query_string(method, path, params)
+    body = if method in [:get, :delete], do: "", else: params
+
+    Plug.Test.conn(method, path, body)
+    |> Plug.Conn.put_req_header("content-type", "application/json")
+    |> Plug.Conn.put_req_header("authorization", "Bearer sk_test_refund_list_key")
+    |> put_sandbox_headers()
+    |> Router.call([])
+  end
+
+  defp maybe_put_query_string(method, path, params) when method in [:get, :delete] and map_size(params) > 0 do
+    "#{path}?#{URI.encode_query(params)}"
+  end
+
+  defp maybe_put_query_string(_method, path, _params), do: path
+
+  defp put_sandbox_headers(conn) do
+    Enum.reduce(sandbox_headers(), conn, fn {key, value}, acc ->
+      Plug.Conn.put_req_header(acc, key, value)
+    end)
+  end
+
+  defp json_response(conn), do: Jason.decode!(conn.resp_body)
+
+  describe "GET /v1/refunds" do
+    test "defaults to remaining charge amount and updates charge refund state" do
+      charge = create_charge(2_000)
+
+      partial = create_refund(charge["id"], 600)
+
+      assert partial["amount"] == 600
+
+      partially_refunded_charge =
+        request(:get, "/v1/charges/#{charge["id"]}", %{})
+        |> json_response()
+
+      assert partially_refunded_charge["amount_refunded"] == 600
+      assert partially_refunded_charge["refunded"] == false
+
+      full_conn = request(:post, "/v1/refunds", %{"charge" => charge["id"]})
+
+      assert full_conn.status == 200
+      final_refund = json_response(full_conn)
+      assert final_refund["amount"] == 1_400
+
+      fully_refunded_charge =
+        request(:get, "/v1/charges/#{charge["id"]}", %{})
+        |> json_response()
+
+      assert fully_refunded_charge["amount_refunded"] == 2_000
+      assert fully_refunded_charge["refunded"] == true
+
+      over_refund_conn = request(:post, "/v1/refunds", %{"amount" => 1, "charge" => charge["id"]})
+
+      assert over_refund_conn.status == 400
+      assert json_response(over_refund_conn)["error"]["param"] == "amount"
+    end
+
+    test "filters refunds by charge and created range before pagination" do
+      charge1 = create_charge(2_000)
+      charge2 = create_charge(3_000)
+
+      refund1 = create_refund(charge1["id"], 500)
+      refund2 = create_refund(charge2["id"], 700)
+
+      conn =
+        request(:get, "/v1/refunds", %{
+          "charge" => charge1["id"],
+          "created[gte]" => refund1["created"],
+          "created[lte]" => refund1["created"],
+          "limit" => 10
+        })
+
+      assert conn.status == 200
+      assert json_response(conn)["data"] |> Enum.map(& &1["id"]) == [refund1["id"]]
+
+      conn = request(:get, "/v1/refunds", %{"charge" => charge2["id"], "limit" => 10})
+
+      assert conn.status == 200
+      assert json_response(conn)["data"] |> Enum.map(& &1["id"]) == [refund2["id"]]
+    end
+
+    test "filters refunds by payment intent" do
+      pi =
+        request(:post, "/v1/payment_intents", %{
+          "amount" => 2_500,
+          "currency" => "usd",
+          "payment_method" => "pm_card_visa"
+        })
+        |> json_response()
+
+      confirmed =
+        request(:post, "/v1/payment_intents/#{pi["id"]}/confirm", %{})
+        |> json_response()
+
+      refund = create_refund(confirmed["latest_charge"], 400)
+
+      conn = request(:get, "/v1/refunds", %{"limit" => 10, "payment_intent" => pi["id"]})
+
+      assert conn.status == 200
+      assert json_response(conn)["data"] |> Enum.map(& &1["id"]) == [refund["id"]]
+    end
+
+    test "returns Stripe-shaped errors for non-existent list filter references" do
+      conn = request(:get, "/v1/refunds", %{"charge" => "ch_missing"})
+
+      assert conn.status == 404
+      assert json_response(conn)["error"]["param"] == "charge"
+
+      conn = request(:get, "/v1/refunds", %{"payment_intent" => "pi_missing"})
+
+      assert conn.status == 404
+      assert json_response(conn)["error"]["param"] == "intent"
+    end
+  end
+
+  defp create_charge(amount) do
+    conn =
+      request(:post, "/v1/charges", %{
+        "amount" => amount,
+        "currency" => "usd",
+        "source" => "tok_visa"
+      })
+
+    assert conn.status == 200
+    json_response(conn)
+  end
+
+  defp create_refund(charge_id, amount) do
+    conn =
+      request(:post, "/v1/refunds", %{
+        "amount" => amount,
+        "charge" => charge_id
+      })
+
+    assert conn.status == 200
+    json_response(conn)
+  end
+end

--- a/test/support/test_client.ex
+++ b/test/support/test_client.ex
@@ -384,6 +384,19 @@ defmodule PaperTiger.TestClient do
     end
   end
 
+  @doc """
+  Lists products.
+  """
+  def list_products(params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        list_products_real(params)
+
+      :paper_tiger ->
+        list_products_mock(params)
+    end
+  end
+
   ## Price Operations
 
   @doc """
@@ -409,6 +422,19 @@ defmodule PaperTiger.TestClient do
 
       :paper_tiger ->
         get_price_mock(price_id)
+    end
+  end
+
+  @doc """
+  Lists prices.
+  """
+  def list_prices(params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        list_prices_real(params)
+
+      :paper_tiger ->
+        list_prices_mock(params)
     end
   end
 
@@ -945,6 +971,19 @@ defmodule PaperTiger.TestClient do
 
       :paper_tiger ->
         get_refund_mock(refund_id)
+    end
+  end
+
+  @doc """
+  Lists refunds.
+  """
+  def list_refunds(params \\ %{}) do
+    case mode() do
+      :real_stripe ->
+        list_refunds_real(params)
+
+      :paper_tiger ->
+        list_refunds_mock(params)
     end
   end
 
@@ -1560,7 +1599,7 @@ defmodule PaperTiger.TestClient do
   end
 
   defp stripe_request(method, path, params \\ %{}) do
-    url = "https://api.stripe.com#{path}"
+    url = stripe_request_url(method, path, params)
 
     headers = [
       {"authorization", "Bearer #{System.get_env("STRIPE_API_KEY")}"},
@@ -1570,16 +1609,10 @@ defmodule PaperTiger.TestClient do
     req_opts =
       case method do
         :get ->
-          [
-            headers: headers,
-            params: params
-          ]
+          [headers: headers]
 
         :delete ->
-          [
-            headers: headers,
-            params: params
-          ]
+          [headers: headers]
 
         :post ->
           [
@@ -1605,6 +1638,18 @@ defmodule PaperTiger.TestClient do
          }}
     end
   end
+
+  defp stripe_request_url(method, path, params) when method in [:get, :delete] do
+    url = "https://api.stripe.com#{path}"
+
+    if params && map_size(params) > 0 do
+      "#{url}?#{params_to_form_data(params)}"
+    else
+      url
+    end
+  end
+
+  defp stripe_request_url(_method, path, _params), do: "https://api.stripe.com#{path}"
 
   defp create_customer_real(params) do
     stripe_request(:post, "/v1/customers", params)
@@ -1813,6 +1858,10 @@ defmodule PaperTiger.TestClient do
     end
   end
 
+  defp list_products_real(params) do
+    stripe_request(:get, "/v1/products", params)
+  end
+
   defp create_price_real(params) do
     case Stripe.Price.create(normalize_params(params), stripe_opts()) do
       {:ok, price} -> {:ok, stripe_to_map(price)}
@@ -1825,6 +1874,10 @@ defmodule PaperTiger.TestClient do
       {:ok, price} -> {:ok, stripe_to_map(price)}
       {:error, error} -> {:error, stripe_error_to_map(error)}
     end
+  end
+
+  defp list_prices_real(params) do
+    stripe_request(:get, "/v1/prices", params)
   end
 
   defp create_charge_real(params) do
@@ -1906,6 +1959,10 @@ defmodule PaperTiger.TestClient do
       {:ok, refund} -> {:ok, stripe_to_map(refund)}
       {:error, error} -> {:error, stripe_error_to_map(error)}
     end
+  end
+
+  defp list_refunds_real(params) do
+    stripe_request(:get, "/v1/refunds", params)
   end
 
   defp create_checkout_session_real(params) do
@@ -2276,6 +2333,11 @@ defmodule PaperTiger.TestClient do
     handle_response(conn)
   end
 
+  defp list_products_mock(params) do
+    conn = request(:get, "/v1/products", params)
+    handle_response(conn)
+  end
+
   defp create_price_mock(params) do
     conn = request(:post, "/v1/prices", params)
     handle_response(conn)
@@ -2283,6 +2345,11 @@ defmodule PaperTiger.TestClient do
 
   defp get_price_mock(price_id) do
     conn = request(:get, "/v1/prices/#{price_id}", %{})
+    handle_response(conn)
+  end
+
+  defp list_prices_mock(params) do
+    conn = request(:get, "/v1/prices", params)
     handle_response(conn)
   end
 
@@ -2373,6 +2440,11 @@ defmodule PaperTiger.TestClient do
 
   defp get_refund_mock(refund_id) do
     conn = request(:get, "/v1/refunds/#{refund_id}", %{})
+    handle_response(conn)
+  end
+
+  defp list_refunds_mock(params) do
+    conn = request(:get, "/v1/refunds", params)
     handle_response(conn)
   end
 


### PR DESCRIPTION
## Summary

- Add a shared `PaperTiger.ListFilters` helper for documented list endpoint filters before cursor pagination.
- Implement Product list filters for `active`, `created`, `ids[]`, `shippable`, and `url`, plus list-item expansion support.
- Implement Price list filters for `active`, `created`, `currency`, `product`, `type`, `lookup_keys[]`, and recurring child filters, including `expand[]=data.product`.
- Implement Refund list filters for `charge`, `payment_intent`, `created`, and `status`.
- Tighten Refund creation fidelity so full refunds default to the remaining charge amount, partial refunds update Charge refund state, and over-refunds fail.

Closes #85.
Closes #86.
Closes #87.

## Validation

- `mise exec -- mix test test/paper_tiger/resources/product_price_test.exs`
- `mise exec -- mix test test/paper_tiger/resources/refund_list_test.exs`
- `mise exec -- mix test test/paper_tiger/contract_test.exs:747 test/paper_tiger/contract_test.exs:783 test/paper_tiger/contract_test.exs:965 test/paper_tiger/contract_test.exs:984`
- `STRIPE_API_KEY=<test key> VALIDATE_AGAINST_STRIPE=true mise exec -- mix test test/paper_tiger/contract_test.exs:747 test/paper_tiger/contract_test.exs:783 test/paper_tiger/contract_test.exs:965 test/paper_tiger/contract_test.exs:984`
- `mise exec -- mix test`
- `mise exec -- mix dialyzer`
- `mise exec -- mix credo --strict`
- `mise exec -- mix format --check-formatted`
- `git diff --check`
