### PR TITLE
Mirror the image to Docker Hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,12 +73,49 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Docker Hub is where people browse this category; GHCR has no search or
+      # browse surface worth the name. Mirroring is gated on the secret so the
+      # workflow stays green if the credentials are ever absent or rotated out.
+      - name: Check for Docker Hub credentials
+        if: github.event_name == 'push'
+        id: dockerhub
+        env:
+          TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        run: |
+          # Multiline outputs require a heredoc delimiter; a bare newline in the
+          # value silently corrupts the parse.
+          if [ -n "$TOKEN" ] && [ -n "$USERNAME" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "images<<IMAGES_EOF"
+              echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+              echo "docker.io/${USERNAME}/paper_tiger"
+              echo "IMAGES_EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "images<<IMAGES_EOF"
+              echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+              echo "IMAGES_EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "::notice::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN not set; publishing to GHCR only."
+          fi
+
+      - name: Log in to Docker Hub
+        if: github.event_name == 'push' && steps.dockerhub.outputs.enabled == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Image metadata
         if: github.event_name == 'push'
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ steps.dockerhub.outputs.images }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -96,3 +133,16 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # The Docker Hub page is the actual discovery surface: it is what someone
+      # sees when they search "stripe" there. Keep it in step with the README
+      # rather than letting it rot at whatever the first push happened to say.
+      - name: Sync Docker Hub description
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.dockerhub.outputs.enabled == 'true'
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ secrets.DOCKERHUB_USERNAME }}/paper_tiger
+          short-description: "A stateful mock Stripe server for testing. Point any Stripe SDK at it."
+          readme-filepath: ./README.md


### PR DESCRIPTION
GHCR has no browse or search surface, so nobody discovers an image there. Docker Hub is where people type "stripe" and scroll, and where stripe-mock already sits with visible pull counts. Same build, pushed to both registries.

**Gated on credentials.** If `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` are absent, the workflow publishes to GHCR alone and logs a notice. So this is a clean no-op until the secrets exist, and it stays green if they're ever rotated out.

Also syncs the README to the Docker Hub page on pushes to `main`. That page is what a stranger actually reads, and a short description pinned to whatever the first push said would rot immediately.

## To enable

The account `neilberkman` exists on Docker Hub (joined 2016) with 0 repositories, so `neilberkman/paper_tiger` is free. The credential in 1Password is from 2018, predates access tokens, and returns 401.

1. hub.docker.com → Account Settings → Security → New Access Token, Read/Write
2. Repo secrets: `DOCKERHUB_USERNAME=neilberkman`, `DOCKERHUB_TOKEN=<token>`

Until then this changes nothing about what gets published.