### PR TITLE
Release @neilberkman/papertiger-testcontainers 0.5.0

### DIFF
--- a/clients/testcontainers-node/package-lock.json
+++ b/clients/testcontainers-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neilberkman/papertiger-testcontainers",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neilberkman/papertiger-testcontainers",
-      "version": "0.1.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "testcontainers": "^11.0.0 || ^12.0.0"

--- a/clients/testcontainers-node/package.json
+++ b/clients/testcontainers-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neilberkman/papertiger-testcontainers",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "description": "Testcontainers module for PaperTiger, a stateful mock Stripe server",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
Version bump only, no code change from 0.1.0.

`0.1.0` understated a module that is feature-complete and covered: the container class, clock control, `flush()`, and five tests exercising the published image through the official `stripe` SDK. Re-baselining at `0.5.0` so the number reflects that rather than reading as a first sketch.

This is also the first release through the OIDC trusted publisher configured on npm, so it exercises the keyless path end to end. After merge:

```
git tag testcontainers-node-v0.5.0 && git push --tags
```

The release workflow verifies the tag matches `package.json` before publishing, so a mismatch fails rather than shipping the wrong version.