### PR TITLE
Prepare 1.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-05-21
+
 ### Added
 
 - Optional Python SDK contract suite that drives the official `stripe` Python package against PaperTiger over local HTTP, tagged `:python_sdk` and enabled with `VALIDATE_PYTHON_SDK=true`.

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PaperTiger.MixProject do
   @moduledoc false
   use Mix.Project
 
-  @version "1.1.0"
+  @version "1.1.1"
   @url "https://github.com/EnaiaInc/paper_tiger"
   @maintainers ["Enaia Inc"]
 


### PR DESCRIPTION
## Summary

- Bump PaperTiger to 1.1.1.
- Move the current unreleased Python SDK contract-test and Stripe-fidelity fixes into the 1.1.1 changelog section.

## Notes

This prepares the package for a 1.1.1 publish after the Python SDK contract-test work merged in #95.