### PR TITLE
Fix ex_doc warnings in docs build

### DIFF
--- a/lib/paper_tiger/webhook_delivery/response.ex
+++ b/lib/paper_tiger/webhook_delivery/response.ex
@@ -1,6 +1,6 @@
 defmodule PaperTiger.WebhookDelivery.Response do
   @moduledoc """
-  The successful result of a `PaperTiger.WebhookDelivery.Adapter.deliver/1`
+  The successful result of a `c:PaperTiger.WebhookDelivery.Adapter.deliver/1`
   call.
 
   Returned inside `{:ok, %Response{}}` to signal the webhook was either

--- a/mix.exs
+++ b/mix.exs
@@ -132,6 +132,9 @@ defmodule PaperTiger.MixProject do
       main: "readme",
       source_ref: "v#{@version}",
       source_url: @url,
+      # PaperTiger.Port is internal (@moduledoc false) but mentioned in the
+      # changelog; don't autolink references to it.
+      skip_code_autolink_to: &String.match?(&1, ~r/^PaperTiger\.Port(\..*)?$/),
       extras: [
         "README.md",
         "CHANGELOG.md",


### PR DESCRIPTION
- Reference the Adapter.deliver/1 behaviour callback with the c: prefix
- Skip autolinking the hidden PaperTiger.Port module mentioned in the
  changelog via skip_code_autolink_to
