### PR TITLE
Add standalone server distribution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+_build
+deps
+doc
+.git
+.github
+.elixir_ls
+.elixir-tools
+cover
+tmp
+erl_crash.dump
+*.ez
+node_modules
+integration
+test
+examples
+docs

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,98 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - mix.exs
+      - mix.lock
+      - config/**
+      - lib/**
+      - .github/workflows/docker.yml
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: paper_tiger:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # The image is only worth publishing if a real Stripe SDK can drive it, so
+      # the smoke test exercises the round trip that stripe-mock cannot do:
+      # create a resource, then read it back.
+      - name: Smoke test
+        run: |
+          docker run -d --name pt -p 12111:12111 paper_tiger:ci
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:12111/health >/dev/null 2>&1; then break; fi
+            sleep 1
+          done
+          curl -fsS http://localhost:12111/health
+
+          id=$(curl -fsS -X POST http://localhost:12111/v1/customers \
+                 -u sk_test_ci: -d "email=ci@example.com" \
+               | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
+          echo "created $id"
+
+          curl -fsS "http://localhost:12111/v1/customers/$id" -u sk_test_ci: \
+            | python3 -c "import json,sys; assert json.load(sys.stdin)['id'] == '$id'"
+          echo "round trip ok"
+
+          curl -fsS -X POST http://localhost:12111/_config/time/advance \
+            -u sk_test_ci: -d "days=30"
+
+          docker rm -f pt
+
+      - name: Log in to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        if: github.event_name == 'push'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Push image
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Standalone server distribution. `mix release` now produces a `paper_tiger`
+  release, and a `Dockerfile` builds a container image that serves the same
+  Stripe-compatible API the library serves in-process. Any Stripe SDK in any
+  language can point its API base at it; no Elixir required on the caller's
+  side. Defaults to port 12111, matching stripe-mock, so an existing
+  stripe-mock service definition can be repointed without further changes.
+- Standalone server configuration via environment variables:
+  `PAPER_TIGER_PORT` (and `PORT`), `PAPER_TIGER_CLOCK_MODE`,
+  `PAPER_TIGER_CLOCK_MULTIPLIER`, `PAPER_TIGER_BILLING_ENGINE`, and
+  `PAPER_TIGER_LOG_LEVEL`.
+
+### Fixed
+
+- `POST /_config/time/advance` now accepts form-encoded bodies
+  (`seconds=86400`) in addition to JSON. Form encoding is what every Stripe SDK
+  emits, so time travel was previously reachable only from hand-written JSON
+  requests.
+- `GET /health` no longer requires an Authorization header. It is not a Stripe
+  endpoint, so gating it bought no fidelity while denying container runtimes and
+  load balancers their probe.
+
 ## [1.2.2] - 2026-07-08
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,66 @@
+ARG ELIXIR_VERSION=1.19.5
+ARG OTP_VERSION=28.5
+ARG DEBIAN_VERSION=bookworm-20260421-slim
+
+ARG BUILDER_IMAGE="docker.io/hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
+ARG RUNNER_IMAGE="docker.io/debian:${DEBIAN_VERSION}"
+
+FROM ${BUILDER_IMAGE} AS builder
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends build-essential ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+RUN mix local.hex --force && mix local.rebar --force
+
+ENV MIX_ENV=prod
+
+COPY mix.exs mix.lock ./
+RUN mix deps.get --only $MIX_ENV
+
+COPY config/config.exs config/prod.exs config/
+RUN mix deps.compile
+
+COPY lib lib
+COPY config/runtime.exs config/
+
+RUN mix compile
+RUN mix release
+
+FROM ${RUNNER_IMAGE} AS final
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    libncurses6 \
+    libstdc++6 \
+    locales \
+    openssl \
+  && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
+  && locale-gen \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+ENV MIX_ENV=prod
+ENV HOME=/app
+
+WORKDIR /app
+RUN chown nobody /app
+
+COPY --from=builder --chown=nobody:root /app/_build/prod/rel/paper_tiger ./
+
+USER nobody
+
+# stripe-mock's default port, so an existing stripe-mock service definition can
+# be repointed here without changing anything else.
+EXPOSE 12111
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
+  CMD curl -fsS "http://127.0.0.1:${PAPER_TIGER_PORT:-${PORT:-12111}}/health" || exit 1
+
+CMD ["/app/bin/paper_tiger", "start"]

--- a/README.md
+++ b/README.md
@@ -1,16 +1,40 @@
 [![Hex.pm](https://img.shields.io/hexpm/v/paper_tiger)](https://hex.pm/packages/paper_tiger)
 [![Hexdocs.pm](https://img.shields.io/badge/docs-hexdocs.pm-purple)](https://hexdocs.pm/paper_tiger)
-[![Github.com](https://github.com/EnaiaInc/paper_tiger/actions/workflows/ci.yml/badge.svg)](https://github.com/EnaiaInc/paper_tiger/actions)
+[![Github.com](https://github.com/neilberkman/paper_tiger/actions/workflows/ci.yml/badge.svg)](https://github.com/neilberkman/paper_tiger/actions)
 
 # PaperTiger
 
-A stateful mock Stripe server for testing Elixir applications.
+A stateful mock Stripe server for testing.
+
+**In Elixir**, add the dependency. PaperTiger runs in-process on ETS, so there
+is no network hop, no container to manage, and each test gets its own isolated
+namespace:
+
+```elixir
+{:paper_tiger, "~> 1.0"}
+```
+
+**In any other language**, run the container and point your Stripe SDK at it.
+PaperTiger speaks HTTP, so the SDK does not know the difference:
+
+```bash
+docker run -p 12111:12111 ghcr.io/neilberkman/paper_tiger
+```
+
+Full setup for both paths is under [Installation](#installation).
 
 ## Rationale
 
 Testing payment processing requires simulating complex Stripe workflows: subscription billing cycles, invoice finalization, webhook delivery, idempotency handling. Using real Stripe test accounts introduces external dependencies, network latency, rate limits, and non-deterministic test data. Stubbing individual Stripe API calls leads to brittle tests that break when Stripe's API evolves.
 
-PaperTiger solves this by providing a complete, stateful implementation of the Stripe API that runs in-process. Tests execute in milliseconds instead of seconds, work offline, and produce deterministic results. The dual-mode contract testing system validates that PaperTiger's behavior matches production Stripe, catching API drift automatically.
+Stripe's own testing surfaces have hard limits that a mock does not: an account
+can have [up to five sandboxes](https://docs.stripe.com/sandboxes/dashboard/manage),
+sandboxes are capped at [25 operations per second](https://docs.stripe.com/rate-limits),
+and a [test clock](https://docs.stripe.com/billing/testing/test-clocks/api-advanced-usage)
+holds at most three customers, three subscriptions, and ten quotes while
+advancing at most two billing intervals at a time.
+
+PaperTiger solves this by providing a complete, stateful implementation of the Stripe API. Tests execute in milliseconds instead of seconds, work offline, and produce deterministic results. The dual-mode contract testing system validates that PaperTiger's behavior matches production Stripe, catching API drift automatically.
 
 ## Philosophy
 
@@ -20,7 +44,7 @@ PaperTiger solves this by providing a complete, stateful implementation of the S
 
 **Time control**: Subscription billing, trial periods, and webhook retry logic depend on time progression. PaperTiger provides accelerated and manual clock modes for testing time-dependent behavior without waiting.
 
-**Elixir-native**: Built with ETS, GenServers, and Plug. No external databases or runtimes required.
+**Elixir-native**: Built with ETS, GenServers, and Plug. No external databases or runtimes required. Elixir callers get the server in the same BEAM, which is strictly faster than talking to a container; every other language gets that same server over HTTP.
 
 ## Features
 
@@ -37,6 +61,8 @@ PaperTiger solves this by providing a complete, stateful implementation of the S
 
 ## Installation
 
+### Elixir
+
 Add `paper_tiger` to your dependencies in `mix.exs`:
 
 ```elixir
@@ -47,9 +73,134 @@ def deps do
 end
 ```
 
+### Any other language
+
+PaperTiger speaks HTTP, so it works with any Stripe SDK. Run it as a container
+and point the SDK's API base at it:
+
+```bash
+docker run -p 12111:12111 ghcr.io/neilberkman/paper_tiger
+```
+
+```python
+import stripe
+stripe.api_key = "sk_test_anything"   # any non-empty key is accepted
+stripe.api_base = "http://localhost:12111"
+
+c = stripe.Customer.create(email="dev@example.com")
+stripe.Customer.retrieve(c.id)        # the customer is still there
+```
+
+12111 is stripe-mock's default port, so an existing stripe-mock service
+definition can be repointed at PaperTiger without changing anything else.
+
+See [Standalone Server](#standalone-server) for configuration, CI service
+definitions, and the HTTP control API.
+
+## Standalone Server
+
+The container runs the same server the Elixir library runs in-process. Nothing
+is persisted to disk: each container is an isolated store that starts empty and
+disappears when the container does, which is what makes it safe to run one per
+CI job or per pull request.
+
+### Configuration
+
+All settings are environment variables. None are required.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `PAPER_TIGER_PORT` | `12111` | Listen port. `PORT` is also honored, for PaaS runtimes that inject it. |
+| `PAPER_TIGER_CLOCK_MODE` | `real` | `real`, `accelerated`, or `manual`. |
+| `PAPER_TIGER_CLOCK_MULTIPLIER` | `1` | Seconds of simulated time per real second, in `accelerated` mode. |
+| `PAPER_TIGER_BILLING_ENGINE` | `false` | Advance subscriptions and finalize invoices on a timer. Leave off when driving the clock yourself. |
+| `PAPER_TIGER_LOG_LEVEL` | `info` | Standard Elixir log levels. |
+
+`GET /health` responds `{"status":"ok","service":"paper_tiger"}` without an
+Authorization header, for container and load balancer probes. Every `/v1/*` path
+requires one, as real Stripe does, though any non-empty key is accepted.
+
+### Time travel over HTTP
+
+Stripe's test clocks cap at three customers, three subscriptions, and ten quotes
+per clock, and advance at most two billing intervals at a time. PaperTiger's
+clock has no such limits and is driven over HTTP:
+
+```bash
+docker run -p 12111:12111 -e PAPER_TIGER_CLOCK_MODE=manual ghcr.io/neilberkman/paper_tiger
+```
+
+```bash
+curl -X POST http://localhost:12111/_config/time/advance \
+  -u sk_test_anything: -d "days=45"
+#=> {"now":1791553401,"success":true}
+```
+
+Both form-encoded and JSON bodies are accepted. Other control endpoints:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /_config/time/advance` | Advance the clock by `seconds` or `days`. |
+| `POST /_config/webhooks` | Register a webhook endpoint and signing secret. |
+| `DELETE /_config/data` | Flush all resources. |
+
+### GitHub Actions
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      stripe:
+        image: ghcr.io/neilberkman/paper_tiger
+        ports:
+          - 12111:12111
+        options: >-
+          --health-cmd "curl -fsS http://127.0.0.1:12111/health"
+          --health-interval 10s
+          --health-retries 5
+    env:
+      STRIPE_API_BASE: http://localhost:12111
+      STRIPE_API_KEY: sk_test_ci
+```
+
+Because each job gets its own container, parallel jobs cannot collide with each
+other the way they do when sharing a Stripe sandbox, and there is no rate limit
+to back off from.
+
+### Docker Compose
+
+```yaml
+services:
+  stripe:
+    image: ghcr.io/neilberkman/paper_tiger
+    ports:
+      - "12111:12111"
+    environment:
+      PAPER_TIGER_CLOCK_MODE: manual
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:12111/health"]
+      interval: 10s
+
+  app:
+    build: .
+    depends_on:
+      stripe:
+        condition: service_healthy
+    environment:
+      STRIPE_API_BASE: http://stripe:12111
+      STRIPE_API_KEY: sk_test_local
+```
+
+### Building the image yourself
+
+```bash
+docker build -t paper_tiger .
+```
+
 ## Quick Start
 
-[![Run in Livebook](https://livebook.dev/badge/v1/blue.svg)](https://livebook.dev/run?url=https://github.com/EnaiaInc/paper_tiger/blob/main/examples/getting_started.livemd)
+[![Run in Livebook](https://livebook.dev/badge/v1/blue.svg)](https://livebook.dev/run?url=https://github.com/neilberkman/paper_tiger/blob/main/examples/getting_started.livemd)
 
 Try the [interactive Livebook tutorial](examples/getting_started.livemd) for a hands-on introduction!
 
@@ -772,7 +923,7 @@ PaperTiger provides comprehensive coverage of core Stripe resources with full CR
 
 **Checkout & Events**: CheckoutSessions, WebhookEndpoints, Events, Reviews, Topups
 
-> **Note**: PaperTiger implements Stripe API v1 resources. Some v2-only resources (e.g., v2 billing features) are not yet supported. Check the [issues page](https://github.com/EnaiaInc/paper_tiger/issues) for planned additions or open a feature request.
+> **Note**: PaperTiger implements Stripe API v1 resources. Some v2-only resources (e.g., v2 billing features) are not yet supported. Check the [issues page](https://github.com/neilberkman/paper_tiger/issues) for planned additions or open a feature request.
 
 ### Connect Semantics
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Please report security vulnerabilities **privately**. Do not open a public
 issue, pull request, or discussion for a suspected security problem.
 
 Use GitHub's private vulnerability reporting for this repository:
-https://github.com/EnaiaInc/paper_tiger/security/advisories/new
+https://github.com/neilberkman/paper_tiger/security/advisories/new
 
 (From the repository's **Security** tab, choose **Report a vulnerability**.)
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,8 @@
+import Config
+
+config :logger, level: :info
+
+# 12111 is stripe-mock's default port, so an existing stripe-mock service
+# definition can be repointed at PaperTiger without changing the port anywhere
+# else. Override at runtime with PAPER_TIGER_PORT or PORT.
+config :paper_tiger, port: 12_111

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,5 +1,47 @@
 import Config
 
+# Standalone server configuration. Only relevant to the container image and any
+# other `mix release` build; library consumers configure PaperTiger through
+# `PaperTiger.start/1` or their own config files.
+if config_env() == :prod do
+  # Port precedence: PAPER_TIGER_PORT, then PORT (which most PaaS runtimes
+  # inject), then the prod.exs default. `PaperTiger.Port` also reads
+  # PAPER_TIGER_PORT directly, so both paths resolve to the same value.
+  if port = System.get_env("PAPER_TIGER_PORT") || System.get_env("PORT") do
+    config :paper_tiger, port: String.to_integer(port)
+  end
+
+  # `PaperTiger.Clock` reads :time_mode and :time_multiplier at init.
+  case System.get_env("PAPER_TIGER_CLOCK_MODE") do
+    nil ->
+      :ok
+
+    mode when mode in ~w(real accelerated manual) ->
+      config :paper_tiger, time_mode: String.to_atom(mode)
+
+    other ->
+      raise """
+      PAPER_TIGER_CLOCK_MODE must be one of: real, accelerated, manual.
+      Got: #{inspect(other)}
+      """
+  end
+
+  if multiplier = System.get_env("PAPER_TIGER_CLOCK_MULTIPLIER") do
+    config :paper_tiger, time_multiplier: String.to_integer(multiplier)
+  end
+
+  # The billing engine advances subscriptions and finalizes invoices on a timer.
+  # Off by default: callers driving the clock themselves want to control when
+  # billing runs, and a timer racing their assertions is worse than no timer.
+  if System.get_env("PAPER_TIGER_BILLING_ENGINE") == "true" do
+    config :paper_tiger, billing_engine: true
+  end
+
+  if level = System.get_env("PAPER_TIGER_LOG_LEVEL") do
+    config :logger, level: String.to_existing_atom(level)
+  end
+end
+
 # Configure stripity_stripe at runtime
 # Uses PaperTiger by default, real Stripe when VALIDATE_AGAINST_STRIPE=true
 if config_env() == :test do

--- a/examples/getting_started.livemd
+++ b/examples/getting_started.livemd
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-[![Run in Livebook](https://livebook.dev/badge/v1/blue.svg)](https://livebook.dev/run?url=https://github.com/EnaiaInc/paper_tiger/blob/main/examples/getting_started.livemd)
+[![Run in Livebook](https://livebook.dev/badge/v1/blue.svg)](https://livebook.dev/run?url=https://github.com/neilberkman/paper_tiger/blob/main/examples/getting_started.livemd)
 
 This LiveBook demonstrates how to use PaperTiger, a stateful mock Stripe server for testing Elixir applications. You'll learn how to:
 
@@ -283,8 +283,8 @@ Now that you've explored the basics, try:
 
 For more examples, check out:
 
-* [PaperTiger README](https://github.com/EnaiaInc/paper_tiger)
-* [Contract Testing Guide](https://github.com/EnaiaInc/paper_tiger#contract-testing)
+* [PaperTiger README](https://github.com/neilberkman/paper_tiger)
+* [Contract Testing Guide](https://github.com/neilberkman/paper_tiger#contract-testing)
 * [Stripe API Documentation](https://stripe.com/docs/api)
 
 ## Summary

--- a/lib/paper_tiger/plugs/auth.ex
+++ b/lib/paper_tiger/plugs/auth.ex
@@ -7,6 +7,12 @@ defmodule PaperTiger.Plugs.Auth do
   - **Lenient (default)** - Accepts any non-empty Authorization header
   - **Strict** - Validates key format (sk_test_*, sk_live_*)
 
+  ## Unauthenticated Paths
+
+  `/health` and the browser-facing Checkout, Payment Link, and Billing Portal
+  paths are served without an Authorization header, matching the fact that a
+  real browser never carries one.
+
   ## Usage
 
       # In router
@@ -57,6 +63,9 @@ defmodule PaperTiger.Plugs.Auth do
 
   ## Private Functions
 
+  # `/health` is not a Stripe endpoint, so gating it behind an API key buys no
+  # fidelity and costs container runtimes and load balancers their probe.
+  defp public_browser_path?("/health"), do: true
   defp public_browser_path?("/checkout/" <> _rest), do: true
   defp public_browser_path?("/payment_links/" <> _rest), do: true
   defp public_browser_path?("/billing_portal/sessions/" <> _rest), do: true

--- a/lib/paper_tiger/router.ex
+++ b/lib/paper_tiger/router.ex
@@ -167,8 +167,11 @@ defmodule PaperTiger.Router do
   end
 
   post "/_config/time/advance" do
-    case conn.params do
-      %{seconds: seconds} when is_integer(seconds) ->
+    # Accepts both a JSON body (integer values) and form-encoded input (string
+    # values). Form encoding is what every Stripe SDK emits, so rejecting it
+    # would make time travel reachable only from hand-written JSON requests.
+    case {integer_param(conn.params, :seconds), integer_param(conn.params, :days)} do
+      {{:ok, seconds}, _days} ->
         PaperTiger.advance_time(seconds)
 
         send_resp(
@@ -177,7 +180,7 @@ defmodule PaperTiger.Router do
           Jason.encode!(%{now: PaperTiger.now(), success: true})
         )
 
-      %{days: days} when is_integer(days) ->
+      {_seconds, {:ok, days}} ->
         PaperTiger.advance_time(days: days)
 
         send_resp(
@@ -186,7 +189,7 @@ defmodule PaperTiger.Router do
           Jason.encode!(%{now: PaperTiger.now(), success: true})
         )
 
-      _invalid ->
+      {:error, :error} ->
         send_resp(
           conn,
           400,
@@ -500,5 +503,25 @@ defmodule PaperTiger.Router do
         }
       })
     )
+  end
+
+  ## Private Functions
+
+  # Reads a param that may arrive as an integer (JSON body) or a string (form
+  # encoding, which is what the Stripe SDKs send).
+  defp integer_param(params, key) do
+    case Map.get(params, key) do
+      value when is_integer(value) ->
+        {:ok, value}
+
+      value when is_binary(value) ->
+        case Integer.parse(value) do
+          {parsed, ""} -> {:ok, parsed}
+          _otherwise -> :error
+        end
+
+      _missing ->
+        :error
+    end
   end
 end

--- a/lib/paper_tiger/user_adapters/auto_discover.ex
+++ b/lib/paper_tiger/user_adapters/auto_discover.ex
@@ -84,7 +84,7 @@ defmodule PaperTiger.UserAdapters.AutoDiscover do
       email = user_data["email_address"] ->
         {:ok, email}
 
-      # Follow FK to emails table (like Enaia)
+      # Follow FK to a separate emails table
       email_id = user_data["primary_email_id"] ->
         case fetch_email_from_table(repo, email_id) do
           {:ok, email} -> {:ok, email}

--- a/mix.exs
+++ b/mix.exs
@@ -3,8 +3,8 @@ defmodule PaperTiger.MixProject do
   use Mix.Project
 
   @version "1.2.2"
-  @url "https://github.com/EnaiaInc/paper_tiger"
-  @maintainers ["Enaia Inc"]
+  @url "https://github.com/neilberkman/paper_tiger"
+  @maintainers ["Neil Berkman"]
 
   def project do
     [
@@ -16,9 +16,12 @@ defmodule PaperTiger.MixProject do
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env()),
 
+      # Standalone server release (see Dockerfile)
+      releases: releases(),
+
       # Hex package
       package: package(),
-      description: "A stateful mock Stripe server for testing Elixir applications",
+      description: "A stateful mock Stripe server for testing",
       source_url: @url,
       homepage_url: @url,
 
@@ -51,6 +54,20 @@ defmodule PaperTiger.MixProject do
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
+
+  # Release used by the container image. PaperTiger is primarily consumed as a
+  # library, so this exists purely to let non-Elixir callers run the same server
+  # over HTTP. `PaperTiger.Application.should_start?/0` returns true whenever
+  # Mix is absent, which is exactly the release case, so no extra config is
+  # needed to make the HTTP listener come up.
+  defp releases do
+    [
+      paper_tiger: [
+        include_executables_for: [:unix],
+        applications: [runtime_tools: :permanent]
+      ]
+    ]
+  end
 
   def application do
     [

--- a/test/paper_tiger/standalone_server_test.exs
+++ b/test/paper_tiger/standalone_server_test.exs
@@ -1,0 +1,113 @@
+defmodule PaperTiger.StandaloneServerTest do
+  @moduledoc """
+  Covers the HTTP surface that non-Elixir callers depend on when PaperTiger runs
+  as a standalone server rather than as an in-process library.
+
+  Not async: the clock is a singleton, so advancing it would race other tests.
+  """
+
+  use ExUnit.Case, async: false
+
+  import PaperTiger.Test
+
+  alias PaperTiger.Router
+
+  setup :checkout_paper_tiger
+
+  defp request(method, path, params, headers) do
+    method
+    |> Plug.Test.conn(path, params)
+    |> then(fn conn ->
+      Enum.reduce(headers ++ sandbox_headers(), conn, fn {key, value}, acc ->
+        Plug.Conn.put_req_header(acc, key, value)
+      end)
+    end)
+    |> Router.call([])
+  end
+
+  defp json_response(conn), do: Jason.decode!(conn.resp_body)
+
+  describe "GET /health" do
+    test "responds without an Authorization header" do
+      conn = request(:get, "/health", nil, [])
+
+      assert conn.status == 200
+      assert json_response(conn) == %{"service" => "paper_tiger", "status" => "ok"}
+    end
+
+    test "still responds when an Authorization header is present" do
+      conn = request(:get, "/health", nil, [{"authorization", "Bearer sk_test_health"}])
+
+      assert conn.status == 200
+    end
+  end
+
+  describe "API paths remain authenticated" do
+    test "a missing Authorization header is rejected" do
+      conn = request(:get, "/v1/customers", nil, [])
+
+      assert conn.status == 401
+      assert %{"error" => %{"type" => "invalid_request_error"}} = json_response(conn)
+    end
+  end
+
+  describe "POST /_config/time/advance" do
+    setup do
+      PaperTiger.Clock.set_mode(:manual)
+      PaperTiger.Clock.reset()
+      on_exit(fn -> PaperTiger.Clock.set_mode(:real) end)
+    end
+
+    @auth [
+      {"authorization", "Bearer sk_test_time"},
+      {"content-type", "application/x-www-form-urlencoded"}
+    ]
+
+    test "accepts form-encoded seconds, as the Stripe SDKs send them" do
+      before = PaperTiger.now()
+      conn = request(:post, "/_config/time/advance", %{"seconds" => "86400"}, @auth)
+
+      assert conn.status == 200
+      assert %{"now" => now, "success" => true} = json_response(conn)
+      assert now - before >= 86_400
+    end
+
+    test "accepts form-encoded days" do
+      before = PaperTiger.now()
+      conn = request(:post, "/_config/time/advance", %{"days" => "2"}, @auth)
+
+      assert conn.status == 200
+      assert %{"now" => now, "success" => true} = json_response(conn)
+      assert now - before >= 2 * 86_400
+    end
+
+    test "accepts integer seconds from a JSON body" do
+      before = PaperTiger.now()
+
+      conn =
+        request(:post, "/_config/time/advance", %{"seconds" => 3600}, [
+          {"authorization", "Bearer sk_test_time"},
+          {"content-type", "application/json"}
+        ])
+
+      assert conn.status == 200
+      assert %{"now" => now} = json_response(conn)
+      assert now - before >= 3600
+    end
+
+    test "rejects a non-numeric value" do
+      conn = request(:post, "/_config/time/advance", %{"seconds" => "later"}, @auth)
+
+      assert conn.status == 400
+
+      assert %{"error" => %{"message" => "Missing seconds or days parameter"}} =
+               json_response(conn)
+    end
+
+    test "rejects a request with neither parameter" do
+      conn = request(:post, "/_config/time/advance", %{}, @auth)
+
+      assert conn.status == 400
+    end
+  end
+end

--- a/test/paper_tiger/user_adapters/auto_discover_test.exs
+++ b/test/paper_tiger/user_adapters/auto_discover_test.exs
@@ -26,7 +26,7 @@ defmodule PaperTiger.UserAdapters.AutoDiscoverTest do
     end
   end
 
-  describe "get_user_info/2 with separate emails table (like Enaia)" do
+  describe "get_user_info/2 with separate emails table" do
     defmodule EmailsTableRepo do
       def query("SELECT EXISTS" <> _, ["users"]), do: {:ok, %{rows: [[true]]}}
       def query("SELECT EXISTS" <> _, _), do: {:ok, %{rows: [[false]]}}


### PR DESCRIPTION
PaperTiger has only ever been installable as a Hex dependency, so the Stripe-testing problems it solves have been reachable only from Elixir. The server itself is protocol-agnostic, so this ships it as a container image any Stripe SDK can point at.

Elixir users are unaffected and still get the better deal: in-process on ETS, no network hop, per-test namespace isolation. The README now branches on that in its first ten lines rather than leading with one audience.

## What's here

- `mix release` produces a `paper_tiger` release. No application changes were needed — `should_start?/0` already returns true whenever Mix is absent, which is the release case.
- `Dockerfile` builds that release onto debian-slim. 148MB. Defaults to port **12111**, which is stripe-mock's default, so an existing stripe-mock service definition can be repointed without touching the port.
- Runtime configuration through environment variables, none required: `PAPER_TIGER_PORT` (and `PORT`), `PAPER_TIGER_CLOCK_MODE`, `PAPER_TIGER_CLOCK_MULTIPLIER`, `PAPER_TIGER_BILLING_ENGINE`, `PAPER_TIGER_LOG_LEVEL`.
- `.github/workflows/docker.yml` builds on every relevant change and smoke-tests the create-then-retrieve round trip before publishing multi-arch to GHCR. Publish steps are gated on push events, so PRs build and test without pushing an image.
- README gains a Standalone Server section with GitHub Actions service-container and Docker Compose examples.

## Two defects fixed

Both surfaced while validating the container, and neither was visible from Elixir:

- **`POST /_config/time/advance` rejected form encoding.** It matched only `when is_integer(seconds)`, so a hand-written JSON body worked but the form encoding every Stripe SDK emits returned 400. Time travel was effectively unreachable over HTTP.
- **`GET /health` required an API key.** It sat below the `Auth` plug and returned 401, which breaks container healthchecks and load balancer probes. It isn't a Stripe endpoint, so authenticating it bought no fidelity.

## Verification

737 tests pass, credo strict clean, formatter clean. New `standalone_server_test.exs` covers both fixes.

Exercised against the **official Python Stripe SDK** with only `api_base` changed:

- create customer, retrieve it back (the round trip stripe-mock cannot do)
- product and price creation with recurring intervals
- ten customers with ten subscriptions on a single manual clock, advanced 45 days

That last one is the case Stripe's own test clocks cap at three customers and three subscriptions.