### PR TITLE
Emit PaymentMethod attach and detach webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `POST /v1/payment_methods/:id/attach` and `/detach` now emit `payment_method.attached` and `payment_method.detached` webhooks.
 - Removed unreachable invoice-proration fallback branches flagged by the Elixir `1.20.0-rc.5` type checker; generated proration lines are unchanged.
 - Webhook delivery adapter requests now carry the captured PaperTiger namespace through chaos buffering, async task delivery, retry scheduling, telemetry, and delivery-attempt updates, so host-owned durable adapters can preserve tenant context.
 - Subscription item direct store helpers now respect the active PaperTiger namespace for lookup and bulk deletion, matching the shared store isolation used by standard CRUD operations.

--- a/lib/paper_tiger/resources/payment_method.ex
+++ b/lib/paper_tiger/resources/payment_method.ex
@@ -197,6 +197,8 @@ defmodule PaperTiger.Resources.PaymentMethod do
          {:ok, customer_id} <- validate_customer_param(conn.params),
          attached = attach_to_customer(payment_method, customer_id),
          {:ok, attached} <- PaymentMethods.update(attached) do
+      :telemetry.execute([:paper_tiger, :payment_method, :attached], %{}, %{object: attached})
+
       attached
       |> maybe_expand(conn.params)
       |> then(&json_response(conn, 200, &1))
@@ -224,6 +226,8 @@ defmodule PaperTiger.Resources.PaymentMethod do
     with {:ok, payment_method} <- PaymentMethods.get(id),
          detached = detach_from_customer(payment_method),
          {:ok, detached} <- PaymentMethods.update(detached) do
+      :telemetry.execute([:paper_tiger, :payment_method, :detached], %{}, %{object: detached})
+
       detached
       |> maybe_expand(conn.params)
       |> then(&json_response(conn, 200, &1))

--- a/test/paper_tiger/webhook_collection_test.exs
+++ b/test/paper_tiger/webhook_collection_test.exs
@@ -226,6 +226,31 @@ defmodule PaperTiger.WebhookCollectionTest do
       assert delivery.event_data.object.status == "uncollectible"
       assert is_integer(delivery.event_data.object.status_transitions.marked_uncollectible_at)
     end
+
+    test "attaching a payment method triggers payment_method.attached webhook" do
+      {:ok, customer} = TestClient.create_customer(%{"email" => "pm-attached@example.com"})
+      {:ok, payment_method} = TestClient.create_payment_method(%{"type" => "card"})
+      clear_delivered_webhooks()
+
+      {:ok, attached} = TestClient.attach_payment_method(payment_method["id"], %{"customer" => customer["id"]})
+
+      [delivery] = assert_webhook_delivered("payment_method.attached")
+      assert delivery.event_data.object.id == attached["id"]
+      assert delivery.event_data.object.customer == customer["id"]
+    end
+
+    test "detaching a payment method triggers payment_method.detached webhook" do
+      {:ok, customer} = TestClient.create_customer(%{"email" => "pm-detached@example.com"})
+      {:ok, payment_method} = TestClient.create_payment_method(%{"type" => "card"})
+      {:ok, attached} = TestClient.attach_payment_method(payment_method["id"], %{"customer" => customer["id"]})
+      clear_delivered_webhooks()
+
+      {:ok, detached} = TestClient.detach_payment_method(attached["id"])
+
+      [delivery] = assert_webhook_delivered("payment_method.detached")
+      assert delivery.event_data.object.id == detached["id"]
+      assert delivery.event_data.object.customer == nil
+    end
   end
 
   describe "get_delivered_webhooks/0" do

--- a/test/support/test_client.ex
+++ b/test/support/test_client.ex
@@ -656,6 +656,19 @@ defmodule PaperTiger.TestClient do
   end
 
   @doc """
+  Detaches a payment method from its customer.
+  """
+  def detach_payment_method(payment_method_id) do
+    case mode() do
+      :real_stripe ->
+        detach_payment_method_real(payment_method_id)
+
+      :paper_tiger ->
+        detach_payment_method_mock(payment_method_id)
+    end
+  end
+
+  @doc """
   Creates a test ConfirmationToken.
   """
   def create_confirmation_token(params \\ %{}) do
@@ -1866,6 +1879,10 @@ defmodule PaperTiger.TestClient do
     end
   end
 
+  defp detach_payment_method_real(payment_method_id) do
+    stripe_request(:post, "/v1/payment_methods/#{payment_method_id}/detach")
+  end
+
   defp create_confirmation_token_real(params) do
     stripe_request(:post, "/v1/test_helpers/confirmation_tokens", params)
   end
@@ -2348,6 +2365,11 @@ defmodule PaperTiger.TestClient do
 
   defp attach_payment_method_mock(payment_method_id, params) do
     conn = request(:post, "/v1/payment_methods/#{payment_method_id}/attach", params)
+    handle_response(conn)
+  end
+
+  defp detach_payment_method_mock(payment_method_id) do
+    conn = request(:post, "/v1/payment_methods/#{payment_method_id}/detach", %{})
     handle_response(conn)
   end
 


### PR DESCRIPTION
## Summary

- Emit `payment_method.attached` after `POST /v1/payment_methods/:id/attach` successfully updates the PaymentMethod.
- Emit `payment_method.detached` after `POST /v1/payment_methods/:id/detach` successfully clears the customer.
- Add collection-mode coverage for both webhook events and a `TestClient.detach_payment_method/1` helper.

## Validation

- `mise exec -- mix test test/paper_tiger/webhook_collection_test.exs test/paper_tiger/resources/payment_method_test.exs`
- `mise exec -- mix test`
- `mise exec -- mix format --check-formatted`
- `git diff --check`
