### PR TITLE
Require return_url when confirming an intent that allows redirects

### DIFF
--- a/lib/paper_tiger/resources/payment_intent.ex
+++ b/lib/paper_tiger/resources/payment_intent.ex
@@ -178,6 +178,7 @@ defmodule PaperTiger.Resources.PaymentIntent do
   def confirm(conn, id) do
     with {:ok, pi} <- PaymentIntents.get(id),
          :ok <- validate_confirmable(pi),
+         :ok <- PaperTiger.ReturnUrlHelper.validate(pi, conn.params),
          {:ok, updated, payment_method, mandate_params} <- prepare_confirmation(pi, conn.params) do
       # Transition to succeeded, create charge + balance transaction, then re-fetch to get latest_charge.
 
@@ -211,6 +212,12 @@ defmodule PaperTiger.Resources.PaymentIntent do
     else
       {:error, :not_found} ->
         error_response(conn, PaperTiger.Error.not_found("payment_intent", id))
+
+      {:error, :return_url_required} ->
+        error_response(
+          conn,
+          PaperTiger.Error.invalid_request(PaperTiger.ReturnUrlHelper.error_message(), "return_url")
+        )
 
       {:error, :not_confirmable, status} ->
         error_response(
@@ -446,6 +453,7 @@ defmodule PaperTiger.Resources.PaymentIntent do
       amount_received: 0,
       application: nil,
       application_fee_amount: get_optional_integer(params, :application_fee_amount),
+      automatic_payment_methods: Map.get(params, :automatic_payment_methods),
       canceled_at: nil,
       cancellation_reason: nil,
       capture_method: Map.get(params, :capture_method, "automatic"),
@@ -469,6 +477,7 @@ defmodule PaperTiger.Resources.PaymentIntent do
       payment_method: Map.get(params, :payment_method),
       processing: nil,
       receipt_email: Map.get(params, :receipt_email),
+      return_url: Map.get(params, :return_url),
       review: nil,
       setup_future_usage: Map.get(params, :setup_future_usage),
       shipping: Map.get(params, :shipping),

--- a/lib/paper_tiger/resources/setup_intent.ex
+++ b/lib/paper_tiger/resources/setup_intent.ex
@@ -144,6 +144,7 @@ defmodule PaperTiger.Resources.SetupIntent do
   def confirm(conn, id) do
     with {:ok, setup_intent} <- SetupIntents.get(id),
          :ok <- validate_confirmable(setup_intent),
+         :ok <- PaperTiger.ReturnUrlHelper.validate(setup_intent, conn.params),
          {:ok, payment_method} <- resolve_payment_method(setup_intent, conn.params),
          {:ok, confirmed} <- confirm_with_payment_method(setup_intent, payment_method, conn.params) do
       confirmed
@@ -152,6 +153,12 @@ defmodule PaperTiger.Resources.SetupIntent do
     else
       {:error, :not_found} ->
         error_response(conn, PaperTiger.Error.not_found("setup_intent", id))
+
+      {:error, :return_url_required} ->
+        error_response(
+          conn,
+          PaperTiger.Error.invalid_request(PaperTiger.ReturnUrlHelper.error_message(), "return_url")
+        )
 
       {:error, :not_confirmable, status} ->
         error_response(
@@ -673,6 +680,7 @@ defmodule PaperTiger.Resources.SetupIntent do
       payment_method_configuration_details: nil,
       payment_method_options: Map.get(params, :payment_method_options),
       payment_method_types: Map.get(params, :payment_method_types, ["card"]),
+      return_url: Map.get(params, :return_url),
       single_use_mandate: nil,
       status: initial_status(params),
       usage: Map.get(params, :usage, "off_session")

--- a/lib/paper_tiger/return_url_helper.ex
+++ b/lib/paper_tiger/return_url_helper.ex
@@ -1,0 +1,82 @@
+defmodule PaperTiger.ReturnUrlHelper do
+  @moduledoc """
+  Shared `return_url` validation for PaymentIntent and SetupIntent confirmation.
+
+  Stripe refuses to confirm an intent whose enabled payment methods include
+  redirect-based ones (boleto, iDEAL, ...) unless the caller supplied a
+  `return_url` to send the customer back to. Accepting that confirmation would
+  let an integration ship a call that cannot succeed against the real API, with
+  a green suite the whole way.
+
+  ## What is and is not decided here
+
+  Only the case that is decidable from the request: `automatic_payment_methods`
+  present with `enabled` truthy and `allow_redirects` not `"never"`. Stripe
+  defaults `allow_redirects` to `"always"`, so an enabled block that omits it
+  requires the URL.
+
+  When `automatic_payment_methods` is absent entirely, Stripe falls back to the
+  payment methods enabled in the account's dashboard — state PaperTiger does not
+  model — so that case is deliberately allowed through rather than guessed at.
+  """
+
+  @doc """
+  Returns `:ok`, or `{:error, :return_url_required}` when redirects are allowed
+  and neither the stored intent nor the confirm params carry a `return_url`.
+
+  `intent` is the stored object; `params` are the confirm request's params, since
+  Stripe accepts `return_url` at either create or confirm time.
+  """
+  @spec validate(map(), map()) :: :ok | {:error, :return_url_required}
+  def validate(intent, params) do
+    if redirects_allowed?(param(intent, :automatic_payment_methods)) and
+         is_nil(return_url(intent, params)) do
+      {:error, :return_url_required}
+    else
+      :ok
+    end
+  end
+
+  @doc """
+  The operator-facing message, worded as Stripe words it.
+  """
+  @spec error_message() :: String.t()
+  def error_message do
+    "This PaymentIntent or SetupIntent is configured to accept redirect-based " <>
+      "payment methods, so a return_url must be supplied. Pass return_url, or set " <>
+      "automatic_payment_methods[allow_redirects]=never."
+  end
+
+  defp redirects_allowed?(nil), do: false
+
+  defp redirects_allowed?(automatic_payment_methods) when is_map(automatic_payment_methods) do
+    enabled?(param(automatic_payment_methods, :enabled)) and
+      param(automatic_payment_methods, :allow_redirects) not in ["never", :never]
+  end
+
+  defp redirects_allowed?(_other), do: false
+
+  # Form-encoded bodies arrive as strings, JSON bodies as booleans.
+  defp enabled?(true), do: true
+  defp enabled?("true"), do: true
+  defp enabled?(_other), do: false
+
+  defp return_url(intent, params) do
+    presence(param(params, :return_url)) || presence(param(intent, :return_url))
+  end
+
+  defp presence(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp presence(_value), do: nil
+
+  defp param(map, key) when is_map(map) and is_atom(key) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  defp param(_map, _key), do: nil
+end

--- a/test/paper_tiger/resources/intent_redirect_return_url_test.exs
+++ b/test/paper_tiger/resources/intent_redirect_return_url_test.exs
@@ -1,0 +1,154 @@
+defmodule PaperTiger.Resources.IntentRedirectReturnUrlTest do
+  @moduledoc """
+  Confirming an intent whose `automatic_payment_methods` allows redirects
+  requires a `return_url`, as real Stripe does.
+
+  Stripe rejects the confirmation outright when redirect-based methods (boleto,
+  iDEAL, ...) are in play and the caller supplied nowhere to send the customer
+  back to. Accepting it here lets an integration ship a confirm call that cannot
+  succeed against the real API — the mock and the bug agree, and the suite stays
+  green.
+
+  Only the case that is decidable from the request is covered:
+  `automatic_payment_methods[enabled]=true` with `allow_redirects` not set to
+  `never`. When the parameter is omitted entirely, real Stripe falls back to the
+  payment methods enabled in the account's dashboard, which PaperTiger does not
+  model.
+  """
+
+  use ExUnit.Case, async: true
+
+  import PaperTiger.Test
+
+  alias PaperTiger.Router
+
+  setup :checkout_paper_tiger
+
+  defp conn(method, path, params, headers) do
+    conn = Plug.Test.conn(method, path, params)
+
+    headers_with_defaults =
+      headers ++
+        [
+          {"content-type", "application/json"},
+          {"authorization", "Bearer sk_test_return_url_key"}
+        ] ++ sandbox_headers()
+
+    Enum.reduce(headers_with_defaults, conn, fn {key, value}, acc ->
+      Plug.Conn.put_req_header(acc, key, value)
+    end)
+  end
+
+  defp request(method, path, params \\ nil, headers \\ []) do
+    method
+    |> conn(path, params, headers)
+    |> Router.call([])
+  end
+
+  defp json_response(conn), do: Jason.decode!(conn.resp_body)
+
+  defp create_payment_intent(automatic_payment_methods) do
+    params =
+      %{"amount" => 1000, "currency" => "usd"}
+      |> put_apm(automatic_payment_methods)
+
+    :post
+    |> request("/v1/payment_intents", params)
+    |> json_response()
+    |> Map.fetch!("id")
+  end
+
+  # A SetupIntent needs a payment method before it is confirmable at all —
+  # without one, confirm fails on that instead, which would make these tests red
+  # for the wrong reason.
+  defp create_setup_intent(automatic_payment_methods) do
+    :post
+    |> request(
+      "/v1/setup_intents",
+      put_apm(%{"payment_method" => "pm_card_visa"}, automatic_payment_methods)
+    )
+    |> json_response()
+    |> Map.fetch!("id")
+  end
+
+  defp put_apm(params, nil), do: params
+  defp put_apm(params, apm), do: Map.put(params, "automatic_payment_methods", apm)
+
+  describe "POST /v1/payment_intents/:id/confirm" do
+    test "rejects confirmation when redirects are allowed and no return_url is given" do
+      id = create_payment_intent(%{"enabled" => "true"})
+
+      conn = request(:post, "/v1/payment_intents/#{id}/confirm")
+
+      assert conn.status == 400
+      error = json_response(conn)
+      assert error["error"]["type"] == "invalid_request_error"
+      assert error["error"]["message"] =~ "return_url"
+      assert error["error"]["param"] == "return_url"
+    end
+
+    test "accepts confirmation when the return_url is supplied at confirm time" do
+      id = create_payment_intent(%{"enabled" => "true"})
+
+      conn =
+        request(:post, "/v1/payment_intents/#{id}/confirm", %{
+          "return_url" => "https://example.test/return"
+        })
+
+      assert conn.status == 200
+    end
+
+    test "accepts confirmation when the return_url was supplied at create time" do
+      params = %{
+        "amount" => 1000,
+        "automatic_payment_methods" => %{"enabled" => "true"},
+        "currency" => "usd",
+        "return_url" => "https://example.test/return"
+      }
+
+      id = request(:post, "/v1/payment_intents", params) |> json_response() |> Map.fetch!("id")
+
+      assert request(:post, "/v1/payment_intents/#{id}/confirm").status == 200
+    end
+
+    test "accepts confirmation when redirects are disallowed" do
+      id = create_payment_intent(%{"allow_redirects" => "never", "enabled" => "true"})
+
+      assert request(:post, "/v1/payment_intents/#{id}/confirm").status == 200
+    end
+
+    # The omitted case depends on account-level configuration PaperTiger does not
+    # model, so it must keep working rather than guess a rejection.
+    test "accepts confirmation when automatic_payment_methods is absent" do
+      id = create_payment_intent(nil)
+
+      assert request(:post, "/v1/payment_intents/#{id}/confirm").status == 200
+    end
+  end
+
+  describe "POST /v1/setup_intents/:id/confirm" do
+    test "rejects confirmation when redirects are allowed and no return_url is given" do
+      id = create_setup_intent(%{"enabled" => "true"})
+
+      conn = request(:post, "/v1/setup_intents/#{id}/confirm")
+
+      assert conn.status == 400
+      error = json_response(conn)
+      assert error["error"]["type"] == "invalid_request_error"
+      assert error["error"]["message"] =~ "return_url"
+      assert error["error"]["param"] == "return_url"
+    end
+
+    test "accepts confirmation when redirects are disallowed" do
+      id = create_setup_intent(%{"allow_redirects" => "never", "enabled" => "true"})
+
+      assert request(:post, "/v1/setup_intents/#{id}/confirm").status == 200
+    end
+
+    test "accepts confirmation when automatic_payment_methods is absent" do
+      id = create_setup_intent(nil)
+
+      assert request(:post, "/v1/setup_intents/#{id}/confirm").status == 200
+    end
+  end
+end


### PR DESCRIPTION
# Comments

Stripe refuses to confirm a PaymentIntent or SetupIntent whose `automatic_payment_methods` allows redirect-based methods (boleto, iDEAL, …) unless a `return_url` is supplied. PaperTiger accepts it. The shape is modelled — `setup_intent.ex` already reads and stores the field — but the rejection behaviour is not, so a mock-only suite passes on a call the real API refuses. That's how it reached us: two intent encoders omitted the parameter entirely, stayed green indefinitely, and only failed against a live test account.

Enforced only for the case decidable from the request: `automatic_payment_methods` present, `enabled` truthy, `allow_redirects` not `"never"`. When the parameter is absent, Stripe falls back to the methods enabled in the account's dashboard — state PaperTiger doesn't model — so that path is deliberately left alone rather than guessed at. Happy to add a contract-drift scenario for this if you'd like it pinned against live Stripe.

PaymentIntent stored neither `automatic_payment_methods` nor `return_url` and SetupIntent stored no `return_url`, so all three are now kept for `confirm` to read. 780 existing tests still pass.

Let me know if you see any issues.
Cheers
